### PR TITLE
feat(harness): define external orchestrator Work Item read contract

### DIFF
--- a/docs/adoption/repo-interop-contract.md
+++ b/docs/adoption/repo-interop-contract.md
@@ -6,11 +6,12 @@
 
 ## 1. 目标与边界
 
-`.loom/companion/interop.json` 用于声明三类只读入口：
+`.loom/companion/interop.json` 用于声明四类只读入口：
 
 - retained host action result 的读取入口
 - repo-native carrier / evidence / truth 的读取入口
 - `shadow mode` parity compare 的读取入口
+- external orchestrator 读面 locator
 
 它不承接：
 
@@ -71,6 +72,7 @@ approval / sandbox policy read locator 属于 [repo-companion-contract.md](./rep
 - `host_adapters` 必须存在，可为空数组
 - `repo_native_carriers` 必须存在，可为空数组
 - `shadow_surfaces` 必须同时声明 `admission`、`review`、`merge_ready`、`closeout`
+- `external_orchestrators` 可存在；缺省等价于空数组，以保持既有 `loom-repo-interop/v1` 读面兼容
 
 ## 3. `host_adapters`
 
@@ -273,7 +275,54 @@ blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
 - 不在 `interop.json` 中声明 blocking owner、override decision 或 final verdict
 - 不要求 `shadow parity` 代替 review、merge-ready 或 closeout 的正式 authority-of-truth
 
-## 6. 与其他合同的关系
+## 6. `external_orchestrators`
+
+`external_orchestrators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `operations`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `surfaces` 必须是非空数组
+- `surfaces[*]` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `operations` 必须是非空数组
+- `operations[*]` 第一版只允许 `work_item_read`
+- `locator` 只描述 Loom 如何读取外部 orchestrator 的 retained read evidence，不描述如何调度任务
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+
+外部 orchestrator read evidence 只能作为 retained result 或 locator provenance 消费。
+它不得替代 `Work Item`、恢复主入口、status control plane、review record、
+merge checkpoint 或 closeout basis。
+
+外部 orchestrator locator payload 不得承载：
+
+- scheduler state
+- attempt ownership
+- authored progress
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- status truth
+- gate verdict
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+若 required external orchestrator locator 缺失、越界、不可读，或 payload 包含这些
+forbidden authored fields，消费方必须 fail closed。optional / advisory 缺口只能进入
+profile-local advisory evidence，不得污染 `orchestration-core`。
+
+## 7. 与其他合同的关系
 
 - `repo-interface.json`
   - 承接 repo-specific rules、requirements、typed gates、metadata/context contract
@@ -285,6 +334,8 @@ blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
   - 承接从 vendored `.loom/bin` 到 versioned external Loom runtime 的迁移路径
 - [host-action-contract.md](../methodology/harness/host-action-contract.md)
   - 承接宿主动作 ownership、结果语义与 fallback discipline
+- [external-orchestrator-interop.md](../methodology/harness/external-orchestrator-interop.md)
+  - 承接外部 orchestrator 的 Work Item 读取、workspace attach、recovery writeback 与 status/gate 消费边界
 
 纪律重申：
 
@@ -295,11 +346,12 @@ blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
 - 不让 `interop.json` 承载 dynamic tool availability locator；这些 locator 必须通过 `repo-interface.json` 的 `dynamic_tool_locators` 声明
 - 不让 `interop.json` 承载 approval / sandbox policy read locator；这些 locator 必须通过 `repo-interface.json` 的 `policy_locators` 声明
 - 不让 `interop.json` 承载 external-runtime locator、runtime version、rollback mode 或 runtime provenance
+- 不让 `interop.json` 承载 external orchestrator scheduler state、attempt ownership、status truth 或 gate truth
 - 不让 Loom 因为读取了 interop contract，就接管宿主底层实现
 - 不让 `interop.json` 定义 blocking owner、override path 或 final merge authority
 - 不让 zero-friction adoption 把 validation-only shadow parity 自动升级成 blocking gate
 
-## 7. 与 external-runtime / de-vendor migration 的边界
+## 8. 与 external-runtime / de-vendor migration 的边界
 
 external-runtime 迁移只改变 Loom runtime 的执行来源，不改变 interop 读取的 repo-native truth。
 

--- a/docs/evidence/fixtures/external-orchestrator-interop-fixtures.json
+++ b/docs/evidence/fixtures/external-orchestrator-interop-fixtures.json
@@ -1,0 +1,109 @@
+{
+  "schema_version": "loom-external-orchestrator-interop-fixtures/v1",
+  "fixtures": [
+    {
+      "name": "work-item-read-present",
+      "entry": {
+        "id": "fake-external-orchestrator",
+        "summary": "Read the active Work Item through the Loom fact chain.",
+        "surfaces": ["admission"],
+        "operations": ["work_item_read"],
+        "locator": ".loom/external-orchestrator/read-present.json",
+        "owner": "external-tool",
+        "requirement": "required",
+        "fallback_to": "admission"
+      },
+      "payload": {
+        "schema_version": "loom-external-orchestrator-read/v1",
+        "operation": "work_item_read",
+        "entry_kind": "work_item",
+        "source_layer": "authored_truth",
+        "source_locator": ".loom/work-items/INIT-0001.md",
+        "source_binding": {
+          "item_id": "INIT-0001"
+        },
+        "consumed_as": "locator"
+      },
+      "expect": {
+        "result": "pass"
+      }
+    },
+    {
+      "name": "pr-only-entry-block",
+      "entry": {
+        "id": "fake-external-orchestrator",
+        "summary": "Attempt to start from a PR instead of a Work Item.",
+        "surfaces": ["admission"],
+        "operations": ["work_item_read"],
+        "locator": ".loom/external-orchestrator/pr-only.json",
+        "owner": "external-tool",
+        "requirement": "required",
+        "fallback_to": "admission"
+      },
+      "payload": {
+        "schema_version": "loom-external-orchestrator-read/v1",
+        "operation": "work_item_read",
+        "entry_kind": "implementation_pr",
+        "source_layer": "host_control_mirror",
+        "source_locator": "https://github.com/example/repo/pull/1",
+        "source_binding": {
+          "pr": 1
+        },
+        "consumed_as": "mirror"
+      },
+      "expect": {
+        "result": "block",
+        "failure": "gate_failure.missing_prerequisite_gate",
+        "fallback_to": "work_item"
+      }
+    },
+    {
+      "name": "truth-poisoning-block",
+      "entry": {
+        "id": "fake-external-orchestrator",
+        "summary": "Attempt to carry scheduler state and authored progress.",
+        "surfaces": ["admission"],
+        "operations": ["work_item_read"],
+        "locator": ".loom/external-orchestrator/truth-poisoning.json",
+        "owner": "external-tool",
+        "requirement": "required",
+        "fallback_to": "admission"
+      },
+      "payload": {
+        "schema_version": "loom-external-orchestrator-read/v1",
+        "operation": "work_item_read",
+        "entry_kind": "work_item",
+        "source_layer": "authored_truth",
+        "source_locator": ".loom/work-items/INIT-0001.md",
+        "source_binding": {
+          "item_id": "INIT-0001"
+        },
+        "consumed_as": "truth",
+        "scheduler_state": "Running",
+        "next_step": "Continue from the orchestrator queue."
+      },
+      "expect": {
+        "result": "block",
+        "failure": "truth_pollution",
+        "fallback_to": "admission"
+      }
+    },
+    {
+      "name": "optional-missing-warn",
+      "entry": {
+        "id": "optional-external-orchestrator",
+        "summary": "Optional external orchestrator read evidence may be absent.",
+        "surfaces": ["admission"],
+        "operations": ["work_item_read"],
+        "locator": ".loom/external-orchestrator/missing-optional.json",
+        "owner": "external-tool",
+        "requirement": "optional",
+        "fallback_to": "admission"
+      },
+      "payload": null,
+      "expect": {
+        "result": "warn"
+      }
+    }
+  ]
+}

--- a/docs/evidence/orchestration-conformance-profiles.md
+++ b/docs/evidence/orchestration-conformance-profiles.md
@@ -39,6 +39,7 @@ Core 缺口必须 fail closed，因为这些能力构成 Loom v0.7.0 的可恢�
 - host action / dynamic tool declaration-time locator contract
 - hook locator safety declarations, mapped hook envelopes, and unsafe
   host-adapter results
+- external orchestrator Work Item read locators and retained read evidence
 - host-backed tracker state 只能作为 structured event evidence 或 retained host result 被消费
 - required locator missing / unreadable / invalid boundary 的 fail-closed 行为
 - optional / advisory missing in-repo locator 只进入 profile-local `missing_optional`
@@ -67,6 +68,24 @@ Extension 缺口不得污染 `orchestration-core` pass/fail。若某 adopted rep
 该 profile 的 live evidence 命令是
 `python3 tools/loom_flow.py live-smoke hooks-extension --target <repo>`，输出
 schema 为 `loom-hooks-extension-profile/v1`。
+
+### `orchestration-extension/external-orchestrator`
+
+`orchestration-extension/external-orchestrator` 是外部 orchestrator interop 的
+optional extension profile。它证明外部 orchestrator 可以消费 Loom，而 Loom 不变成
+daemon 或 scheduler 产品。
+
+第一版覆盖：
+
+- `Work Item` read locator
+- PR-only / tracker-only / release-only / merge-commit-only 入口 fail closed
+- external orchestrator locator payload 不承载 authored progress、status truth、gate truth 或 scheduler state
+- required locator missing / unreadable / unsafe 时在 extension path 内 block
+- optional / advisory locator gaps 只进入 profile-local warning
+
+该 profile 只消费 [external-orchestrator-interop.md](../methodology/harness/external-orchestrator-interop.md)
+与 `repo interop` 的 locator-only 声明。它不得新增第二状态面，不得改变
+`orchestration-core` pass/fail。
 
 ## 4. `orchestration-live`
 

--- a/docs/methodology/harness/external-orchestrator-interop.md
+++ b/docs/methodology/harness/external-orchestrator-interop.md
@@ -1,0 +1,113 @@
+# External Orchestrator Interop
+
+本文件定义外部 orchestrator 如何消费 Loom，而不把 Loom 变成 scheduler 产品。
+
+它承接 `#535` 的外部 interop 边界。完整事实链仍以
+[fact-chain-contract.md](./fact-chain-contract.md) 为准。
+
+## 1. 目标
+
+外部 orchestrator 可以做四件事：
+
+- 读取当前 `Work Item`
+- attach 已存在的 workspace 语义
+- 通过 recovery writeback 写回执行进展
+- 只读消费 status 与 gates
+
+它不得做三件事：
+
+- 创建第二状态面
+- author gate / review / status truth
+- 接管 branch、PR、git worktree 或 worker lifecycle
+
+## 2. Work Item 读取顺序
+
+外部 orchestrator 必须按同一条事实链读取：
+
+1. `init-result`
+   - 只用于 locator discovery，不承载执行真相
+2. `Work Item`
+   - 读取 `item_id`、目标、范围、执行路径、workspace / recovery / review / validation locator
+3. recovery entry
+   - 读取当前 checkpoint、停点、下一步、阻断项和最近验证摘要
+4. status control plane
+   - 只作为派生汇总和 provenance 读面
+5. host mirror / retained result
+   - 只作为绑定、镜像或 evidence 消费
+
+外部 orchestrator 不得跳过 `Work Item`，也不得从 PR、tracker、release index 或
+merge commit 反推执行入口。
+
+## 3. 非法入口
+
+以下入口必须 fail closed：
+
+- PR-only
+- tracker-only
+- release-only
+- merge-commit-only
+- 缺少 `Work Item` 最小字段
+- `Work Item` 与 host binding 无法回链到同一事项
+
+结果必须使用现有 taxonomy：
+
+- `gate_failure.missing_prerequisite_gate`
+- `gate_failure.binding_failure`
+
+回退方向只允许指向：
+
+- `work_item`
+- `admission`
+- `binding_repair`
+
+不得指向 orchestrator 私有队列、retry state、tracker state 或 scheduler action。
+
+## 4. Locator Declaration
+
+成熟既有仓库可以通过 `.loom/companion/interop.json` 的
+`external_orchestrators` 声明外部 orchestrator 读面。
+
+这些声明只定位可读 evidence / adapter surface：
+
+- `id`
+- `summary`
+- `surfaces`
+- `operations`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+`operations` 第一版至少允许：
+
+- `work_item_read`
+
+后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
+`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+
+## 5. Truth Boundary
+
+`external_orchestrators` 不得承载：
+
+- scheduler state
+- attempt ownership
+- authored progress
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- status truth
+- gate verdict
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
+pollution，并阻断 required 声明。
+
+## 6. 非目标
+
+- 不提供默认 daemon
+- 不定义 tracker polling 产品
+- 不定义自动 retry / backoff 状态机
+- 不复制任何外部 orchestrator 的私有状态模型

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.99",
+  "version": "0.1.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.99",
+      "version": "0.1.100",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.99",
+  "version": "0.1.100",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/install-layout.json
+++ b/skills/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/external-orchestrator-interop.md",
     "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",

--- a/skills/loom-adopt/.loom-runtime/install-layout.json
+++ b/skills/loom-adopt/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/external-orchestrator-interop.md",
     "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -1,0 +1,113 @@
+# External Orchestrator Interop
+
+本文件定义外部 orchestrator 如何消费 Loom，而不把 Loom 变成 scheduler 产品。
+
+它承接 `#535` 的外部 interop 边界。完整事实链仍以
+[fact-chain-contract.md](./fact-chain-contract.md) 为准。
+
+## 1. 目标
+
+外部 orchestrator 可以做四件事：
+
+- 读取当前 `Work Item`
+- attach 已存在的 workspace 语义
+- 通过 recovery writeback 写回执行进展
+- 只读消费 status 与 gates
+
+它不得做三件事：
+
+- 创建第二状态面
+- author gate / review / status truth
+- 接管 branch、PR、git worktree 或 worker lifecycle
+
+## 2. Work Item 读取顺序
+
+外部 orchestrator 必须按同一条事实链读取：
+
+1. `init-result`
+   - 只用于 locator discovery，不承载执行真相
+2. `Work Item`
+   - 读取 `item_id`、目标、范围、执行路径、workspace / recovery / review / validation locator
+3. recovery entry
+   - 读取当前 checkpoint、停点、下一步、阻断项和最近验证摘要
+4. status control plane
+   - 只作为派生汇总和 provenance 读面
+5. host mirror / retained result
+   - 只作为绑定、镜像或 evidence 消费
+
+外部 orchestrator 不得跳过 `Work Item`，也不得从 PR、tracker、release index 或
+merge commit 反推执行入口。
+
+## 3. 非法入口
+
+以下入口必须 fail closed：
+
+- PR-only
+- tracker-only
+- release-only
+- merge-commit-only
+- 缺少 `Work Item` 最小字段
+- `Work Item` 与 host binding 无法回链到同一事项
+
+结果必须使用现有 taxonomy：
+
+- `gate_failure.missing_prerequisite_gate`
+- `gate_failure.binding_failure`
+
+回退方向只允许指向：
+
+- `work_item`
+- `admission`
+- `binding_repair`
+
+不得指向 orchestrator 私有队列、retry state、tracker state 或 scheduler action。
+
+## 4. Locator Declaration
+
+成熟既有仓库可以通过 `.loom/companion/interop.json` 的
+`external_orchestrators` 声明外部 orchestrator 读面。
+
+这些声明只定位可读 evidence / adapter surface：
+
+- `id`
+- `summary`
+- `surfaces`
+- `operations`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+`operations` 第一版至少允许：
+
+- `work_item_read`
+
+后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
+`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+
+## 5. Truth Boundary
+
+`external_orchestrators` 不得承载：
+
+- scheduler state
+- attempt ownership
+- authored progress
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- status truth
+- gate verdict
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
+pollution，并阻断 required 声明。
+
+## 6. 非目标
+
+- 不提供默认 daemon
+- 不定义 tracker polling 产品
+- 不定义自动 retry / backoff 状态机
+- 不复制任何外部 orchestrator 的私有状态模型

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/governance_surface.py
@@ -415,7 +415,7 @@ RELEASE_TARGET_DELIVERY_STATUSES = {
 }
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
-REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
+REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"}
 REPO_INTEROP_COLLECTION_SURFACES = {
     "admission",
     "pre_review",
@@ -423,6 +423,9 @@ REPO_INTEROP_COLLECTION_SURFACES = {
     "build",
     "merge_ready",
     "closeout",
+}
+EXTERNAL_ORCHESTRATOR_OPERATIONS = {
+    "work_item_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2096,6 +2099,33 @@ def validate_repo_interop_collection_entry(
     return missing_inputs, missing_optional
 
 
+def validate_external_orchestrator_entry(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    missing_inputs, missing_optional = validate_repo_interop_collection_entry(
+        root=root,
+        collection="external_orchestrators",
+        entry=entry,
+        index=index,
+    )
+    if not isinstance(entry, dict):
+        return missing_inputs, missing_optional
+    prefix = f"external_orchestrators[{index}]"
+    operations = entry.get("operations")
+    if not isinstance(operations, list) or not operations:
+        missing_inputs.append(f"{prefix} must include `operations` as a non-empty list")
+    else:
+        for operation_index, operation in enumerate(operations):
+            if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
+                missing_inputs.append(
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                )
+    return missing_inputs, missing_optional
+
+
 def validate_shadow_surface(
     *,
     root: Path,
@@ -2412,6 +2442,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "host_adapters": carrier_entry("missing", "unknown", "repo interop contract"),
         "repo_native_carriers": carrier_entry("missing", "unknown", "repo interop contract"),
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
+        "external_orchestrators": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2440,7 +2471,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 + ", ".join(extra_keys)
             )
 
-        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
             repo_interop_surface[key] = carrier_entry(
                 "present",
                 ".loom/companion/interop.json",
@@ -2469,6 +2500,19 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 blocking, optional = validate_repo_interop_collection_entry(
                     root=root,
                     collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
+                )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
+
+        external_orchestrators = interop_payload.get("external_orchestrators", [])
+        if not isinstance(external_orchestrators, list):
+            missing_inputs.append("repo interop contract must include `external_orchestrators` as a list")
+        else:
+            for index, entry in enumerate(external_orchestrators):
+                blocking, optional = validate_external_orchestrator_entry(
+                    root=root,
                     entry=entry,
                     index=index,
                 )
@@ -2505,7 +2549,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = (
             "repo interop contract is readable with optional locator advisories."
             if missing_optional
-            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+            else "repo interop contract is readable for host adapters, repo-native carriers, shadow parity, and external orchestrator locators."
         )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
     repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -78,6 +78,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/external-orchestrator-interop.md",
     "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
@@ -308,6 +309,22 @@ EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -1514,7 +1531,7 @@ def require_repo_interop_payload(
         payload=payload.get("contract"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
         require_locator_entry(
             failures,
             category=category,
@@ -9228,6 +9245,15 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         (target / "native" / "status").mkdir(parents=True, exist_ok=True)
         for relative, payload in {
             "host/guardian-review.json": {"verdict": "allow"},
+            "host/external-orchestrator-read.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "work_item_read",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/work-items/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9285,6 +9311,28 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "requirement": "required",
                 "fallback_to": "manual-reconciliation",
             }
+        ],
+        "external_orchestrators": [
+            {
+                "id": "fake-external-orchestrator",
+                "summary": "Read external orchestrator retained read evidence without making it a scheduler state.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/external-orchestrator-read.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-external-orchestrator",
+                "summary": "Optional external orchestrator evidence may be unavailable.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/missing-external-orchestrator.json",
+                "owner": "external-tool",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            },
         ],
         "shadow_surfaces": {
             "admission": {
@@ -9345,6 +9393,7 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                     }
                 ],
                 "repo_native_carriers": [],
+                "external_orchestrators": [],
                 "shadow_surfaces": {
                     "admission": {
                         "summary": "Compare admission parity.",
@@ -9406,10 +9455,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
         elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        elif "missing-external-orchestrator.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must stay in missing_optional"))
         if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "missing-external-orchestrator.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -9609,6 +9662,89 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             reports = rogue_payload.get("reports")
             if not isinstance(reports, list) or not reports or reports[0].get("result") != "unreadable":
                 failures.append(Failure("repo-interop", "`shadow-parity` rogue evidence sample must report `unreadable`"))
+
+    return failures
+
+
+def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Failure]:
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-interop-fixtures.json"
+    category = "external-orchestrator-interop"
+    failures: list[Failure] = []
+    if not fixture_path.exists():
+        return [Failure(category, "`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` is missing")]
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [Failure(category, f"external orchestrator fixture JSON is invalid: {exc}")]
+
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` schema_version must be `{EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA}`",
+            )
+        )
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator fixtures must include a non-empty `fixtures` list"))
+        return failures
+
+    seen_names: set[str] = set()
+    required_names = {
+        "work-item-read-present",
+        "pr-only-entry-block",
+        "truth-poisoning-block",
+        "optional-missing-warn",
+    }
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if not isinstance(name, str) or not name:
+            failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
+        else:
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+        else:
+            for field in ("id", "summary", "locator", "owner", "requirement", "fallback_to"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{name or index} entry missing `{field}`"))
+            if entry.get("owner") not in governance_surface_module.DECLARED_LOCATOR_OWNERS:
+                failures.append(Failure(category, f"{name or index} owner must stay within declared locator owners"))
+            if entry.get("requirement") not in governance_surface_module.DECLARED_LOCATOR_REQUIREMENTS:
+                failures.append(Failure(category, f"{name or index} requirement must be required/optional/advisory"))
+            surfaces = entry.get("surfaces")
+            if not isinstance(surfaces, list) or not surfaces:
+                failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
+            operations = entry.get("operations")
+            if not isinstance(operations, list) or "work_item_read" not in operations:
+                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
+        if payload is not None:
+            if not isinstance(payload, dict):
+                failures.append(Failure(category, f"{name or index} payload must be an object or null"))
+            else:
+                if payload.get("operation") != "work_item_read":
+                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
+                    failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+                if forbidden and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
+                if payload.get("entry_kind") != "work_item" and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
+                if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
+                    failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator fixtures missing required cases: " + ", ".join(missing)))
 
     return failures
 
@@ -14073,6 +14209,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
+    failures.extend(check_external_orchestrator_interop_fixture_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14101,7 +14238,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 34
+    categories_checked = 35
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-build/.loom-runtime/install-layout.json
+++ b/skills/loom-build/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/external-orchestrator-interop.md",
     "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",

--- a/skills/loom-build/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -1,0 +1,113 @@
+# External Orchestrator Interop
+
+本文件定义外部 orchestrator 如何消费 Loom，而不把 Loom 变成 scheduler 产品。
+
+它承接 `#535` 的外部 interop 边界。完整事实链仍以
+[fact-chain-contract.md](./fact-chain-contract.md) 为准。
+
+## 1. 目标
+
+外部 orchestrator 可以做四件事：
+
+- 读取当前 `Work Item`
+- attach 已存在的 workspace 语义
+- 通过 recovery writeback 写回执行进展
+- 只读消费 status 与 gates
+
+它不得做三件事：
+
+- 创建第二状态面
+- author gate / review / status truth
+- 接管 branch、PR、git worktree 或 worker lifecycle
+
+## 2. Work Item 读取顺序
+
+外部 orchestrator 必须按同一条事实链读取：
+
+1. `init-result`
+   - 只用于 locator discovery，不承载执行真相
+2. `Work Item`
+   - 读取 `item_id`、目标、范围、执行路径、workspace / recovery / review / validation locator
+3. recovery entry
+   - 读取当前 checkpoint、停点、下一步、阻断项和最近验证摘要
+4. status control plane
+   - 只作为派生汇总和 provenance 读面
+5. host mirror / retained result
+   - 只作为绑定、镜像或 evidence 消费
+
+外部 orchestrator 不得跳过 `Work Item`，也不得从 PR、tracker、release index 或
+merge commit 反推执行入口。
+
+## 3. 非法入口
+
+以下入口必须 fail closed：
+
+- PR-only
+- tracker-only
+- release-only
+- merge-commit-only
+- 缺少 `Work Item` 最小字段
+- `Work Item` 与 host binding 无法回链到同一事项
+
+结果必须使用现有 taxonomy：
+
+- `gate_failure.missing_prerequisite_gate`
+- `gate_failure.binding_failure`
+
+回退方向只允许指向：
+
+- `work_item`
+- `admission`
+- `binding_repair`
+
+不得指向 orchestrator 私有队列、retry state、tracker state 或 scheduler action。
+
+## 4. Locator Declaration
+
+成熟既有仓库可以通过 `.loom/companion/interop.json` 的
+`external_orchestrators` 声明外部 orchestrator 读面。
+
+这些声明只定位可读 evidence / adapter surface：
+
+- `id`
+- `summary`
+- `surfaces`
+- `operations`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+`operations` 第一版至少允许：
+
+- `work_item_read`
+
+后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
+`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+
+## 5. Truth Boundary
+
+`external_orchestrators` 不得承载：
+
+- scheduler state
+- attempt ownership
+- authored progress
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- status truth
+- gate verdict
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
+pollution，并阻断 required 声明。
+
+## 6. 非目标
+
+- 不提供默认 daemon
+- 不定义 tracker polling 产品
+- 不定义自动 retry / backoff 状态机
+- 不复制任何外部 orchestrator 的私有状态模型

--- a/skills/loom-build/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/governance_surface.py
@@ -415,7 +415,7 @@ RELEASE_TARGET_DELIVERY_STATUSES = {
 }
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
-REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
+REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"}
 REPO_INTEROP_COLLECTION_SURFACES = {
     "admission",
     "pre_review",
@@ -423,6 +423,9 @@ REPO_INTEROP_COLLECTION_SURFACES = {
     "build",
     "merge_ready",
     "closeout",
+}
+EXTERNAL_ORCHESTRATOR_OPERATIONS = {
+    "work_item_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2096,6 +2099,33 @@ def validate_repo_interop_collection_entry(
     return missing_inputs, missing_optional
 
 
+def validate_external_orchestrator_entry(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    missing_inputs, missing_optional = validate_repo_interop_collection_entry(
+        root=root,
+        collection="external_orchestrators",
+        entry=entry,
+        index=index,
+    )
+    if not isinstance(entry, dict):
+        return missing_inputs, missing_optional
+    prefix = f"external_orchestrators[{index}]"
+    operations = entry.get("operations")
+    if not isinstance(operations, list) or not operations:
+        missing_inputs.append(f"{prefix} must include `operations` as a non-empty list")
+    else:
+        for operation_index, operation in enumerate(operations):
+            if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
+                missing_inputs.append(
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                )
+    return missing_inputs, missing_optional
+
+
 def validate_shadow_surface(
     *,
     root: Path,
@@ -2412,6 +2442,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "host_adapters": carrier_entry("missing", "unknown", "repo interop contract"),
         "repo_native_carriers": carrier_entry("missing", "unknown", "repo interop contract"),
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
+        "external_orchestrators": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2440,7 +2471,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 + ", ".join(extra_keys)
             )
 
-        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
             repo_interop_surface[key] = carrier_entry(
                 "present",
                 ".loom/companion/interop.json",
@@ -2469,6 +2500,19 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 blocking, optional = validate_repo_interop_collection_entry(
                     root=root,
                     collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
+                )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
+
+        external_orchestrators = interop_payload.get("external_orchestrators", [])
+        if not isinstance(external_orchestrators, list):
+            missing_inputs.append("repo interop contract must include `external_orchestrators` as a list")
+        else:
+            for index, entry in enumerate(external_orchestrators):
+                blocking, optional = validate_external_orchestrator_entry(
+                    root=root,
                     entry=entry,
                     index=index,
                 )
@@ -2505,7 +2549,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = (
             "repo interop contract is readable with optional locator advisories."
             if missing_optional
-            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+            else "repo interop contract is readable for host adapters, repo-native carriers, shadow parity, and external orchestrator locators."
         )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
     repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -78,6 +78,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/external-orchestrator-interop.md",
     "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
@@ -308,6 +309,22 @@ EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -1514,7 +1531,7 @@ def require_repo_interop_payload(
         payload=payload.get("contract"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
         require_locator_entry(
             failures,
             category=category,
@@ -9228,6 +9245,15 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         (target / "native" / "status").mkdir(parents=True, exist_ok=True)
         for relative, payload in {
             "host/guardian-review.json": {"verdict": "allow"},
+            "host/external-orchestrator-read.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "work_item_read",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/work-items/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9285,6 +9311,28 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "requirement": "required",
                 "fallback_to": "manual-reconciliation",
             }
+        ],
+        "external_orchestrators": [
+            {
+                "id": "fake-external-orchestrator",
+                "summary": "Read external orchestrator retained read evidence without making it a scheduler state.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/external-orchestrator-read.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-external-orchestrator",
+                "summary": "Optional external orchestrator evidence may be unavailable.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/missing-external-orchestrator.json",
+                "owner": "external-tool",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            },
         ],
         "shadow_surfaces": {
             "admission": {
@@ -9345,6 +9393,7 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                     }
                 ],
                 "repo_native_carriers": [],
+                "external_orchestrators": [],
                 "shadow_surfaces": {
                     "admission": {
                         "summary": "Compare admission parity.",
@@ -9406,10 +9455,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
         elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        elif "missing-external-orchestrator.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must stay in missing_optional"))
         if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "missing-external-orchestrator.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -9609,6 +9662,89 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             reports = rogue_payload.get("reports")
             if not isinstance(reports, list) or not reports or reports[0].get("result") != "unreadable":
                 failures.append(Failure("repo-interop", "`shadow-parity` rogue evidence sample must report `unreadable`"))
+
+    return failures
+
+
+def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Failure]:
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-interop-fixtures.json"
+    category = "external-orchestrator-interop"
+    failures: list[Failure] = []
+    if not fixture_path.exists():
+        return [Failure(category, "`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` is missing")]
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [Failure(category, f"external orchestrator fixture JSON is invalid: {exc}")]
+
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` schema_version must be `{EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA}`",
+            )
+        )
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator fixtures must include a non-empty `fixtures` list"))
+        return failures
+
+    seen_names: set[str] = set()
+    required_names = {
+        "work-item-read-present",
+        "pr-only-entry-block",
+        "truth-poisoning-block",
+        "optional-missing-warn",
+    }
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if not isinstance(name, str) or not name:
+            failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
+        else:
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+        else:
+            for field in ("id", "summary", "locator", "owner", "requirement", "fallback_to"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{name or index} entry missing `{field}`"))
+            if entry.get("owner") not in governance_surface_module.DECLARED_LOCATOR_OWNERS:
+                failures.append(Failure(category, f"{name or index} owner must stay within declared locator owners"))
+            if entry.get("requirement") not in governance_surface_module.DECLARED_LOCATOR_REQUIREMENTS:
+                failures.append(Failure(category, f"{name or index} requirement must be required/optional/advisory"))
+            surfaces = entry.get("surfaces")
+            if not isinstance(surfaces, list) or not surfaces:
+                failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
+            operations = entry.get("operations")
+            if not isinstance(operations, list) or "work_item_read" not in operations:
+                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
+        if payload is not None:
+            if not isinstance(payload, dict):
+                failures.append(Failure(category, f"{name or index} payload must be an object or null"))
+            else:
+                if payload.get("operation") != "work_item_read":
+                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
+                    failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+                if forbidden and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
+                if payload.get("entry_kind") != "work_item" and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
+                if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
+                    failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator fixtures missing required cases: " + ", ".join(missing)))
 
     return failures
 
@@ -14073,6 +14209,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
+    failures.extend(check_external_orchestrator_interop_fixture_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14101,7 +14238,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 34
+    categories_checked = 35
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-handoff/.loom-runtime/install-layout.json
+++ b/skills/loom-handoff/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/external-orchestrator-interop.md",
     "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -1,0 +1,113 @@
+# External Orchestrator Interop
+
+本文件定义外部 orchestrator 如何消费 Loom，而不把 Loom 变成 scheduler 产品。
+
+它承接 `#535` 的外部 interop 边界。完整事实链仍以
+[fact-chain-contract.md](./fact-chain-contract.md) 为准。
+
+## 1. 目标
+
+外部 orchestrator 可以做四件事：
+
+- 读取当前 `Work Item`
+- attach 已存在的 workspace 语义
+- 通过 recovery writeback 写回执行进展
+- 只读消费 status 与 gates
+
+它不得做三件事：
+
+- 创建第二状态面
+- author gate / review / status truth
+- 接管 branch、PR、git worktree 或 worker lifecycle
+
+## 2. Work Item 读取顺序
+
+外部 orchestrator 必须按同一条事实链读取：
+
+1. `init-result`
+   - 只用于 locator discovery，不承载执行真相
+2. `Work Item`
+   - 读取 `item_id`、目标、范围、执行路径、workspace / recovery / review / validation locator
+3. recovery entry
+   - 读取当前 checkpoint、停点、下一步、阻断项和最近验证摘要
+4. status control plane
+   - 只作为派生汇总和 provenance 读面
+5. host mirror / retained result
+   - 只作为绑定、镜像或 evidence 消费
+
+外部 orchestrator 不得跳过 `Work Item`，也不得从 PR、tracker、release index 或
+merge commit 反推执行入口。
+
+## 3. 非法入口
+
+以下入口必须 fail closed：
+
+- PR-only
+- tracker-only
+- release-only
+- merge-commit-only
+- 缺少 `Work Item` 最小字段
+- `Work Item` 与 host binding 无法回链到同一事项
+
+结果必须使用现有 taxonomy：
+
+- `gate_failure.missing_prerequisite_gate`
+- `gate_failure.binding_failure`
+
+回退方向只允许指向：
+
+- `work_item`
+- `admission`
+- `binding_repair`
+
+不得指向 orchestrator 私有队列、retry state、tracker state 或 scheduler action。
+
+## 4. Locator Declaration
+
+成熟既有仓库可以通过 `.loom/companion/interop.json` 的
+`external_orchestrators` 声明外部 orchestrator 读面。
+
+这些声明只定位可读 evidence / adapter surface：
+
+- `id`
+- `summary`
+- `surfaces`
+- `operations`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+`operations` 第一版至少允许：
+
+- `work_item_read`
+
+后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
+`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+
+## 5. Truth Boundary
+
+`external_orchestrators` 不得承载：
+
+- scheduler state
+- attempt ownership
+- authored progress
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- status truth
+- gate verdict
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
+pollution，并阻断 required 声明。
+
+## 6. 非目标
+
+- 不提供默认 daemon
+- 不定义 tracker polling 产品
+- 不定义自动 retry / backoff 状态机
+- 不复制任何外部 orchestrator 的私有状态模型

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/governance_surface.py
@@ -415,7 +415,7 @@ RELEASE_TARGET_DELIVERY_STATUSES = {
 }
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
-REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
+REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"}
 REPO_INTEROP_COLLECTION_SURFACES = {
     "admission",
     "pre_review",
@@ -423,6 +423,9 @@ REPO_INTEROP_COLLECTION_SURFACES = {
     "build",
     "merge_ready",
     "closeout",
+}
+EXTERNAL_ORCHESTRATOR_OPERATIONS = {
+    "work_item_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2096,6 +2099,33 @@ def validate_repo_interop_collection_entry(
     return missing_inputs, missing_optional
 
 
+def validate_external_orchestrator_entry(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    missing_inputs, missing_optional = validate_repo_interop_collection_entry(
+        root=root,
+        collection="external_orchestrators",
+        entry=entry,
+        index=index,
+    )
+    if not isinstance(entry, dict):
+        return missing_inputs, missing_optional
+    prefix = f"external_orchestrators[{index}]"
+    operations = entry.get("operations")
+    if not isinstance(operations, list) or not operations:
+        missing_inputs.append(f"{prefix} must include `operations` as a non-empty list")
+    else:
+        for operation_index, operation in enumerate(operations):
+            if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
+                missing_inputs.append(
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                )
+    return missing_inputs, missing_optional
+
+
 def validate_shadow_surface(
     *,
     root: Path,
@@ -2412,6 +2442,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "host_adapters": carrier_entry("missing", "unknown", "repo interop contract"),
         "repo_native_carriers": carrier_entry("missing", "unknown", "repo interop contract"),
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
+        "external_orchestrators": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2440,7 +2471,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 + ", ".join(extra_keys)
             )
 
-        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
             repo_interop_surface[key] = carrier_entry(
                 "present",
                 ".loom/companion/interop.json",
@@ -2469,6 +2500,19 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 blocking, optional = validate_repo_interop_collection_entry(
                     root=root,
                     collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
+                )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
+
+        external_orchestrators = interop_payload.get("external_orchestrators", [])
+        if not isinstance(external_orchestrators, list):
+            missing_inputs.append("repo interop contract must include `external_orchestrators` as a list")
+        else:
+            for index, entry in enumerate(external_orchestrators):
+                blocking, optional = validate_external_orchestrator_entry(
+                    root=root,
                     entry=entry,
                     index=index,
                 )
@@ -2505,7 +2549,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = (
             "repo interop contract is readable with optional locator advisories."
             if missing_optional
-            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+            else "repo interop contract is readable for host adapters, repo-native carriers, shadow parity, and external orchestrator locators."
         )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
     repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -78,6 +78,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/external-orchestrator-interop.md",
     "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
@@ -308,6 +309,22 @@ EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -1514,7 +1531,7 @@ def require_repo_interop_payload(
         payload=payload.get("contract"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
         require_locator_entry(
             failures,
             category=category,
@@ -9228,6 +9245,15 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         (target / "native" / "status").mkdir(parents=True, exist_ok=True)
         for relative, payload in {
             "host/guardian-review.json": {"verdict": "allow"},
+            "host/external-orchestrator-read.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "work_item_read",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/work-items/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9285,6 +9311,28 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "requirement": "required",
                 "fallback_to": "manual-reconciliation",
             }
+        ],
+        "external_orchestrators": [
+            {
+                "id": "fake-external-orchestrator",
+                "summary": "Read external orchestrator retained read evidence without making it a scheduler state.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/external-orchestrator-read.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-external-orchestrator",
+                "summary": "Optional external orchestrator evidence may be unavailable.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/missing-external-orchestrator.json",
+                "owner": "external-tool",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            },
         ],
         "shadow_surfaces": {
             "admission": {
@@ -9345,6 +9393,7 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                     }
                 ],
                 "repo_native_carriers": [],
+                "external_orchestrators": [],
                 "shadow_surfaces": {
                     "admission": {
                         "summary": "Compare admission parity.",
@@ -9406,10 +9455,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
         elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        elif "missing-external-orchestrator.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must stay in missing_optional"))
         if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "missing-external-orchestrator.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -9609,6 +9662,89 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             reports = rogue_payload.get("reports")
             if not isinstance(reports, list) or not reports or reports[0].get("result") != "unreadable":
                 failures.append(Failure("repo-interop", "`shadow-parity` rogue evidence sample must report `unreadable`"))
+
+    return failures
+
+
+def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Failure]:
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-interop-fixtures.json"
+    category = "external-orchestrator-interop"
+    failures: list[Failure] = []
+    if not fixture_path.exists():
+        return [Failure(category, "`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` is missing")]
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [Failure(category, f"external orchestrator fixture JSON is invalid: {exc}")]
+
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` schema_version must be `{EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA}`",
+            )
+        )
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator fixtures must include a non-empty `fixtures` list"))
+        return failures
+
+    seen_names: set[str] = set()
+    required_names = {
+        "work-item-read-present",
+        "pr-only-entry-block",
+        "truth-poisoning-block",
+        "optional-missing-warn",
+    }
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if not isinstance(name, str) or not name:
+            failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
+        else:
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+        else:
+            for field in ("id", "summary", "locator", "owner", "requirement", "fallback_to"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{name or index} entry missing `{field}`"))
+            if entry.get("owner") not in governance_surface_module.DECLARED_LOCATOR_OWNERS:
+                failures.append(Failure(category, f"{name or index} owner must stay within declared locator owners"))
+            if entry.get("requirement") not in governance_surface_module.DECLARED_LOCATOR_REQUIREMENTS:
+                failures.append(Failure(category, f"{name or index} requirement must be required/optional/advisory"))
+            surfaces = entry.get("surfaces")
+            if not isinstance(surfaces, list) or not surfaces:
+                failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
+            operations = entry.get("operations")
+            if not isinstance(operations, list) or "work_item_read" not in operations:
+                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
+        if payload is not None:
+            if not isinstance(payload, dict):
+                failures.append(Failure(category, f"{name or index} payload must be an object or null"))
+            else:
+                if payload.get("operation") != "work_item_read":
+                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
+                    failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+                if forbidden and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
+                if payload.get("entry_kind") != "work_item" and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
+                if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
+                    failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator fixtures missing required cases: " + ", ".join(missing)))
 
     return failures
 
@@ -14073,6 +14209,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
+    failures.extend(check_external_orchestrator_interop_fixture_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14101,7 +14238,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 34
+    categories_checked = 35
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-init/.loom-runtime/install-layout.json
+++ b/skills/loom-init/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/external-orchestrator-interop.md",
     "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",

--- a/skills/loom-init/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -1,0 +1,113 @@
+# External Orchestrator Interop
+
+本文件定义外部 orchestrator 如何消费 Loom，而不把 Loom 变成 scheduler 产品。
+
+它承接 `#535` 的外部 interop 边界。完整事实链仍以
+[fact-chain-contract.md](./fact-chain-contract.md) 为准。
+
+## 1. 目标
+
+外部 orchestrator 可以做四件事：
+
+- 读取当前 `Work Item`
+- attach 已存在的 workspace 语义
+- 通过 recovery writeback 写回执行进展
+- 只读消费 status 与 gates
+
+它不得做三件事：
+
+- 创建第二状态面
+- author gate / review / status truth
+- 接管 branch、PR、git worktree 或 worker lifecycle
+
+## 2. Work Item 读取顺序
+
+外部 orchestrator 必须按同一条事实链读取：
+
+1. `init-result`
+   - 只用于 locator discovery，不承载执行真相
+2. `Work Item`
+   - 读取 `item_id`、目标、范围、执行路径、workspace / recovery / review / validation locator
+3. recovery entry
+   - 读取当前 checkpoint、停点、下一步、阻断项和最近验证摘要
+4. status control plane
+   - 只作为派生汇总和 provenance 读面
+5. host mirror / retained result
+   - 只作为绑定、镜像或 evidence 消费
+
+外部 orchestrator 不得跳过 `Work Item`，也不得从 PR、tracker、release index 或
+merge commit 反推执行入口。
+
+## 3. 非法入口
+
+以下入口必须 fail closed：
+
+- PR-only
+- tracker-only
+- release-only
+- merge-commit-only
+- 缺少 `Work Item` 最小字段
+- `Work Item` 与 host binding 无法回链到同一事项
+
+结果必须使用现有 taxonomy：
+
+- `gate_failure.missing_prerequisite_gate`
+- `gate_failure.binding_failure`
+
+回退方向只允许指向：
+
+- `work_item`
+- `admission`
+- `binding_repair`
+
+不得指向 orchestrator 私有队列、retry state、tracker state 或 scheduler action。
+
+## 4. Locator Declaration
+
+成熟既有仓库可以通过 `.loom/companion/interop.json` 的
+`external_orchestrators` 声明外部 orchestrator 读面。
+
+这些声明只定位可读 evidence / adapter surface：
+
+- `id`
+- `summary`
+- `surfaces`
+- `operations`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+`operations` 第一版至少允许：
+
+- `work_item_read`
+
+后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
+`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+
+## 5. Truth Boundary
+
+`external_orchestrators` 不得承载：
+
+- scheduler state
+- attempt ownership
+- authored progress
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- status truth
+- gate verdict
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
+pollution，并阻断 required 声明。
+
+## 6. 非目标
+
+- 不提供默认 daemon
+- 不定义 tracker polling 产品
+- 不定义自动 retry / backoff 状态机
+- 不复制任何外部 orchestrator 的私有状态模型

--- a/skills/loom-init/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/governance_surface.py
@@ -415,7 +415,7 @@ RELEASE_TARGET_DELIVERY_STATUSES = {
 }
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
-REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
+REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"}
 REPO_INTEROP_COLLECTION_SURFACES = {
     "admission",
     "pre_review",
@@ -423,6 +423,9 @@ REPO_INTEROP_COLLECTION_SURFACES = {
     "build",
     "merge_ready",
     "closeout",
+}
+EXTERNAL_ORCHESTRATOR_OPERATIONS = {
+    "work_item_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2096,6 +2099,33 @@ def validate_repo_interop_collection_entry(
     return missing_inputs, missing_optional
 
 
+def validate_external_orchestrator_entry(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    missing_inputs, missing_optional = validate_repo_interop_collection_entry(
+        root=root,
+        collection="external_orchestrators",
+        entry=entry,
+        index=index,
+    )
+    if not isinstance(entry, dict):
+        return missing_inputs, missing_optional
+    prefix = f"external_orchestrators[{index}]"
+    operations = entry.get("operations")
+    if not isinstance(operations, list) or not operations:
+        missing_inputs.append(f"{prefix} must include `operations` as a non-empty list")
+    else:
+        for operation_index, operation in enumerate(operations):
+            if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
+                missing_inputs.append(
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                )
+    return missing_inputs, missing_optional
+
+
 def validate_shadow_surface(
     *,
     root: Path,
@@ -2412,6 +2442,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "host_adapters": carrier_entry("missing", "unknown", "repo interop contract"),
         "repo_native_carriers": carrier_entry("missing", "unknown", "repo interop contract"),
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
+        "external_orchestrators": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2440,7 +2471,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 + ", ".join(extra_keys)
             )
 
-        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
             repo_interop_surface[key] = carrier_entry(
                 "present",
                 ".loom/companion/interop.json",
@@ -2469,6 +2500,19 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 blocking, optional = validate_repo_interop_collection_entry(
                     root=root,
                     collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
+                )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
+
+        external_orchestrators = interop_payload.get("external_orchestrators", [])
+        if not isinstance(external_orchestrators, list):
+            missing_inputs.append("repo interop contract must include `external_orchestrators` as a list")
+        else:
+            for index, entry in enumerate(external_orchestrators):
+                blocking, optional = validate_external_orchestrator_entry(
+                    root=root,
                     entry=entry,
                     index=index,
                 )
@@ -2505,7 +2549,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = (
             "repo interop contract is readable with optional locator advisories."
             if missing_optional
-            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+            else "repo interop contract is readable for host adapters, repo-native carriers, shadow parity, and external orchestrator locators."
         )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
     repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -78,6 +78,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/external-orchestrator-interop.md",
     "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
@@ -308,6 +309,22 @@ EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -1514,7 +1531,7 @@ def require_repo_interop_payload(
         payload=payload.get("contract"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
         require_locator_entry(
             failures,
             category=category,
@@ -9228,6 +9245,15 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         (target / "native" / "status").mkdir(parents=True, exist_ok=True)
         for relative, payload in {
             "host/guardian-review.json": {"verdict": "allow"},
+            "host/external-orchestrator-read.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "work_item_read",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/work-items/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9285,6 +9311,28 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "requirement": "required",
                 "fallback_to": "manual-reconciliation",
             }
+        ],
+        "external_orchestrators": [
+            {
+                "id": "fake-external-orchestrator",
+                "summary": "Read external orchestrator retained read evidence without making it a scheduler state.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/external-orchestrator-read.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-external-orchestrator",
+                "summary": "Optional external orchestrator evidence may be unavailable.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/missing-external-orchestrator.json",
+                "owner": "external-tool",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            },
         ],
         "shadow_surfaces": {
             "admission": {
@@ -9345,6 +9393,7 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                     }
                 ],
                 "repo_native_carriers": [],
+                "external_orchestrators": [],
                 "shadow_surfaces": {
                     "admission": {
                         "summary": "Compare admission parity.",
@@ -9406,10 +9455,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
         elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        elif "missing-external-orchestrator.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must stay in missing_optional"))
         if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "missing-external-orchestrator.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -9609,6 +9662,89 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             reports = rogue_payload.get("reports")
             if not isinstance(reports, list) or not reports or reports[0].get("result") != "unreadable":
                 failures.append(Failure("repo-interop", "`shadow-parity` rogue evidence sample must report `unreadable`"))
+
+    return failures
+
+
+def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Failure]:
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-interop-fixtures.json"
+    category = "external-orchestrator-interop"
+    failures: list[Failure] = []
+    if not fixture_path.exists():
+        return [Failure(category, "`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` is missing")]
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [Failure(category, f"external orchestrator fixture JSON is invalid: {exc}")]
+
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` schema_version must be `{EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA}`",
+            )
+        )
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator fixtures must include a non-empty `fixtures` list"))
+        return failures
+
+    seen_names: set[str] = set()
+    required_names = {
+        "work-item-read-present",
+        "pr-only-entry-block",
+        "truth-poisoning-block",
+        "optional-missing-warn",
+    }
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if not isinstance(name, str) or not name:
+            failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
+        else:
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+        else:
+            for field in ("id", "summary", "locator", "owner", "requirement", "fallback_to"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{name or index} entry missing `{field}`"))
+            if entry.get("owner") not in governance_surface_module.DECLARED_LOCATOR_OWNERS:
+                failures.append(Failure(category, f"{name or index} owner must stay within declared locator owners"))
+            if entry.get("requirement") not in governance_surface_module.DECLARED_LOCATOR_REQUIREMENTS:
+                failures.append(Failure(category, f"{name or index} requirement must be required/optional/advisory"))
+            surfaces = entry.get("surfaces")
+            if not isinstance(surfaces, list) or not surfaces:
+                failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
+            operations = entry.get("operations")
+            if not isinstance(operations, list) or "work_item_read" not in operations:
+                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
+        if payload is not None:
+            if not isinstance(payload, dict):
+                failures.append(Failure(category, f"{name or index} payload must be an object or null"))
+            else:
+                if payload.get("operation") != "work_item_read":
+                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
+                    failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+                if forbidden and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
+                if payload.get("entry_kind") != "work_item" and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
+                if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
+                    failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator fixtures missing required cases: " + ", ".join(missing)))
 
     return failures
 
@@ -14073,6 +14209,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
+    failures.extend(check_external_orchestrator_interop_fixture_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14101,7 +14238,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 34
+    categories_checked = 35
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-merge-ready/.loom-runtime/install-layout.json
+++ b/skills/loom-merge-ready/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/external-orchestrator-interop.md",
     "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -1,0 +1,113 @@
+# External Orchestrator Interop
+
+本文件定义外部 orchestrator 如何消费 Loom，而不把 Loom 变成 scheduler 产品。
+
+它承接 `#535` 的外部 interop 边界。完整事实链仍以
+[fact-chain-contract.md](./fact-chain-contract.md) 为准。
+
+## 1. 目标
+
+外部 orchestrator 可以做四件事：
+
+- 读取当前 `Work Item`
+- attach 已存在的 workspace 语义
+- 通过 recovery writeback 写回执行进展
+- 只读消费 status 与 gates
+
+它不得做三件事：
+
+- 创建第二状态面
+- author gate / review / status truth
+- 接管 branch、PR、git worktree 或 worker lifecycle
+
+## 2. Work Item 读取顺序
+
+外部 orchestrator 必须按同一条事实链读取：
+
+1. `init-result`
+   - 只用于 locator discovery，不承载执行真相
+2. `Work Item`
+   - 读取 `item_id`、目标、范围、执行路径、workspace / recovery / review / validation locator
+3. recovery entry
+   - 读取当前 checkpoint、停点、下一步、阻断项和最近验证摘要
+4. status control plane
+   - 只作为派生汇总和 provenance 读面
+5. host mirror / retained result
+   - 只作为绑定、镜像或 evidence 消费
+
+外部 orchestrator 不得跳过 `Work Item`，也不得从 PR、tracker、release index 或
+merge commit 反推执行入口。
+
+## 3. 非法入口
+
+以下入口必须 fail closed：
+
+- PR-only
+- tracker-only
+- release-only
+- merge-commit-only
+- 缺少 `Work Item` 最小字段
+- `Work Item` 与 host binding 无法回链到同一事项
+
+结果必须使用现有 taxonomy：
+
+- `gate_failure.missing_prerequisite_gate`
+- `gate_failure.binding_failure`
+
+回退方向只允许指向：
+
+- `work_item`
+- `admission`
+- `binding_repair`
+
+不得指向 orchestrator 私有队列、retry state、tracker state 或 scheduler action。
+
+## 4. Locator Declaration
+
+成熟既有仓库可以通过 `.loom/companion/interop.json` 的
+`external_orchestrators` 声明外部 orchestrator 读面。
+
+这些声明只定位可读 evidence / adapter surface：
+
+- `id`
+- `summary`
+- `surfaces`
+- `operations`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+`operations` 第一版至少允许：
+
+- `work_item_read`
+
+后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
+`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+
+## 5. Truth Boundary
+
+`external_orchestrators` 不得承载：
+
+- scheduler state
+- attempt ownership
+- authored progress
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- status truth
+- gate verdict
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
+pollution，并阻断 required 声明。
+
+## 6. 非目标
+
+- 不提供默认 daemon
+- 不定义 tracker polling 产品
+- 不定义自动 retry / backoff 状态机
+- 不复制任何外部 orchestrator 的私有状态模型

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/governance_surface.py
@@ -415,7 +415,7 @@ RELEASE_TARGET_DELIVERY_STATUSES = {
 }
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
-REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
+REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"}
 REPO_INTEROP_COLLECTION_SURFACES = {
     "admission",
     "pre_review",
@@ -423,6 +423,9 @@ REPO_INTEROP_COLLECTION_SURFACES = {
     "build",
     "merge_ready",
     "closeout",
+}
+EXTERNAL_ORCHESTRATOR_OPERATIONS = {
+    "work_item_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2096,6 +2099,33 @@ def validate_repo_interop_collection_entry(
     return missing_inputs, missing_optional
 
 
+def validate_external_orchestrator_entry(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    missing_inputs, missing_optional = validate_repo_interop_collection_entry(
+        root=root,
+        collection="external_orchestrators",
+        entry=entry,
+        index=index,
+    )
+    if not isinstance(entry, dict):
+        return missing_inputs, missing_optional
+    prefix = f"external_orchestrators[{index}]"
+    operations = entry.get("operations")
+    if not isinstance(operations, list) or not operations:
+        missing_inputs.append(f"{prefix} must include `operations` as a non-empty list")
+    else:
+        for operation_index, operation in enumerate(operations):
+            if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
+                missing_inputs.append(
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                )
+    return missing_inputs, missing_optional
+
+
 def validate_shadow_surface(
     *,
     root: Path,
@@ -2412,6 +2442,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "host_adapters": carrier_entry("missing", "unknown", "repo interop contract"),
         "repo_native_carriers": carrier_entry("missing", "unknown", "repo interop contract"),
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
+        "external_orchestrators": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2440,7 +2471,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 + ", ".join(extra_keys)
             )
 
-        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
             repo_interop_surface[key] = carrier_entry(
                 "present",
                 ".loom/companion/interop.json",
@@ -2469,6 +2500,19 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 blocking, optional = validate_repo_interop_collection_entry(
                     root=root,
                     collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
+                )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
+
+        external_orchestrators = interop_payload.get("external_orchestrators", [])
+        if not isinstance(external_orchestrators, list):
+            missing_inputs.append("repo interop contract must include `external_orchestrators` as a list")
+        else:
+            for index, entry in enumerate(external_orchestrators):
+                blocking, optional = validate_external_orchestrator_entry(
+                    root=root,
                     entry=entry,
                     index=index,
                 )
@@ -2505,7 +2549,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = (
             "repo interop contract is readable with optional locator advisories."
             if missing_optional
-            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+            else "repo interop contract is readable for host adapters, repo-native carriers, shadow parity, and external orchestrator locators."
         )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
     repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -78,6 +78,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/external-orchestrator-interop.md",
     "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
@@ -308,6 +309,22 @@ EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -1514,7 +1531,7 @@ def require_repo_interop_payload(
         payload=payload.get("contract"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
         require_locator_entry(
             failures,
             category=category,
@@ -9228,6 +9245,15 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         (target / "native" / "status").mkdir(parents=True, exist_ok=True)
         for relative, payload in {
             "host/guardian-review.json": {"verdict": "allow"},
+            "host/external-orchestrator-read.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "work_item_read",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/work-items/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9285,6 +9311,28 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "requirement": "required",
                 "fallback_to": "manual-reconciliation",
             }
+        ],
+        "external_orchestrators": [
+            {
+                "id": "fake-external-orchestrator",
+                "summary": "Read external orchestrator retained read evidence without making it a scheduler state.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/external-orchestrator-read.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-external-orchestrator",
+                "summary": "Optional external orchestrator evidence may be unavailable.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/missing-external-orchestrator.json",
+                "owner": "external-tool",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            },
         ],
         "shadow_surfaces": {
             "admission": {
@@ -9345,6 +9393,7 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                     }
                 ],
                 "repo_native_carriers": [],
+                "external_orchestrators": [],
                 "shadow_surfaces": {
                     "admission": {
                         "summary": "Compare admission parity.",
@@ -9406,10 +9455,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
         elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        elif "missing-external-orchestrator.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must stay in missing_optional"))
         if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "missing-external-orchestrator.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -9609,6 +9662,89 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             reports = rogue_payload.get("reports")
             if not isinstance(reports, list) or not reports or reports[0].get("result") != "unreadable":
                 failures.append(Failure("repo-interop", "`shadow-parity` rogue evidence sample must report `unreadable`"))
+
+    return failures
+
+
+def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Failure]:
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-interop-fixtures.json"
+    category = "external-orchestrator-interop"
+    failures: list[Failure] = []
+    if not fixture_path.exists():
+        return [Failure(category, "`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` is missing")]
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [Failure(category, f"external orchestrator fixture JSON is invalid: {exc}")]
+
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` schema_version must be `{EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA}`",
+            )
+        )
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator fixtures must include a non-empty `fixtures` list"))
+        return failures
+
+    seen_names: set[str] = set()
+    required_names = {
+        "work-item-read-present",
+        "pr-only-entry-block",
+        "truth-poisoning-block",
+        "optional-missing-warn",
+    }
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if not isinstance(name, str) or not name:
+            failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
+        else:
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+        else:
+            for field in ("id", "summary", "locator", "owner", "requirement", "fallback_to"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{name or index} entry missing `{field}`"))
+            if entry.get("owner") not in governance_surface_module.DECLARED_LOCATOR_OWNERS:
+                failures.append(Failure(category, f"{name or index} owner must stay within declared locator owners"))
+            if entry.get("requirement") not in governance_surface_module.DECLARED_LOCATOR_REQUIREMENTS:
+                failures.append(Failure(category, f"{name or index} requirement must be required/optional/advisory"))
+            surfaces = entry.get("surfaces")
+            if not isinstance(surfaces, list) or not surfaces:
+                failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
+            operations = entry.get("operations")
+            if not isinstance(operations, list) or "work_item_read" not in operations:
+                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
+        if payload is not None:
+            if not isinstance(payload, dict):
+                failures.append(Failure(category, f"{name or index} payload must be an object or null"))
+            else:
+                if payload.get("operation") != "work_item_read":
+                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
+                    failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+                if forbidden and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
+                if payload.get("entry_kind") != "work_item" and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
+                if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
+                    failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator fixtures missing required cases: " + ", ".join(missing)))
 
     return failures
 
@@ -14073,6 +14209,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
+    failures.extend(check_external_orchestrator_interop_fixture_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14101,7 +14238,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 34
+    categories_checked = 35
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-pre-review/.loom-runtime/install-layout.json
+++ b/skills/loom-pre-review/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/external-orchestrator-interop.md",
     "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -1,0 +1,113 @@
+# External Orchestrator Interop
+
+本文件定义外部 orchestrator 如何消费 Loom，而不把 Loom 变成 scheduler 产品。
+
+它承接 `#535` 的外部 interop 边界。完整事实链仍以
+[fact-chain-contract.md](./fact-chain-contract.md) 为准。
+
+## 1. 目标
+
+外部 orchestrator 可以做四件事：
+
+- 读取当前 `Work Item`
+- attach 已存在的 workspace 语义
+- 通过 recovery writeback 写回执行进展
+- 只读消费 status 与 gates
+
+它不得做三件事：
+
+- 创建第二状态面
+- author gate / review / status truth
+- 接管 branch、PR、git worktree 或 worker lifecycle
+
+## 2. Work Item 读取顺序
+
+外部 orchestrator 必须按同一条事实链读取：
+
+1. `init-result`
+   - 只用于 locator discovery，不承载执行真相
+2. `Work Item`
+   - 读取 `item_id`、目标、范围、执行路径、workspace / recovery / review / validation locator
+3. recovery entry
+   - 读取当前 checkpoint、停点、下一步、阻断项和最近验证摘要
+4. status control plane
+   - 只作为派生汇总和 provenance 读面
+5. host mirror / retained result
+   - 只作为绑定、镜像或 evidence 消费
+
+外部 orchestrator 不得跳过 `Work Item`，也不得从 PR、tracker、release index 或
+merge commit 反推执行入口。
+
+## 3. 非法入口
+
+以下入口必须 fail closed：
+
+- PR-only
+- tracker-only
+- release-only
+- merge-commit-only
+- 缺少 `Work Item` 最小字段
+- `Work Item` 与 host binding 无法回链到同一事项
+
+结果必须使用现有 taxonomy：
+
+- `gate_failure.missing_prerequisite_gate`
+- `gate_failure.binding_failure`
+
+回退方向只允许指向：
+
+- `work_item`
+- `admission`
+- `binding_repair`
+
+不得指向 orchestrator 私有队列、retry state、tracker state 或 scheduler action。
+
+## 4. Locator Declaration
+
+成熟既有仓库可以通过 `.loom/companion/interop.json` 的
+`external_orchestrators` 声明外部 orchestrator 读面。
+
+这些声明只定位可读 evidence / adapter surface：
+
+- `id`
+- `summary`
+- `surfaces`
+- `operations`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+`operations` 第一版至少允许：
+
+- `work_item_read`
+
+后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
+`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+
+## 5. Truth Boundary
+
+`external_orchestrators` 不得承载：
+
+- scheduler state
+- attempt ownership
+- authored progress
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- status truth
+- gate verdict
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
+pollution，并阻断 required 声明。
+
+## 6. 非目标
+
+- 不提供默认 daemon
+- 不定义 tracker polling 产品
+- 不定义自动 retry / backoff 状态机
+- 不复制任何外部 orchestrator 的私有状态模型

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -415,7 +415,7 @@ RELEASE_TARGET_DELIVERY_STATUSES = {
 }
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
-REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
+REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"}
 REPO_INTEROP_COLLECTION_SURFACES = {
     "admission",
     "pre_review",
@@ -423,6 +423,9 @@ REPO_INTEROP_COLLECTION_SURFACES = {
     "build",
     "merge_ready",
     "closeout",
+}
+EXTERNAL_ORCHESTRATOR_OPERATIONS = {
+    "work_item_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2096,6 +2099,33 @@ def validate_repo_interop_collection_entry(
     return missing_inputs, missing_optional
 
 
+def validate_external_orchestrator_entry(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    missing_inputs, missing_optional = validate_repo_interop_collection_entry(
+        root=root,
+        collection="external_orchestrators",
+        entry=entry,
+        index=index,
+    )
+    if not isinstance(entry, dict):
+        return missing_inputs, missing_optional
+    prefix = f"external_orchestrators[{index}]"
+    operations = entry.get("operations")
+    if not isinstance(operations, list) or not operations:
+        missing_inputs.append(f"{prefix} must include `operations` as a non-empty list")
+    else:
+        for operation_index, operation in enumerate(operations):
+            if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
+                missing_inputs.append(
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                )
+    return missing_inputs, missing_optional
+
+
 def validate_shadow_surface(
     *,
     root: Path,
@@ -2412,6 +2442,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "host_adapters": carrier_entry("missing", "unknown", "repo interop contract"),
         "repo_native_carriers": carrier_entry("missing", "unknown", "repo interop contract"),
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
+        "external_orchestrators": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2440,7 +2471,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 + ", ".join(extra_keys)
             )
 
-        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
             repo_interop_surface[key] = carrier_entry(
                 "present",
                 ".loom/companion/interop.json",
@@ -2469,6 +2500,19 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 blocking, optional = validate_repo_interop_collection_entry(
                     root=root,
                     collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
+                )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
+
+        external_orchestrators = interop_payload.get("external_orchestrators", [])
+        if not isinstance(external_orchestrators, list):
+            missing_inputs.append("repo interop contract must include `external_orchestrators` as a list")
+        else:
+            for index, entry in enumerate(external_orchestrators):
+                blocking, optional = validate_external_orchestrator_entry(
+                    root=root,
                     entry=entry,
                     index=index,
                 )
@@ -2505,7 +2549,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = (
             "repo interop contract is readable with optional locator advisories."
             if missing_optional
-            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+            else "repo interop contract is readable for host adapters, repo-native carriers, shadow parity, and external orchestrator locators."
         )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
     repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -78,6 +78,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/external-orchestrator-interop.md",
     "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
@@ -308,6 +309,22 @@ EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -1514,7 +1531,7 @@ def require_repo_interop_payload(
         payload=payload.get("contract"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
         require_locator_entry(
             failures,
             category=category,
@@ -9228,6 +9245,15 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         (target / "native" / "status").mkdir(parents=True, exist_ok=True)
         for relative, payload in {
             "host/guardian-review.json": {"verdict": "allow"},
+            "host/external-orchestrator-read.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "work_item_read",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/work-items/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9285,6 +9311,28 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "requirement": "required",
                 "fallback_to": "manual-reconciliation",
             }
+        ],
+        "external_orchestrators": [
+            {
+                "id": "fake-external-orchestrator",
+                "summary": "Read external orchestrator retained read evidence without making it a scheduler state.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/external-orchestrator-read.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-external-orchestrator",
+                "summary": "Optional external orchestrator evidence may be unavailable.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/missing-external-orchestrator.json",
+                "owner": "external-tool",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            },
         ],
         "shadow_surfaces": {
             "admission": {
@@ -9345,6 +9393,7 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                     }
                 ],
                 "repo_native_carriers": [],
+                "external_orchestrators": [],
                 "shadow_surfaces": {
                     "admission": {
                         "summary": "Compare admission parity.",
@@ -9406,10 +9455,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
         elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        elif "missing-external-orchestrator.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must stay in missing_optional"))
         if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "missing-external-orchestrator.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -9609,6 +9662,89 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             reports = rogue_payload.get("reports")
             if not isinstance(reports, list) or not reports or reports[0].get("result") != "unreadable":
                 failures.append(Failure("repo-interop", "`shadow-parity` rogue evidence sample must report `unreadable`"))
+
+    return failures
+
+
+def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Failure]:
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-interop-fixtures.json"
+    category = "external-orchestrator-interop"
+    failures: list[Failure] = []
+    if not fixture_path.exists():
+        return [Failure(category, "`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` is missing")]
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [Failure(category, f"external orchestrator fixture JSON is invalid: {exc}")]
+
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` schema_version must be `{EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA}`",
+            )
+        )
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator fixtures must include a non-empty `fixtures` list"))
+        return failures
+
+    seen_names: set[str] = set()
+    required_names = {
+        "work-item-read-present",
+        "pr-only-entry-block",
+        "truth-poisoning-block",
+        "optional-missing-warn",
+    }
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if not isinstance(name, str) or not name:
+            failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
+        else:
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+        else:
+            for field in ("id", "summary", "locator", "owner", "requirement", "fallback_to"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{name or index} entry missing `{field}`"))
+            if entry.get("owner") not in governance_surface_module.DECLARED_LOCATOR_OWNERS:
+                failures.append(Failure(category, f"{name or index} owner must stay within declared locator owners"))
+            if entry.get("requirement") not in governance_surface_module.DECLARED_LOCATOR_REQUIREMENTS:
+                failures.append(Failure(category, f"{name or index} requirement must be required/optional/advisory"))
+            surfaces = entry.get("surfaces")
+            if not isinstance(surfaces, list) or not surfaces:
+                failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
+            operations = entry.get("operations")
+            if not isinstance(operations, list) or "work_item_read" not in operations:
+                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
+        if payload is not None:
+            if not isinstance(payload, dict):
+                failures.append(Failure(category, f"{name or index} payload must be an object or null"))
+            else:
+                if payload.get("operation") != "work_item_read":
+                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
+                    failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+                if forbidden and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
+                if payload.get("entry_kind") != "work_item" and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
+                if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
+                    failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator fixtures missing required cases: " + ", ".join(missing)))
 
     return failures
 
@@ -14073,6 +14209,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
+    failures.extend(check_external_orchestrator_interop_fixture_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14101,7 +14238,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 34
+    categories_checked = 35
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-resume/.loom-runtime/install-layout.json
+++ b/skills/loom-resume/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/external-orchestrator-interop.md",
     "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -1,0 +1,113 @@
+# External Orchestrator Interop
+
+本文件定义外部 orchestrator 如何消费 Loom，而不把 Loom 变成 scheduler 产品。
+
+它承接 `#535` 的外部 interop 边界。完整事实链仍以
+[fact-chain-contract.md](./fact-chain-contract.md) 为准。
+
+## 1. 目标
+
+外部 orchestrator 可以做四件事：
+
+- 读取当前 `Work Item`
+- attach 已存在的 workspace 语义
+- 通过 recovery writeback 写回执行进展
+- 只读消费 status 与 gates
+
+它不得做三件事：
+
+- 创建第二状态面
+- author gate / review / status truth
+- 接管 branch、PR、git worktree 或 worker lifecycle
+
+## 2. Work Item 读取顺序
+
+外部 orchestrator 必须按同一条事实链读取：
+
+1. `init-result`
+   - 只用于 locator discovery，不承载执行真相
+2. `Work Item`
+   - 读取 `item_id`、目标、范围、执行路径、workspace / recovery / review / validation locator
+3. recovery entry
+   - 读取当前 checkpoint、停点、下一步、阻断项和最近验证摘要
+4. status control plane
+   - 只作为派生汇总和 provenance 读面
+5. host mirror / retained result
+   - 只作为绑定、镜像或 evidence 消费
+
+外部 orchestrator 不得跳过 `Work Item`，也不得从 PR、tracker、release index 或
+merge commit 反推执行入口。
+
+## 3. 非法入口
+
+以下入口必须 fail closed：
+
+- PR-only
+- tracker-only
+- release-only
+- merge-commit-only
+- 缺少 `Work Item` 最小字段
+- `Work Item` 与 host binding 无法回链到同一事项
+
+结果必须使用现有 taxonomy：
+
+- `gate_failure.missing_prerequisite_gate`
+- `gate_failure.binding_failure`
+
+回退方向只允许指向：
+
+- `work_item`
+- `admission`
+- `binding_repair`
+
+不得指向 orchestrator 私有队列、retry state、tracker state 或 scheduler action。
+
+## 4. Locator Declaration
+
+成熟既有仓库可以通过 `.loom/companion/interop.json` 的
+`external_orchestrators` 声明外部 orchestrator 读面。
+
+这些声明只定位可读 evidence / adapter surface：
+
+- `id`
+- `summary`
+- `surfaces`
+- `operations`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+`operations` 第一版至少允许：
+
+- `work_item_read`
+
+后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
+`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+
+## 5. Truth Boundary
+
+`external_orchestrators` 不得承载：
+
+- scheduler state
+- attempt ownership
+- authored progress
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- status truth
+- gate verdict
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
+pollution，并阻断 required 声明。
+
+## 6. 非目标
+
+- 不提供默认 daemon
+- 不定义 tracker polling 产品
+- 不定义自动 retry / backoff 状态机
+- 不复制任何外部 orchestrator 的私有状态模型

--- a/skills/loom-resume/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/governance_surface.py
@@ -415,7 +415,7 @@ RELEASE_TARGET_DELIVERY_STATUSES = {
 }
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
-REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
+REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"}
 REPO_INTEROP_COLLECTION_SURFACES = {
     "admission",
     "pre_review",
@@ -423,6 +423,9 @@ REPO_INTEROP_COLLECTION_SURFACES = {
     "build",
     "merge_ready",
     "closeout",
+}
+EXTERNAL_ORCHESTRATOR_OPERATIONS = {
+    "work_item_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2096,6 +2099,33 @@ def validate_repo_interop_collection_entry(
     return missing_inputs, missing_optional
 
 
+def validate_external_orchestrator_entry(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    missing_inputs, missing_optional = validate_repo_interop_collection_entry(
+        root=root,
+        collection="external_orchestrators",
+        entry=entry,
+        index=index,
+    )
+    if not isinstance(entry, dict):
+        return missing_inputs, missing_optional
+    prefix = f"external_orchestrators[{index}]"
+    operations = entry.get("operations")
+    if not isinstance(operations, list) or not operations:
+        missing_inputs.append(f"{prefix} must include `operations` as a non-empty list")
+    else:
+        for operation_index, operation in enumerate(operations):
+            if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
+                missing_inputs.append(
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                )
+    return missing_inputs, missing_optional
+
+
 def validate_shadow_surface(
     *,
     root: Path,
@@ -2412,6 +2442,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "host_adapters": carrier_entry("missing", "unknown", "repo interop contract"),
         "repo_native_carriers": carrier_entry("missing", "unknown", "repo interop contract"),
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
+        "external_orchestrators": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2440,7 +2471,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 + ", ".join(extra_keys)
             )
 
-        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
             repo_interop_surface[key] = carrier_entry(
                 "present",
                 ".loom/companion/interop.json",
@@ -2469,6 +2500,19 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 blocking, optional = validate_repo_interop_collection_entry(
                     root=root,
                     collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
+                )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
+
+        external_orchestrators = interop_payload.get("external_orchestrators", [])
+        if not isinstance(external_orchestrators, list):
+            missing_inputs.append("repo interop contract must include `external_orchestrators` as a list")
+        else:
+            for index, entry in enumerate(external_orchestrators):
+                blocking, optional = validate_external_orchestrator_entry(
+                    root=root,
                     entry=entry,
                     index=index,
                 )
@@ -2505,7 +2549,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = (
             "repo interop contract is readable with optional locator advisories."
             if missing_optional
-            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+            else "repo interop contract is readable for host adapters, repo-native carriers, shadow parity, and external orchestrator locators."
         )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
     repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -78,6 +78,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/external-orchestrator-interop.md",
     "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
@@ -308,6 +309,22 @@ EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -1514,7 +1531,7 @@ def require_repo_interop_payload(
         payload=payload.get("contract"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
         require_locator_entry(
             failures,
             category=category,
@@ -9228,6 +9245,15 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         (target / "native" / "status").mkdir(parents=True, exist_ok=True)
         for relative, payload in {
             "host/guardian-review.json": {"verdict": "allow"},
+            "host/external-orchestrator-read.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "work_item_read",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/work-items/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9285,6 +9311,28 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "requirement": "required",
                 "fallback_to": "manual-reconciliation",
             }
+        ],
+        "external_orchestrators": [
+            {
+                "id": "fake-external-orchestrator",
+                "summary": "Read external orchestrator retained read evidence without making it a scheduler state.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/external-orchestrator-read.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-external-orchestrator",
+                "summary": "Optional external orchestrator evidence may be unavailable.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/missing-external-orchestrator.json",
+                "owner": "external-tool",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            },
         ],
         "shadow_surfaces": {
             "admission": {
@@ -9345,6 +9393,7 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                     }
                 ],
                 "repo_native_carriers": [],
+                "external_orchestrators": [],
                 "shadow_surfaces": {
                     "admission": {
                         "summary": "Compare admission parity.",
@@ -9406,10 +9455,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
         elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        elif "missing-external-orchestrator.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must stay in missing_optional"))
         if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "missing-external-orchestrator.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -9609,6 +9662,89 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             reports = rogue_payload.get("reports")
             if not isinstance(reports, list) or not reports or reports[0].get("result") != "unreadable":
                 failures.append(Failure("repo-interop", "`shadow-parity` rogue evidence sample must report `unreadable`"))
+
+    return failures
+
+
+def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Failure]:
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-interop-fixtures.json"
+    category = "external-orchestrator-interop"
+    failures: list[Failure] = []
+    if not fixture_path.exists():
+        return [Failure(category, "`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` is missing")]
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [Failure(category, f"external orchestrator fixture JSON is invalid: {exc}")]
+
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` schema_version must be `{EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA}`",
+            )
+        )
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator fixtures must include a non-empty `fixtures` list"))
+        return failures
+
+    seen_names: set[str] = set()
+    required_names = {
+        "work-item-read-present",
+        "pr-only-entry-block",
+        "truth-poisoning-block",
+        "optional-missing-warn",
+    }
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if not isinstance(name, str) or not name:
+            failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
+        else:
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+        else:
+            for field in ("id", "summary", "locator", "owner", "requirement", "fallback_to"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{name or index} entry missing `{field}`"))
+            if entry.get("owner") not in governance_surface_module.DECLARED_LOCATOR_OWNERS:
+                failures.append(Failure(category, f"{name or index} owner must stay within declared locator owners"))
+            if entry.get("requirement") not in governance_surface_module.DECLARED_LOCATOR_REQUIREMENTS:
+                failures.append(Failure(category, f"{name or index} requirement must be required/optional/advisory"))
+            surfaces = entry.get("surfaces")
+            if not isinstance(surfaces, list) or not surfaces:
+                failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
+            operations = entry.get("operations")
+            if not isinstance(operations, list) or "work_item_read" not in operations:
+                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
+        if payload is not None:
+            if not isinstance(payload, dict):
+                failures.append(Failure(category, f"{name or index} payload must be an object or null"))
+            else:
+                if payload.get("operation") != "work_item_read":
+                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
+                    failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+                if forbidden and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
+                if payload.get("entry_kind") != "work_item" and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
+                if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
+                    failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator fixtures missing required cases: " + ", ".join(missing)))
 
     return failures
 
@@ -14073,6 +14209,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
+    failures.extend(check_external_orchestrator_interop_fixture_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14101,7 +14238,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 34
+    categories_checked = 35
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-retire/.loom-runtime/install-layout.json
+++ b/skills/loom-retire/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/external-orchestrator-interop.md",
     "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -1,0 +1,113 @@
+# External Orchestrator Interop
+
+本文件定义外部 orchestrator 如何消费 Loom，而不把 Loom 变成 scheduler 产品。
+
+它承接 `#535` 的外部 interop 边界。完整事实链仍以
+[fact-chain-contract.md](./fact-chain-contract.md) 为准。
+
+## 1. 目标
+
+外部 orchestrator 可以做四件事：
+
+- 读取当前 `Work Item`
+- attach 已存在的 workspace 语义
+- 通过 recovery writeback 写回执行进展
+- 只读消费 status 与 gates
+
+它不得做三件事：
+
+- 创建第二状态面
+- author gate / review / status truth
+- 接管 branch、PR、git worktree 或 worker lifecycle
+
+## 2. Work Item 读取顺序
+
+外部 orchestrator 必须按同一条事实链读取：
+
+1. `init-result`
+   - 只用于 locator discovery，不承载执行真相
+2. `Work Item`
+   - 读取 `item_id`、目标、范围、执行路径、workspace / recovery / review / validation locator
+3. recovery entry
+   - 读取当前 checkpoint、停点、下一步、阻断项和最近验证摘要
+4. status control plane
+   - 只作为派生汇总和 provenance 读面
+5. host mirror / retained result
+   - 只作为绑定、镜像或 evidence 消费
+
+外部 orchestrator 不得跳过 `Work Item`，也不得从 PR、tracker、release index 或
+merge commit 反推执行入口。
+
+## 3. 非法入口
+
+以下入口必须 fail closed：
+
+- PR-only
+- tracker-only
+- release-only
+- merge-commit-only
+- 缺少 `Work Item` 最小字段
+- `Work Item` 与 host binding 无法回链到同一事项
+
+结果必须使用现有 taxonomy：
+
+- `gate_failure.missing_prerequisite_gate`
+- `gate_failure.binding_failure`
+
+回退方向只允许指向：
+
+- `work_item`
+- `admission`
+- `binding_repair`
+
+不得指向 orchestrator 私有队列、retry state、tracker state 或 scheduler action。
+
+## 4. Locator Declaration
+
+成熟既有仓库可以通过 `.loom/companion/interop.json` 的
+`external_orchestrators` 声明外部 orchestrator 读面。
+
+这些声明只定位可读 evidence / adapter surface：
+
+- `id`
+- `summary`
+- `surfaces`
+- `operations`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+`operations` 第一版至少允许：
+
+- `work_item_read`
+
+后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
+`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+
+## 5. Truth Boundary
+
+`external_orchestrators` 不得承载：
+
+- scheduler state
+- attempt ownership
+- authored progress
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- status truth
+- gate verdict
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
+pollution，并阻断 required 声明。
+
+## 6. 非目标
+
+- 不提供默认 daemon
+- 不定义 tracker polling 产品
+- 不定义自动 retry / backoff 状态机
+- 不复制任何外部 orchestrator 的私有状态模型

--- a/skills/loom-retire/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/governance_surface.py
@@ -415,7 +415,7 @@ RELEASE_TARGET_DELIVERY_STATUSES = {
 }
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
-REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
+REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"}
 REPO_INTEROP_COLLECTION_SURFACES = {
     "admission",
     "pre_review",
@@ -423,6 +423,9 @@ REPO_INTEROP_COLLECTION_SURFACES = {
     "build",
     "merge_ready",
     "closeout",
+}
+EXTERNAL_ORCHESTRATOR_OPERATIONS = {
+    "work_item_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2096,6 +2099,33 @@ def validate_repo_interop_collection_entry(
     return missing_inputs, missing_optional
 
 
+def validate_external_orchestrator_entry(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    missing_inputs, missing_optional = validate_repo_interop_collection_entry(
+        root=root,
+        collection="external_orchestrators",
+        entry=entry,
+        index=index,
+    )
+    if not isinstance(entry, dict):
+        return missing_inputs, missing_optional
+    prefix = f"external_orchestrators[{index}]"
+    operations = entry.get("operations")
+    if not isinstance(operations, list) or not operations:
+        missing_inputs.append(f"{prefix} must include `operations` as a non-empty list")
+    else:
+        for operation_index, operation in enumerate(operations):
+            if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
+                missing_inputs.append(
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                )
+    return missing_inputs, missing_optional
+
+
 def validate_shadow_surface(
     *,
     root: Path,
@@ -2412,6 +2442,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "host_adapters": carrier_entry("missing", "unknown", "repo interop contract"),
         "repo_native_carriers": carrier_entry("missing", "unknown", "repo interop contract"),
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
+        "external_orchestrators": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2440,7 +2471,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 + ", ".join(extra_keys)
             )
 
-        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
             repo_interop_surface[key] = carrier_entry(
                 "present",
                 ".loom/companion/interop.json",
@@ -2469,6 +2500,19 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 blocking, optional = validate_repo_interop_collection_entry(
                     root=root,
                     collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
+                )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
+
+        external_orchestrators = interop_payload.get("external_orchestrators", [])
+        if not isinstance(external_orchestrators, list):
+            missing_inputs.append("repo interop contract must include `external_orchestrators` as a list")
+        else:
+            for index, entry in enumerate(external_orchestrators):
+                blocking, optional = validate_external_orchestrator_entry(
+                    root=root,
                     entry=entry,
                     index=index,
                 )
@@ -2505,7 +2549,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = (
             "repo interop contract is readable with optional locator advisories."
             if missing_optional
-            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+            else "repo interop contract is readable for host adapters, repo-native carriers, shadow parity, and external orchestrator locators."
         )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
     repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -78,6 +78,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/external-orchestrator-interop.md",
     "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
@@ -308,6 +309,22 @@ EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -1514,7 +1531,7 @@ def require_repo_interop_payload(
         payload=payload.get("contract"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
         require_locator_entry(
             failures,
             category=category,
@@ -9228,6 +9245,15 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         (target / "native" / "status").mkdir(parents=True, exist_ok=True)
         for relative, payload in {
             "host/guardian-review.json": {"verdict": "allow"},
+            "host/external-orchestrator-read.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "work_item_read",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/work-items/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9285,6 +9311,28 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "requirement": "required",
                 "fallback_to": "manual-reconciliation",
             }
+        ],
+        "external_orchestrators": [
+            {
+                "id": "fake-external-orchestrator",
+                "summary": "Read external orchestrator retained read evidence without making it a scheduler state.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/external-orchestrator-read.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-external-orchestrator",
+                "summary": "Optional external orchestrator evidence may be unavailable.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/missing-external-orchestrator.json",
+                "owner": "external-tool",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            },
         ],
         "shadow_surfaces": {
             "admission": {
@@ -9345,6 +9393,7 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                     }
                 ],
                 "repo_native_carriers": [],
+                "external_orchestrators": [],
                 "shadow_surfaces": {
                     "admission": {
                         "summary": "Compare admission parity.",
@@ -9406,10 +9455,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
         elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        elif "missing-external-orchestrator.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must stay in missing_optional"))
         if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "missing-external-orchestrator.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -9609,6 +9662,89 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             reports = rogue_payload.get("reports")
             if not isinstance(reports, list) or not reports or reports[0].get("result") != "unreadable":
                 failures.append(Failure("repo-interop", "`shadow-parity` rogue evidence sample must report `unreadable`"))
+
+    return failures
+
+
+def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Failure]:
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-interop-fixtures.json"
+    category = "external-orchestrator-interop"
+    failures: list[Failure] = []
+    if not fixture_path.exists():
+        return [Failure(category, "`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` is missing")]
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [Failure(category, f"external orchestrator fixture JSON is invalid: {exc}")]
+
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` schema_version must be `{EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA}`",
+            )
+        )
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator fixtures must include a non-empty `fixtures` list"))
+        return failures
+
+    seen_names: set[str] = set()
+    required_names = {
+        "work-item-read-present",
+        "pr-only-entry-block",
+        "truth-poisoning-block",
+        "optional-missing-warn",
+    }
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if not isinstance(name, str) or not name:
+            failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
+        else:
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+        else:
+            for field in ("id", "summary", "locator", "owner", "requirement", "fallback_to"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{name or index} entry missing `{field}`"))
+            if entry.get("owner") not in governance_surface_module.DECLARED_LOCATOR_OWNERS:
+                failures.append(Failure(category, f"{name or index} owner must stay within declared locator owners"))
+            if entry.get("requirement") not in governance_surface_module.DECLARED_LOCATOR_REQUIREMENTS:
+                failures.append(Failure(category, f"{name or index} requirement must be required/optional/advisory"))
+            surfaces = entry.get("surfaces")
+            if not isinstance(surfaces, list) or not surfaces:
+                failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
+            operations = entry.get("operations")
+            if not isinstance(operations, list) or "work_item_read" not in operations:
+                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
+        if payload is not None:
+            if not isinstance(payload, dict):
+                failures.append(Failure(category, f"{name or index} payload must be an object or null"))
+            else:
+                if payload.get("operation") != "work_item_read":
+                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
+                    failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+                if forbidden and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
+                if payload.get("entry_kind") != "work_item" and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
+                if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
+                    failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator fixtures missing required cases: " + ", ".join(missing)))
 
     return failures
 
@@ -14073,6 +14209,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
+    failures.extend(check_external_orchestrator_interop_fixture_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14101,7 +14238,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 34
+    categories_checked = 35
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-review/.loom-runtime/install-layout.json
+++ b/skills/loom-review/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/external-orchestrator-interop.md",
     "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",

--- a/skills/loom-review/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -1,0 +1,113 @@
+# External Orchestrator Interop
+
+本文件定义外部 orchestrator 如何消费 Loom，而不把 Loom 变成 scheduler 产品。
+
+它承接 `#535` 的外部 interop 边界。完整事实链仍以
+[fact-chain-contract.md](./fact-chain-contract.md) 为准。
+
+## 1. 目标
+
+外部 orchestrator 可以做四件事：
+
+- 读取当前 `Work Item`
+- attach 已存在的 workspace 语义
+- 通过 recovery writeback 写回执行进展
+- 只读消费 status 与 gates
+
+它不得做三件事：
+
+- 创建第二状态面
+- author gate / review / status truth
+- 接管 branch、PR、git worktree 或 worker lifecycle
+
+## 2. Work Item 读取顺序
+
+外部 orchestrator 必须按同一条事实链读取：
+
+1. `init-result`
+   - 只用于 locator discovery，不承载执行真相
+2. `Work Item`
+   - 读取 `item_id`、目标、范围、执行路径、workspace / recovery / review / validation locator
+3. recovery entry
+   - 读取当前 checkpoint、停点、下一步、阻断项和最近验证摘要
+4. status control plane
+   - 只作为派生汇总和 provenance 读面
+5. host mirror / retained result
+   - 只作为绑定、镜像或 evidence 消费
+
+外部 orchestrator 不得跳过 `Work Item`，也不得从 PR、tracker、release index 或
+merge commit 反推执行入口。
+
+## 3. 非法入口
+
+以下入口必须 fail closed：
+
+- PR-only
+- tracker-only
+- release-only
+- merge-commit-only
+- 缺少 `Work Item` 最小字段
+- `Work Item` 与 host binding 无法回链到同一事项
+
+结果必须使用现有 taxonomy：
+
+- `gate_failure.missing_prerequisite_gate`
+- `gate_failure.binding_failure`
+
+回退方向只允许指向：
+
+- `work_item`
+- `admission`
+- `binding_repair`
+
+不得指向 orchestrator 私有队列、retry state、tracker state 或 scheduler action。
+
+## 4. Locator Declaration
+
+成熟既有仓库可以通过 `.loom/companion/interop.json` 的
+`external_orchestrators` 声明外部 orchestrator 读面。
+
+这些声明只定位可读 evidence / adapter surface：
+
+- `id`
+- `summary`
+- `surfaces`
+- `operations`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+`operations` 第一版至少允许：
+
+- `work_item_read`
+
+后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
+`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+
+## 5. Truth Boundary
+
+`external_orchestrators` 不得承载：
+
+- scheduler state
+- attempt ownership
+- authored progress
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- status truth
+- gate verdict
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
+pollution，并阻断 required 声明。
+
+## 6. 非目标
+
+- 不提供默认 daemon
+- 不定义 tracker polling 产品
+- 不定义自动 retry / backoff 状态机
+- 不复制任何外部 orchestrator 的私有状态模型

--- a/skills/loom-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -415,7 +415,7 @@ RELEASE_TARGET_DELIVERY_STATUSES = {
 }
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
-REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
+REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"}
 REPO_INTEROP_COLLECTION_SURFACES = {
     "admission",
     "pre_review",
@@ -423,6 +423,9 @@ REPO_INTEROP_COLLECTION_SURFACES = {
     "build",
     "merge_ready",
     "closeout",
+}
+EXTERNAL_ORCHESTRATOR_OPERATIONS = {
+    "work_item_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2096,6 +2099,33 @@ def validate_repo_interop_collection_entry(
     return missing_inputs, missing_optional
 
 
+def validate_external_orchestrator_entry(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    missing_inputs, missing_optional = validate_repo_interop_collection_entry(
+        root=root,
+        collection="external_orchestrators",
+        entry=entry,
+        index=index,
+    )
+    if not isinstance(entry, dict):
+        return missing_inputs, missing_optional
+    prefix = f"external_orchestrators[{index}]"
+    operations = entry.get("operations")
+    if not isinstance(operations, list) or not operations:
+        missing_inputs.append(f"{prefix} must include `operations` as a non-empty list")
+    else:
+        for operation_index, operation in enumerate(operations):
+            if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
+                missing_inputs.append(
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                )
+    return missing_inputs, missing_optional
+
+
 def validate_shadow_surface(
     *,
     root: Path,
@@ -2412,6 +2442,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "host_adapters": carrier_entry("missing", "unknown", "repo interop contract"),
         "repo_native_carriers": carrier_entry("missing", "unknown", "repo interop contract"),
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
+        "external_orchestrators": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2440,7 +2471,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 + ", ".join(extra_keys)
             )
 
-        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
             repo_interop_surface[key] = carrier_entry(
                 "present",
                 ".loom/companion/interop.json",
@@ -2469,6 +2500,19 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 blocking, optional = validate_repo_interop_collection_entry(
                     root=root,
                     collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
+                )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
+
+        external_orchestrators = interop_payload.get("external_orchestrators", [])
+        if not isinstance(external_orchestrators, list):
+            missing_inputs.append("repo interop contract must include `external_orchestrators` as a list")
+        else:
+            for index, entry in enumerate(external_orchestrators):
+                blocking, optional = validate_external_orchestrator_entry(
+                    root=root,
                     entry=entry,
                     index=index,
                 )
@@ -2505,7 +2549,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = (
             "repo interop contract is readable with optional locator advisories."
             if missing_optional
-            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+            else "repo interop contract is readable for host adapters, repo-native carriers, shadow parity, and external orchestrator locators."
         )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
     repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -78,6 +78,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/external-orchestrator-interop.md",
     "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
@@ -308,6 +309,22 @@ EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -1514,7 +1531,7 @@ def require_repo_interop_payload(
         payload=payload.get("contract"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
         require_locator_entry(
             failures,
             category=category,
@@ -9228,6 +9245,15 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         (target / "native" / "status").mkdir(parents=True, exist_ok=True)
         for relative, payload in {
             "host/guardian-review.json": {"verdict": "allow"},
+            "host/external-orchestrator-read.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "work_item_read",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/work-items/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9285,6 +9311,28 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "requirement": "required",
                 "fallback_to": "manual-reconciliation",
             }
+        ],
+        "external_orchestrators": [
+            {
+                "id": "fake-external-orchestrator",
+                "summary": "Read external orchestrator retained read evidence without making it a scheduler state.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/external-orchestrator-read.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-external-orchestrator",
+                "summary": "Optional external orchestrator evidence may be unavailable.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/missing-external-orchestrator.json",
+                "owner": "external-tool",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            },
         ],
         "shadow_surfaces": {
             "admission": {
@@ -9345,6 +9393,7 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                     }
                 ],
                 "repo_native_carriers": [],
+                "external_orchestrators": [],
                 "shadow_surfaces": {
                     "admission": {
                         "summary": "Compare admission parity.",
@@ -9406,10 +9455,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
         elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        elif "missing-external-orchestrator.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must stay in missing_optional"))
         if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "missing-external-orchestrator.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -9609,6 +9662,89 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             reports = rogue_payload.get("reports")
             if not isinstance(reports, list) or not reports or reports[0].get("result") != "unreadable":
                 failures.append(Failure("repo-interop", "`shadow-parity` rogue evidence sample must report `unreadable`"))
+
+    return failures
+
+
+def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Failure]:
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-interop-fixtures.json"
+    category = "external-orchestrator-interop"
+    failures: list[Failure] = []
+    if not fixture_path.exists():
+        return [Failure(category, "`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` is missing")]
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [Failure(category, f"external orchestrator fixture JSON is invalid: {exc}")]
+
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` schema_version must be `{EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA}`",
+            )
+        )
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator fixtures must include a non-empty `fixtures` list"))
+        return failures
+
+    seen_names: set[str] = set()
+    required_names = {
+        "work-item-read-present",
+        "pr-only-entry-block",
+        "truth-poisoning-block",
+        "optional-missing-warn",
+    }
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if not isinstance(name, str) or not name:
+            failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
+        else:
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+        else:
+            for field in ("id", "summary", "locator", "owner", "requirement", "fallback_to"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{name or index} entry missing `{field}`"))
+            if entry.get("owner") not in governance_surface_module.DECLARED_LOCATOR_OWNERS:
+                failures.append(Failure(category, f"{name or index} owner must stay within declared locator owners"))
+            if entry.get("requirement") not in governance_surface_module.DECLARED_LOCATOR_REQUIREMENTS:
+                failures.append(Failure(category, f"{name or index} requirement must be required/optional/advisory"))
+            surfaces = entry.get("surfaces")
+            if not isinstance(surfaces, list) or not surfaces:
+                failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
+            operations = entry.get("operations")
+            if not isinstance(operations, list) or "work_item_read" not in operations:
+                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
+        if payload is not None:
+            if not isinstance(payload, dict):
+                failures.append(Failure(category, f"{name or index} payload must be an object or null"))
+            else:
+                if payload.get("operation") != "work_item_read":
+                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
+                    failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+                if forbidden and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
+                if payload.get("entry_kind") != "work_item" and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
+                if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
+                    failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator fixtures missing required cases: " + ", ".join(missing)))
 
     return failures
 
@@ -14073,6 +14209,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
+    failures.extend(check_external_orchestrator_interop_fixture_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14101,7 +14238,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 34
+    categories_checked = 35
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-spec-review/.loom-runtime/install-layout.json
+++ b/skills/loom-spec-review/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/external-orchestrator-interop.md",
     "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -1,0 +1,113 @@
+# External Orchestrator Interop
+
+本文件定义外部 orchestrator 如何消费 Loom，而不把 Loom 变成 scheduler 产品。
+
+它承接 `#535` 的外部 interop 边界。完整事实链仍以
+[fact-chain-contract.md](./fact-chain-contract.md) 为准。
+
+## 1. 目标
+
+外部 orchestrator 可以做四件事：
+
+- 读取当前 `Work Item`
+- attach 已存在的 workspace 语义
+- 通过 recovery writeback 写回执行进展
+- 只读消费 status 与 gates
+
+它不得做三件事：
+
+- 创建第二状态面
+- author gate / review / status truth
+- 接管 branch、PR、git worktree 或 worker lifecycle
+
+## 2. Work Item 读取顺序
+
+外部 orchestrator 必须按同一条事实链读取：
+
+1. `init-result`
+   - 只用于 locator discovery，不承载执行真相
+2. `Work Item`
+   - 读取 `item_id`、目标、范围、执行路径、workspace / recovery / review / validation locator
+3. recovery entry
+   - 读取当前 checkpoint、停点、下一步、阻断项和最近验证摘要
+4. status control plane
+   - 只作为派生汇总和 provenance 读面
+5. host mirror / retained result
+   - 只作为绑定、镜像或 evidence 消费
+
+外部 orchestrator 不得跳过 `Work Item`，也不得从 PR、tracker、release index 或
+merge commit 反推执行入口。
+
+## 3. 非法入口
+
+以下入口必须 fail closed：
+
+- PR-only
+- tracker-only
+- release-only
+- merge-commit-only
+- 缺少 `Work Item` 最小字段
+- `Work Item` 与 host binding 无法回链到同一事项
+
+结果必须使用现有 taxonomy：
+
+- `gate_failure.missing_prerequisite_gate`
+- `gate_failure.binding_failure`
+
+回退方向只允许指向：
+
+- `work_item`
+- `admission`
+- `binding_repair`
+
+不得指向 orchestrator 私有队列、retry state、tracker state 或 scheduler action。
+
+## 4. Locator Declaration
+
+成熟既有仓库可以通过 `.loom/companion/interop.json` 的
+`external_orchestrators` 声明外部 orchestrator 读面。
+
+这些声明只定位可读 evidence / adapter surface：
+
+- `id`
+- `summary`
+- `surfaces`
+- `operations`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+`operations` 第一版至少允许：
+
+- `work_item_read`
+
+后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
+`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+
+## 5. Truth Boundary
+
+`external_orchestrators` 不得承载：
+
+- scheduler state
+- attempt ownership
+- authored progress
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- status truth
+- gate verdict
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
+pollution，并阻断 required 声明。
+
+## 6. 非目标
+
+- 不提供默认 daemon
+- 不定义 tracker polling 产品
+- 不定义自动 retry / backoff 状态机
+- 不复制任何外部 orchestrator 的私有状态模型

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -415,7 +415,7 @@ RELEASE_TARGET_DELIVERY_STATUSES = {
 }
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
-REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
+REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"}
 REPO_INTEROP_COLLECTION_SURFACES = {
     "admission",
     "pre_review",
@@ -423,6 +423,9 @@ REPO_INTEROP_COLLECTION_SURFACES = {
     "build",
     "merge_ready",
     "closeout",
+}
+EXTERNAL_ORCHESTRATOR_OPERATIONS = {
+    "work_item_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2096,6 +2099,33 @@ def validate_repo_interop_collection_entry(
     return missing_inputs, missing_optional
 
 
+def validate_external_orchestrator_entry(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    missing_inputs, missing_optional = validate_repo_interop_collection_entry(
+        root=root,
+        collection="external_orchestrators",
+        entry=entry,
+        index=index,
+    )
+    if not isinstance(entry, dict):
+        return missing_inputs, missing_optional
+    prefix = f"external_orchestrators[{index}]"
+    operations = entry.get("operations")
+    if not isinstance(operations, list) or not operations:
+        missing_inputs.append(f"{prefix} must include `operations` as a non-empty list")
+    else:
+        for operation_index, operation in enumerate(operations):
+            if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
+                missing_inputs.append(
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                )
+    return missing_inputs, missing_optional
+
+
 def validate_shadow_surface(
     *,
     root: Path,
@@ -2412,6 +2442,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "host_adapters": carrier_entry("missing", "unknown", "repo interop contract"),
         "repo_native_carriers": carrier_entry("missing", "unknown", "repo interop contract"),
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
+        "external_orchestrators": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2440,7 +2471,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 + ", ".join(extra_keys)
             )
 
-        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
             repo_interop_surface[key] = carrier_entry(
                 "present",
                 ".loom/companion/interop.json",
@@ -2469,6 +2500,19 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 blocking, optional = validate_repo_interop_collection_entry(
                     root=root,
                     collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
+                )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
+
+        external_orchestrators = interop_payload.get("external_orchestrators", [])
+        if not isinstance(external_orchestrators, list):
+            missing_inputs.append("repo interop contract must include `external_orchestrators` as a list")
+        else:
+            for index, entry in enumerate(external_orchestrators):
+                blocking, optional = validate_external_orchestrator_entry(
+                    root=root,
                     entry=entry,
                     index=index,
                 )
@@ -2505,7 +2549,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = (
             "repo interop contract is readable with optional locator advisories."
             if missing_optional
-            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+            else "repo interop contract is readable for host adapters, repo-native carriers, shadow parity, and external orchestrator locators."
         )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
     repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -78,6 +78,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/external-orchestrator-interop.md",
     "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
@@ -308,6 +309,22 @@ EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -1514,7 +1531,7 @@ def require_repo_interop_payload(
         payload=payload.get("contract"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
         require_locator_entry(
             failures,
             category=category,
@@ -9228,6 +9245,15 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         (target / "native" / "status").mkdir(parents=True, exist_ok=True)
         for relative, payload in {
             "host/guardian-review.json": {"verdict": "allow"},
+            "host/external-orchestrator-read.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "work_item_read",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/work-items/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9285,6 +9311,28 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "requirement": "required",
                 "fallback_to": "manual-reconciliation",
             }
+        ],
+        "external_orchestrators": [
+            {
+                "id": "fake-external-orchestrator",
+                "summary": "Read external orchestrator retained read evidence without making it a scheduler state.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/external-orchestrator-read.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-external-orchestrator",
+                "summary": "Optional external orchestrator evidence may be unavailable.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/missing-external-orchestrator.json",
+                "owner": "external-tool",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            },
         ],
         "shadow_surfaces": {
             "admission": {
@@ -9345,6 +9393,7 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                     }
                 ],
                 "repo_native_carriers": [],
+                "external_orchestrators": [],
                 "shadow_surfaces": {
                     "admission": {
                         "summary": "Compare admission parity.",
@@ -9406,10 +9455,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
         elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        elif "missing-external-orchestrator.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must stay in missing_optional"))
         if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "missing-external-orchestrator.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -9609,6 +9662,89 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             reports = rogue_payload.get("reports")
             if not isinstance(reports, list) or not reports or reports[0].get("result") != "unreadable":
                 failures.append(Failure("repo-interop", "`shadow-parity` rogue evidence sample must report `unreadable`"))
+
+    return failures
+
+
+def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Failure]:
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-interop-fixtures.json"
+    category = "external-orchestrator-interop"
+    failures: list[Failure] = []
+    if not fixture_path.exists():
+        return [Failure(category, "`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` is missing")]
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [Failure(category, f"external orchestrator fixture JSON is invalid: {exc}")]
+
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` schema_version must be `{EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA}`",
+            )
+        )
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator fixtures must include a non-empty `fixtures` list"))
+        return failures
+
+    seen_names: set[str] = set()
+    required_names = {
+        "work-item-read-present",
+        "pr-only-entry-block",
+        "truth-poisoning-block",
+        "optional-missing-warn",
+    }
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if not isinstance(name, str) or not name:
+            failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
+        else:
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+        else:
+            for field in ("id", "summary", "locator", "owner", "requirement", "fallback_to"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{name or index} entry missing `{field}`"))
+            if entry.get("owner") not in governance_surface_module.DECLARED_LOCATOR_OWNERS:
+                failures.append(Failure(category, f"{name or index} owner must stay within declared locator owners"))
+            if entry.get("requirement") not in governance_surface_module.DECLARED_LOCATOR_REQUIREMENTS:
+                failures.append(Failure(category, f"{name or index} requirement must be required/optional/advisory"))
+            surfaces = entry.get("surfaces")
+            if not isinstance(surfaces, list) or not surfaces:
+                failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
+            operations = entry.get("operations")
+            if not isinstance(operations, list) or "work_item_read" not in operations:
+                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
+        if payload is not None:
+            if not isinstance(payload, dict):
+                failures.append(Failure(category, f"{name or index} payload must be an object or null"))
+            else:
+                if payload.get("operation") != "work_item_read":
+                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
+                    failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+                if forbidden and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
+                if payload.get("entry_kind") != "work_item" and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
+                if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
+                    failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator fixtures missing required cases: " + ", ".join(missing)))
 
     return failures
 
@@ -14073,6 +14209,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
+    failures.extend(check_external_orchestrator_interop_fixture_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14101,7 +14238,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 34
+    categories_checked = 35
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-story/.loom-runtime/install-layout.json
+++ b/skills/loom-story/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/external-orchestrator-interop.md",
     "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",

--- a/skills/loom-story/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-story/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -1,0 +1,113 @@
+# External Orchestrator Interop
+
+本文件定义外部 orchestrator 如何消费 Loom，而不把 Loom 变成 scheduler 产品。
+
+它承接 `#535` 的外部 interop 边界。完整事实链仍以
+[fact-chain-contract.md](./fact-chain-contract.md) 为准。
+
+## 1. 目标
+
+外部 orchestrator 可以做四件事：
+
+- 读取当前 `Work Item`
+- attach 已存在的 workspace 语义
+- 通过 recovery writeback 写回执行进展
+- 只读消费 status 与 gates
+
+它不得做三件事：
+
+- 创建第二状态面
+- author gate / review / status truth
+- 接管 branch、PR、git worktree 或 worker lifecycle
+
+## 2. Work Item 读取顺序
+
+外部 orchestrator 必须按同一条事实链读取：
+
+1. `init-result`
+   - 只用于 locator discovery，不承载执行真相
+2. `Work Item`
+   - 读取 `item_id`、目标、范围、执行路径、workspace / recovery / review / validation locator
+3. recovery entry
+   - 读取当前 checkpoint、停点、下一步、阻断项和最近验证摘要
+4. status control plane
+   - 只作为派生汇总和 provenance 读面
+5. host mirror / retained result
+   - 只作为绑定、镜像或 evidence 消费
+
+外部 orchestrator 不得跳过 `Work Item`，也不得从 PR、tracker、release index 或
+merge commit 反推执行入口。
+
+## 3. 非法入口
+
+以下入口必须 fail closed：
+
+- PR-only
+- tracker-only
+- release-only
+- merge-commit-only
+- 缺少 `Work Item` 最小字段
+- `Work Item` 与 host binding 无法回链到同一事项
+
+结果必须使用现有 taxonomy：
+
+- `gate_failure.missing_prerequisite_gate`
+- `gate_failure.binding_failure`
+
+回退方向只允许指向：
+
+- `work_item`
+- `admission`
+- `binding_repair`
+
+不得指向 orchestrator 私有队列、retry state、tracker state 或 scheduler action。
+
+## 4. Locator Declaration
+
+成熟既有仓库可以通过 `.loom/companion/interop.json` 的
+`external_orchestrators` 声明外部 orchestrator 读面。
+
+这些声明只定位可读 evidence / adapter surface：
+
+- `id`
+- `summary`
+- `surfaces`
+- `operations`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+`operations` 第一版至少允许：
+
+- `work_item_read`
+
+后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
+`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+
+## 5. Truth Boundary
+
+`external_orchestrators` 不得承载：
+
+- scheduler state
+- attempt ownership
+- authored progress
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- status truth
+- gate verdict
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
+pollution，并阻断 required 声明。
+
+## 6. 非目标
+
+- 不提供默认 daemon
+- 不定义 tracker polling 产品
+- 不定义自动 retry / backoff 状态机
+- 不复制任何外部 orchestrator 的私有状态模型

--- a/skills/loom-story/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/governance_surface.py
@@ -415,7 +415,7 @@ RELEASE_TARGET_DELIVERY_STATUSES = {
 }
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
-REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
+REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"}
 REPO_INTEROP_COLLECTION_SURFACES = {
     "admission",
     "pre_review",
@@ -423,6 +423,9 @@ REPO_INTEROP_COLLECTION_SURFACES = {
     "build",
     "merge_ready",
     "closeout",
+}
+EXTERNAL_ORCHESTRATOR_OPERATIONS = {
+    "work_item_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2096,6 +2099,33 @@ def validate_repo_interop_collection_entry(
     return missing_inputs, missing_optional
 
 
+def validate_external_orchestrator_entry(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    missing_inputs, missing_optional = validate_repo_interop_collection_entry(
+        root=root,
+        collection="external_orchestrators",
+        entry=entry,
+        index=index,
+    )
+    if not isinstance(entry, dict):
+        return missing_inputs, missing_optional
+    prefix = f"external_orchestrators[{index}]"
+    operations = entry.get("operations")
+    if not isinstance(operations, list) or not operations:
+        missing_inputs.append(f"{prefix} must include `operations` as a non-empty list")
+    else:
+        for operation_index, operation in enumerate(operations):
+            if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
+                missing_inputs.append(
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                )
+    return missing_inputs, missing_optional
+
+
 def validate_shadow_surface(
     *,
     root: Path,
@@ -2412,6 +2442,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "host_adapters": carrier_entry("missing", "unknown", "repo interop contract"),
         "repo_native_carriers": carrier_entry("missing", "unknown", "repo interop contract"),
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
+        "external_orchestrators": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2440,7 +2471,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 + ", ".join(extra_keys)
             )
 
-        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
             repo_interop_surface[key] = carrier_entry(
                 "present",
                 ".loom/companion/interop.json",
@@ -2469,6 +2500,19 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 blocking, optional = validate_repo_interop_collection_entry(
                     root=root,
                     collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
+                )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
+
+        external_orchestrators = interop_payload.get("external_orchestrators", [])
+        if not isinstance(external_orchestrators, list):
+            missing_inputs.append("repo interop contract must include `external_orchestrators` as a list")
+        else:
+            for index, entry in enumerate(external_orchestrators):
+                blocking, optional = validate_external_orchestrator_entry(
+                    root=root,
                     entry=entry,
                     index=index,
                 )
@@ -2505,7 +2549,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = (
             "repo interop contract is readable with optional locator advisories."
             if missing_optional
-            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+            else "repo interop contract is readable for host adapters, repo-native carriers, shadow parity, and external orchestrator locators."
         )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
     repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
@@ -78,6 +78,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/external-orchestrator-interop.md",
     "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
@@ -308,6 +309,22 @@ EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -1514,7 +1531,7 @@ def require_repo_interop_payload(
         payload=payload.get("contract"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
         require_locator_entry(
             failures,
             category=category,
@@ -9228,6 +9245,15 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         (target / "native" / "status").mkdir(parents=True, exist_ok=True)
         for relative, payload in {
             "host/guardian-review.json": {"verdict": "allow"},
+            "host/external-orchestrator-read.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "work_item_read",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/work-items/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9285,6 +9311,28 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "requirement": "required",
                 "fallback_to": "manual-reconciliation",
             }
+        ],
+        "external_orchestrators": [
+            {
+                "id": "fake-external-orchestrator",
+                "summary": "Read external orchestrator retained read evidence without making it a scheduler state.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/external-orchestrator-read.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-external-orchestrator",
+                "summary": "Optional external orchestrator evidence may be unavailable.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/missing-external-orchestrator.json",
+                "owner": "external-tool",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            },
         ],
         "shadow_surfaces": {
             "admission": {
@@ -9345,6 +9393,7 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                     }
                 ],
                 "repo_native_carriers": [],
+                "external_orchestrators": [],
                 "shadow_surfaces": {
                     "admission": {
                         "summary": "Compare admission parity.",
@@ -9406,10 +9455,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
         elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        elif "missing-external-orchestrator.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must stay in missing_optional"))
         if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "missing-external-orchestrator.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -9609,6 +9662,89 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             reports = rogue_payload.get("reports")
             if not isinstance(reports, list) or not reports or reports[0].get("result") != "unreadable":
                 failures.append(Failure("repo-interop", "`shadow-parity` rogue evidence sample must report `unreadable`"))
+
+    return failures
+
+
+def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Failure]:
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-interop-fixtures.json"
+    category = "external-orchestrator-interop"
+    failures: list[Failure] = []
+    if not fixture_path.exists():
+        return [Failure(category, "`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` is missing")]
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [Failure(category, f"external orchestrator fixture JSON is invalid: {exc}")]
+
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` schema_version must be `{EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA}`",
+            )
+        )
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator fixtures must include a non-empty `fixtures` list"))
+        return failures
+
+    seen_names: set[str] = set()
+    required_names = {
+        "work-item-read-present",
+        "pr-only-entry-block",
+        "truth-poisoning-block",
+        "optional-missing-warn",
+    }
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if not isinstance(name, str) or not name:
+            failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
+        else:
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+        else:
+            for field in ("id", "summary", "locator", "owner", "requirement", "fallback_to"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{name or index} entry missing `{field}`"))
+            if entry.get("owner") not in governance_surface_module.DECLARED_LOCATOR_OWNERS:
+                failures.append(Failure(category, f"{name or index} owner must stay within declared locator owners"))
+            if entry.get("requirement") not in governance_surface_module.DECLARED_LOCATOR_REQUIREMENTS:
+                failures.append(Failure(category, f"{name or index} requirement must be required/optional/advisory"))
+            surfaces = entry.get("surfaces")
+            if not isinstance(surfaces, list) or not surfaces:
+                failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
+            operations = entry.get("operations")
+            if not isinstance(operations, list) or "work_item_read" not in operations:
+                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
+        if payload is not None:
+            if not isinstance(payload, dict):
+                failures.append(Failure(category, f"{name or index} payload must be an object or null"))
+            else:
+                if payload.get("operation") != "work_item_read":
+                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
+                    failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+                if forbidden and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
+                if payload.get("entry_kind") != "work_item" and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
+                if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
+                    failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator fixtures missing required cases: " + ", ".join(missing)))
 
     return failures
 
@@ -14073,6 +14209,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
+    failures.extend(check_external_orchestrator_interop_fixture_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14101,7 +14238,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 34
+    categories_checked = 35
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/shared/references/harness/external-orchestrator-interop.md
@@ -1,0 +1,113 @@
+# External Orchestrator Interop
+
+本文件定义外部 orchestrator 如何消费 Loom，而不把 Loom 变成 scheduler 产品。
+
+它承接 `#535` 的外部 interop 边界。完整事实链仍以
+[fact-chain-contract.md](./fact-chain-contract.md) 为准。
+
+## 1. 目标
+
+外部 orchestrator 可以做四件事：
+
+- 读取当前 `Work Item`
+- attach 已存在的 workspace 语义
+- 通过 recovery writeback 写回执行进展
+- 只读消费 status 与 gates
+
+它不得做三件事：
+
+- 创建第二状态面
+- author gate / review / status truth
+- 接管 branch、PR、git worktree 或 worker lifecycle
+
+## 2. Work Item 读取顺序
+
+外部 orchestrator 必须按同一条事实链读取：
+
+1. `init-result`
+   - 只用于 locator discovery，不承载执行真相
+2. `Work Item`
+   - 读取 `item_id`、目标、范围、执行路径、workspace / recovery / review / validation locator
+3. recovery entry
+   - 读取当前 checkpoint、停点、下一步、阻断项和最近验证摘要
+4. status control plane
+   - 只作为派生汇总和 provenance 读面
+5. host mirror / retained result
+   - 只作为绑定、镜像或 evidence 消费
+
+外部 orchestrator 不得跳过 `Work Item`，也不得从 PR、tracker、release index 或
+merge commit 反推执行入口。
+
+## 3. 非法入口
+
+以下入口必须 fail closed：
+
+- PR-only
+- tracker-only
+- release-only
+- merge-commit-only
+- 缺少 `Work Item` 最小字段
+- `Work Item` 与 host binding 无法回链到同一事项
+
+结果必须使用现有 taxonomy：
+
+- `gate_failure.missing_prerequisite_gate`
+- `gate_failure.binding_failure`
+
+回退方向只允许指向：
+
+- `work_item`
+- `admission`
+- `binding_repair`
+
+不得指向 orchestrator 私有队列、retry state、tracker state 或 scheduler action。
+
+## 4. Locator Declaration
+
+成熟既有仓库可以通过 `.loom/companion/interop.json` 的
+`external_orchestrators` 声明外部 orchestrator 读面。
+
+这些声明只定位可读 evidence / adapter surface：
+
+- `id`
+- `summary`
+- `surfaces`
+- `operations`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+`operations` 第一版至少允许：
+
+- `work_item_read`
+
+后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
+`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+
+## 5. Truth Boundary
+
+`external_orchestrators` 不得承载：
+
+- scheduler state
+- attempt ownership
+- authored progress
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- status truth
+- gate verdict
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
+pollution，并阻断 required 声明。
+
+## 6. 非目标
+
+- 不提供默认 daemon
+- 不定义 tracker polling 产品
+- 不定义自动 retry / backoff 状态机
+- 不复制任何外部 orchestrator 的私有状态模型

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -415,7 +415,7 @@ RELEASE_TARGET_DELIVERY_STATUSES = {
 }
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
-REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
+REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"}
 REPO_INTEROP_COLLECTION_SURFACES = {
     "admission",
     "pre_review",
@@ -423,6 +423,9 @@ REPO_INTEROP_COLLECTION_SURFACES = {
     "build",
     "merge_ready",
     "closeout",
+}
+EXTERNAL_ORCHESTRATOR_OPERATIONS = {
+    "work_item_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2096,6 +2099,33 @@ def validate_repo_interop_collection_entry(
     return missing_inputs, missing_optional
 
 
+def validate_external_orchestrator_entry(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    missing_inputs, missing_optional = validate_repo_interop_collection_entry(
+        root=root,
+        collection="external_orchestrators",
+        entry=entry,
+        index=index,
+    )
+    if not isinstance(entry, dict):
+        return missing_inputs, missing_optional
+    prefix = f"external_orchestrators[{index}]"
+    operations = entry.get("operations")
+    if not isinstance(operations, list) or not operations:
+        missing_inputs.append(f"{prefix} must include `operations` as a non-empty list")
+    else:
+        for operation_index, operation in enumerate(operations):
+            if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
+                missing_inputs.append(
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                )
+    return missing_inputs, missing_optional
+
+
 def validate_shadow_surface(
     *,
     root: Path,
@@ -2412,6 +2442,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "host_adapters": carrier_entry("missing", "unknown", "repo interop contract"),
         "repo_native_carriers": carrier_entry("missing", "unknown", "repo interop contract"),
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
+        "external_orchestrators": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2440,7 +2471,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 + ", ".join(extra_keys)
             )
 
-        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
             repo_interop_surface[key] = carrier_entry(
                 "present",
                 ".loom/companion/interop.json",
@@ -2469,6 +2500,19 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 blocking, optional = validate_repo_interop_collection_entry(
                     root=root,
                     collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
+                )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
+
+        external_orchestrators = interop_payload.get("external_orchestrators", [])
+        if not isinstance(external_orchestrators, list):
+            missing_inputs.append("repo interop contract must include `external_orchestrators` as a list")
+        else:
+            for index, entry in enumerate(external_orchestrators):
+                blocking, optional = validate_external_orchestrator_entry(
+                    root=root,
                     entry=entry,
                     index=index,
                 )
@@ -2505,7 +2549,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = (
             "repo interop contract is readable with optional locator advisories."
             if missing_optional
-            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+            else "repo interop contract is readable for host adapters, repo-native carriers, shadow parity, and external orchestrator locators."
         )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
     repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -78,6 +78,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/external-orchestrator-interop.md",
     "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
@@ -308,6 +309,22 @@ EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -1514,7 +1531,7 @@ def require_repo_interop_payload(
         payload=payload.get("contract"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
         require_locator_entry(
             failures,
             category=category,
@@ -9228,6 +9245,15 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         (target / "native" / "status").mkdir(parents=True, exist_ok=True)
         for relative, payload in {
             "host/guardian-review.json": {"verdict": "allow"},
+            "host/external-orchestrator-read.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "work_item_read",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/work-items/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9285,6 +9311,28 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "requirement": "required",
                 "fallback_to": "manual-reconciliation",
             }
+        ],
+        "external_orchestrators": [
+            {
+                "id": "fake-external-orchestrator",
+                "summary": "Read external orchestrator retained read evidence without making it a scheduler state.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/external-orchestrator-read.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-external-orchestrator",
+                "summary": "Optional external orchestrator evidence may be unavailable.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/missing-external-orchestrator.json",
+                "owner": "external-tool",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            },
         ],
         "shadow_surfaces": {
             "admission": {
@@ -9345,6 +9393,7 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                     }
                 ],
                 "repo_native_carriers": [],
+                "external_orchestrators": [],
                 "shadow_surfaces": {
                     "admission": {
                         "summary": "Compare admission parity.",
@@ -9406,10 +9455,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
         elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        elif "missing-external-orchestrator.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must stay in missing_optional"))
         if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "missing-external-orchestrator.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -9609,6 +9662,89 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             reports = rogue_payload.get("reports")
             if not isinstance(reports, list) or not reports or reports[0].get("result") != "unreadable":
                 failures.append(Failure("repo-interop", "`shadow-parity` rogue evidence sample must report `unreadable`"))
+
+    return failures
+
+
+def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Failure]:
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-interop-fixtures.json"
+    category = "external-orchestrator-interop"
+    failures: list[Failure] = []
+    if not fixture_path.exists():
+        return [Failure(category, "`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` is missing")]
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [Failure(category, f"external orchestrator fixture JSON is invalid: {exc}")]
+
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` schema_version must be `{EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA}`",
+            )
+        )
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator fixtures must include a non-empty `fixtures` list"))
+        return failures
+
+    seen_names: set[str] = set()
+    required_names = {
+        "work-item-read-present",
+        "pr-only-entry-block",
+        "truth-poisoning-block",
+        "optional-missing-warn",
+    }
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if not isinstance(name, str) or not name:
+            failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
+        else:
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+        else:
+            for field in ("id", "summary", "locator", "owner", "requirement", "fallback_to"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{name or index} entry missing `{field}`"))
+            if entry.get("owner") not in governance_surface_module.DECLARED_LOCATOR_OWNERS:
+                failures.append(Failure(category, f"{name or index} owner must stay within declared locator owners"))
+            if entry.get("requirement") not in governance_surface_module.DECLARED_LOCATOR_REQUIREMENTS:
+                failures.append(Failure(category, f"{name or index} requirement must be required/optional/advisory"))
+            surfaces = entry.get("surfaces")
+            if not isinstance(surfaces, list) or not surfaces:
+                failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
+            operations = entry.get("operations")
+            if not isinstance(operations, list) or "work_item_read" not in operations:
+                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
+        if payload is not None:
+            if not isinstance(payload, dict):
+                failures.append(Failure(category, f"{name or index} payload must be an object or null"))
+            else:
+                if payload.get("operation") != "work_item_read":
+                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
+                    failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+                if forbidden and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
+                if payload.get("entry_kind") != "work_item" and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
+                if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
+                    failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator fixtures missing required cases: " + ", ".join(missing)))
 
     return failures
 
@@ -14073,6 +14209,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
+    failures.extend(check_external_orchestrator_interop_fixture_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14101,7 +14238,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 34
+    categories_checked = 35
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/src/skills/install-layout.json
+++ b/src/skills/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/external-orchestrator-interop.md",
     "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",

--- a/src/skills/shared/references/harness/external-orchestrator-interop.md
+++ b/src/skills/shared/references/harness/external-orchestrator-interop.md
@@ -1,0 +1,113 @@
+# External Orchestrator Interop
+
+本文件定义外部 orchestrator 如何消费 Loom，而不把 Loom 变成 scheduler 产品。
+
+它承接 `#535` 的外部 interop 边界。完整事实链仍以
+[fact-chain-contract.md](./fact-chain-contract.md) 为准。
+
+## 1. 目标
+
+外部 orchestrator 可以做四件事：
+
+- 读取当前 `Work Item`
+- attach 已存在的 workspace 语义
+- 通过 recovery writeback 写回执行进展
+- 只读消费 status 与 gates
+
+它不得做三件事：
+
+- 创建第二状态面
+- author gate / review / status truth
+- 接管 branch、PR、git worktree 或 worker lifecycle
+
+## 2. Work Item 读取顺序
+
+外部 orchestrator 必须按同一条事实链读取：
+
+1. `init-result`
+   - 只用于 locator discovery，不承载执行真相
+2. `Work Item`
+   - 读取 `item_id`、目标、范围、执行路径、workspace / recovery / review / validation locator
+3. recovery entry
+   - 读取当前 checkpoint、停点、下一步、阻断项和最近验证摘要
+4. status control plane
+   - 只作为派生汇总和 provenance 读面
+5. host mirror / retained result
+   - 只作为绑定、镜像或 evidence 消费
+
+外部 orchestrator 不得跳过 `Work Item`，也不得从 PR、tracker、release index 或
+merge commit 反推执行入口。
+
+## 3. 非法入口
+
+以下入口必须 fail closed：
+
+- PR-only
+- tracker-only
+- release-only
+- merge-commit-only
+- 缺少 `Work Item` 最小字段
+- `Work Item` 与 host binding 无法回链到同一事项
+
+结果必须使用现有 taxonomy：
+
+- `gate_failure.missing_prerequisite_gate`
+- `gate_failure.binding_failure`
+
+回退方向只允许指向：
+
+- `work_item`
+- `admission`
+- `binding_repair`
+
+不得指向 orchestrator 私有队列、retry state、tracker state 或 scheduler action。
+
+## 4. Locator Declaration
+
+成熟既有仓库可以通过 `.loom/companion/interop.json` 的
+`external_orchestrators` 声明外部 orchestrator 读面。
+
+这些声明只定位可读 evidence / adapter surface：
+
+- `id`
+- `summary`
+- `surfaces`
+- `operations`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+`operations` 第一版至少允许：
+
+- `work_item_read`
+
+后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
+`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+
+## 5. Truth Boundary
+
+`external_orchestrators` 不得承载：
+
+- scheduler state
+- attempt ownership
+- authored progress
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- status truth
+- gate verdict
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
+pollution，并阻断 required 声明。
+
+## 6. 非目标
+
+- 不提供默认 daemon
+- 不定义 tracker polling 产品
+- 不定义自动 retry / backoff 状态机
+- 不复制任何外部 orchestrator 的私有状态模型

--- a/src/skills/shared/scripts/governance_surface.py
+++ b/src/skills/shared/scripts/governance_surface.py
@@ -415,7 +415,7 @@ RELEASE_TARGET_DELIVERY_STATUSES = {
 }
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
-REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
+REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"}
 REPO_INTEROP_COLLECTION_SURFACES = {
     "admission",
     "pre_review",
@@ -423,6 +423,9 @@ REPO_INTEROP_COLLECTION_SURFACES = {
     "build",
     "merge_ready",
     "closeout",
+}
+EXTERNAL_ORCHESTRATOR_OPERATIONS = {
+    "work_item_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2096,6 +2099,33 @@ def validate_repo_interop_collection_entry(
     return missing_inputs, missing_optional
 
 
+def validate_external_orchestrator_entry(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    missing_inputs, missing_optional = validate_repo_interop_collection_entry(
+        root=root,
+        collection="external_orchestrators",
+        entry=entry,
+        index=index,
+    )
+    if not isinstance(entry, dict):
+        return missing_inputs, missing_optional
+    prefix = f"external_orchestrators[{index}]"
+    operations = entry.get("operations")
+    if not isinstance(operations, list) or not operations:
+        missing_inputs.append(f"{prefix} must include `operations` as a non-empty list")
+    else:
+        for operation_index, operation in enumerate(operations):
+            if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
+                missing_inputs.append(
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                )
+    return missing_inputs, missing_optional
+
+
 def validate_shadow_surface(
     *,
     root: Path,
@@ -2412,6 +2442,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "host_adapters": carrier_entry("missing", "unknown", "repo interop contract"),
         "repo_native_carriers": carrier_entry("missing", "unknown", "repo interop contract"),
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
+        "external_orchestrators": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2440,7 +2471,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 + ", ".join(extra_keys)
             )
 
-        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
             repo_interop_surface[key] = carrier_entry(
                 "present",
                 ".loom/companion/interop.json",
@@ -2469,6 +2500,19 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 blocking, optional = validate_repo_interop_collection_entry(
                     root=root,
                     collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
+                )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
+
+        external_orchestrators = interop_payload.get("external_orchestrators", [])
+        if not isinstance(external_orchestrators, list):
+            missing_inputs.append("repo interop contract must include `external_orchestrators` as a list")
+        else:
+            for index, entry in enumerate(external_orchestrators):
+                blocking, optional = validate_external_orchestrator_entry(
+                    root=root,
                     entry=entry,
                     index=index,
                 )
@@ -2505,7 +2549,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = (
             "repo interop contract is readable with optional locator advisories."
             if missing_optional
-            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+            else "repo interop contract is readable for host adapters, repo-native carriers, shadow parity, and external orchestrator locators."
         )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
     repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -78,6 +78,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/external-orchestrator-interop.md",
     "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
@@ -308,6 +309,22 @@ EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -1514,7 +1531,7 @@ def require_repo_interop_payload(
         payload=payload.get("contract"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
         require_locator_entry(
             failures,
             category=category,
@@ -9228,6 +9245,15 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         (target / "native" / "status").mkdir(parents=True, exist_ok=True)
         for relative, payload in {
             "host/guardian-review.json": {"verdict": "allow"},
+            "host/external-orchestrator-read.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "work_item_read",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/work-items/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9285,6 +9311,28 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "requirement": "required",
                 "fallback_to": "manual-reconciliation",
             }
+        ],
+        "external_orchestrators": [
+            {
+                "id": "fake-external-orchestrator",
+                "summary": "Read external orchestrator retained read evidence without making it a scheduler state.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/external-orchestrator-read.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-external-orchestrator",
+                "summary": "Optional external orchestrator evidence may be unavailable.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/missing-external-orchestrator.json",
+                "owner": "external-tool",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            },
         ],
         "shadow_surfaces": {
             "admission": {
@@ -9345,6 +9393,7 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                     }
                 ],
                 "repo_native_carriers": [],
+                "external_orchestrators": [],
                 "shadow_surfaces": {
                     "admission": {
                         "summary": "Compare admission parity.",
@@ -9406,10 +9455,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
         elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        elif "missing-external-orchestrator.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must stay in missing_optional"))
         if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "missing-external-orchestrator.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -9609,6 +9662,89 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             reports = rogue_payload.get("reports")
             if not isinstance(reports, list) or not reports or reports[0].get("result") != "unreadable":
                 failures.append(Failure("repo-interop", "`shadow-parity` rogue evidence sample must report `unreadable`"))
+
+    return failures
+
+
+def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Failure]:
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-interop-fixtures.json"
+    category = "external-orchestrator-interop"
+    failures: list[Failure] = []
+    if not fixture_path.exists():
+        return [Failure(category, "`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` is missing")]
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [Failure(category, f"external orchestrator fixture JSON is invalid: {exc}")]
+
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` schema_version must be `{EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA}`",
+            )
+        )
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator fixtures must include a non-empty `fixtures` list"))
+        return failures
+
+    seen_names: set[str] = set()
+    required_names = {
+        "work-item-read-present",
+        "pr-only-entry-block",
+        "truth-poisoning-block",
+        "optional-missing-warn",
+    }
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if not isinstance(name, str) or not name:
+            failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
+        else:
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+        else:
+            for field in ("id", "summary", "locator", "owner", "requirement", "fallback_to"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{name or index} entry missing `{field}`"))
+            if entry.get("owner") not in governance_surface_module.DECLARED_LOCATOR_OWNERS:
+                failures.append(Failure(category, f"{name or index} owner must stay within declared locator owners"))
+            if entry.get("requirement") not in governance_surface_module.DECLARED_LOCATOR_REQUIREMENTS:
+                failures.append(Failure(category, f"{name or index} requirement must be required/optional/advisory"))
+            surfaces = entry.get("surfaces")
+            if not isinstance(surfaces, list) or not surfaces:
+                failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
+            operations = entry.get("operations")
+            if not isinstance(operations, list) or "work_item_read" not in operations:
+                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
+        if payload is not None:
+            if not isinstance(payload, dict):
+                failures.append(Failure(category, f"{name or index} payload must be an object or null"))
+            else:
+                if payload.get("operation") != "work_item_read":
+                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
+                    failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+                if forbidden and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
+                if payload.get("entry_kind") != "work_item" and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
+                if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
+                    failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator fixtures missing required cases: " + ", ".join(missing)))
 
     return failures
 
@@ -14073,6 +14209,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
+    failures.extend(check_external_orchestrator_interop_fixture_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14101,7 +14238,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 34
+    categories_checked = 35
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")


### PR DESCRIPTION
## Summary

- Closes #629; covers #630, #631, #632.
- Adds the external orchestrator Work Item read contract and mirrors it into generated skill references.
- Extends repo interop with optional `external_orchestrators` locator-only declarations for `work_item_read` evidence.
- Adds external orchestrator read fixtures for Work Item pass, PR-only block, truth-pollution block, and optional missing warning.
- Bumps `@mc-and-his-agents/loom-installer` to `0.1.100` because the shared runtime/package payload changed.

## Validation

- `python3 -m py_compile tools/loom_check.py tools/loom_flow.py tools/loom_init.py tools/loom_status.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py`
- `python3 tools/skills_surface.py generate`
- `python3 tools/skills_surface.py check`
- `python3 tools/host_adapter_check.py`
- `python3 tools/version_surface_check.py`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `git diff --check`
- `python3 tools/loom_check.py` (`checked 35 surfaces`)
- `npm --prefix packages/loom-installer run check:release`

## Non-goals

- Does not implement workspace attach or recovery writeback; #633 owns that batch.
- Does not add status/gate consumer envelope; #637 owns that batch.
- Does not add fake orchestrator live conformance command; #641 owns that batch.
- Does not add daemon, scheduler state, tracker polling, or a second status surface.
