### PR TITLE
feat(harness): define external orchestrator attach and writeback boundary

### DIFF
--- a/docs/adoption/repo-interop-contract.md
+++ b/docs/adoption/repo-interop-contract.md
@@ -293,7 +293,7 @@ blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
 - `surfaces` 必须是非空数组
 - `surfaces[*]` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
 - `operations` 必须是非空数组
-- `operations[*]` 第一版只允许 `work_item_read`
+- `operations[*]` 只允许 `work_item_read | workspace_attach | recovery_writeback`
 - `locator` 只描述 Loom 如何读取外部 orchestrator 的 retained read evidence，不描述如何调度任务
 - `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
 - `requirement` 只允许 `required | optional | advisory`
@@ -321,6 +321,13 @@ merge checkpoint 或 closeout basis。
 若 required external orchestrator locator 缺失、越界、不可读，或 payload 包含这些
 forbidden authored fields，消费方必须 fail closed。optional / advisory 缺口只能进入
 profile-local advisory evidence，不得污染 `orchestration-core`。
+
+`workspace_attach` 声明只表示外部 orchestrator 可消费 Loom `workspace attach`
+语义；它不授权创建、删除或接管 branch、PR、git worktree、目录或 worker lifecycle。
+
+`recovery_writeback` 声明只表示外部 orchestrator 可通过 Loom recovery writeback
+入口写恢复主入口。它不授权直接写 status、gate、review、validation、host action 或
+closeout authored fields。
 
 ## 7. 与其他合同的关系
 

--- a/docs/evidence/fixtures/external-orchestrator-interop-fixtures.json
+++ b/docs/evidence/fixtures/external-orchestrator-interop-fixtures.json
@@ -104,6 +104,108 @@
       "expect": {
         "result": "warn"
       }
+    },
+    {
+      "name": "workspace-attach-present",
+      "entry": {
+        "id": "fake-external-orchestrator-attach",
+        "summary": "Consume Loom workspace attach semantics without owning host lifecycle.",
+        "surfaces": ["admission"],
+        "operations": ["workspace_attach"],
+        "locator": ".loom/external-orchestrator/workspace-attach.json",
+        "owner": "external-tool",
+        "requirement": "required",
+        "fallback_to": "admission"
+      },
+      "payload": {
+        "schema_version": "loom-external-orchestrator-read/v1",
+        "operation": "workspace_attach",
+        "entry_kind": "work_item",
+        "source_layer": "derived_surface",
+        "source_locator": ".loom/status/current.md",
+        "source_binding": {
+          "item_id": "INIT-0001"
+        },
+        "consumed_as": "summary",
+        "workspace_entry": ".",
+        "recovery_entry": ".loom/progress/INIT-0001.md",
+        "host_lifecycle_ownership": "external"
+      },
+      "expect": {
+        "result": "pass"
+      }
+    },
+    {
+      "name": "recovery-writeback-present",
+      "entry": {
+        "id": "fake-external-orchestrator-writeback",
+        "summary": "Use Loom recovery writeback as the only authored progress write path.",
+        "surfaces": ["build"],
+        "operations": ["recovery_writeback"],
+        "locator": ".loom/external-orchestrator/recovery-writeback.json",
+        "owner": "external-tool",
+        "requirement": "required",
+        "fallback_to": "build"
+      },
+      "payload": {
+        "schema_version": "loom-external-orchestrator-read/v1",
+        "operation": "recovery_writeback",
+        "entry_kind": "work_item",
+        "source_layer": "authored_truth",
+        "source_locator": ".loom/progress/INIT-0001.md",
+        "source_binding": {
+          "item_id": "INIT-0001"
+        },
+        "consumed_as": "locator",
+        "writeback_entry": "python3 tools/loom_flow.py recovery writeback",
+        "allowed_recovery_fields": [
+          "current_checkpoint",
+          "current_stop",
+          "next_step",
+          "blockers",
+          "latest_validation_summary",
+          "recovery_boundary",
+          "current_lane"
+        ]
+      },
+      "expect": {
+        "result": "pass"
+      }
+    },
+    {
+      "name": "direct-status-write-block",
+      "entry": {
+        "id": "fake-external-orchestrator-status-write",
+        "summary": "Attempt to author status truth directly.",
+        "surfaces": ["build"],
+        "operations": ["recovery_writeback"],
+        "locator": ".loom/external-orchestrator/direct-status-write.json",
+        "owner": "external-tool",
+        "requirement": "required",
+        "fallback_to": "build"
+      },
+      "payload": {
+        "schema_version": "loom-external-orchestrator-read/v1",
+        "operation": "recovery_writeback",
+        "entry_kind": "work_item",
+        "source_layer": "derived_surface",
+        "source_locator": ".loom/status/current.md",
+        "source_binding": {
+          "item_id": "INIT-0001"
+        },
+        "consumed_as": "truth",
+        "status_truth": {
+          "result": "pass"
+        },
+        "gate_verdict": {
+          "merge_ready": "pass"
+        }
+      },
+      "expect": {
+        "result": "block",
+        "failure": "truth_pollution",
+        "fallback_to": "build"
+      }
     }
   ]
 }

--- a/docs/evidence/orchestration-conformance-profiles.md
+++ b/docs/evidence/orchestration-conformance-profiles.md
@@ -78,6 +78,8 @@ daemon 或 scheduler 产品。
 第一版覆盖：
 
 - `Work Item` read locator
+- `workspace attach` 只读绑定语义
+- recovery writeback 是唯一 authored progress 写回路径
 - PR-only / tracker-only / release-only / merge-commit-only 入口 fail closed
 - external orchestrator locator payload 不承载 authored progress、status truth、gate truth 或 scheduler state
 - required locator missing / unreadable / unsafe 时在 extension path 内 block

--- a/docs/methodology/harness/external-orchestrator-interop.md
+++ b/docs/methodology/harness/external-orchestrator-interop.md
@@ -78,14 +78,55 @@ merge commit 反推执行入口。
 - `requirement`
 - `fallback_to`
 
-`operations` 第一版至少允许：
+`operations` 至少允许：
 
 - `work_item_read`
+- `workspace_attach`
+- `recovery_writeback`
 
-后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
-`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
+fact-chain，不得新增第二状态面。
 
-## 5. Truth Boundary
+## 5. Workspace Attach
+
+外部 orchestrator 可以消费或调用 Loom `workspace attach` 语义来确认既有现场可用。
+
+它可以读取：
+
+- 当前 `Work Item`
+- `workspace_entry`
+- `recovery_entry`
+- attach / locate 输出中的 purity 与 checkpoint 摘要
+
+它不得：
+
+- 创建目录
+- 删除目录
+- 创建或删除 git worktree
+- 创建、更新或关闭 branch / PR
+- 接管 worker backend lifecycle
+
+attach 失败只能回退到 `workspace_entry`、`admission` 或宿主现场声明修复，不得回退到
+orchestrator 私有 action。
+
+## 6. Recovery Writeback
+
+外部 orchestrator 写回执行进展时，只能通过既有 `recovery writeback` 入口写恢复主入口。
+
+允许写回的 authored 字段固定为：
+
+- `current_checkpoint`
+- `current_stop`
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `recovery_boundary`
+- `current_lane`
+
+写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
+gate、review、validation、host action 或 closeout authored fields。
+
+## 7. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -105,7 +146,7 @@ merge commit 反推执行入口。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 6. 非目标
+## 8. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -78,14 +78,55 @@ merge commit 反推执行入口。
 - `requirement`
 - `fallback_to`
 
-`operations` 第一版至少允许：
+`operations` 至少允许：
 
 - `work_item_read`
+- `workspace_attach`
+- `recovery_writeback`
 
-后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
-`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
+fact-chain，不得新增第二状态面。
 
-## 5. Truth Boundary
+## 5. Workspace Attach
+
+外部 orchestrator 可以消费或调用 Loom `workspace attach` 语义来确认既有现场可用。
+
+它可以读取：
+
+- 当前 `Work Item`
+- `workspace_entry`
+- `recovery_entry`
+- attach / locate 输出中的 purity 与 checkpoint 摘要
+
+它不得：
+
+- 创建目录
+- 删除目录
+- 创建或删除 git worktree
+- 创建、更新或关闭 branch / PR
+- 接管 worker backend lifecycle
+
+attach 失败只能回退到 `workspace_entry`、`admission` 或宿主现场声明修复，不得回退到
+orchestrator 私有 action。
+
+## 6. Recovery Writeback
+
+外部 orchestrator 写回执行进展时，只能通过既有 `recovery writeback` 入口写恢复主入口。
+
+允许写回的 authored 字段固定为：
+
+- `current_checkpoint`
+- `current_stop`
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `recovery_boundary`
+- `current_lane`
+
+写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
+gate、review、validation、host action 或 closeout authored fields。
+
+## 7. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -105,7 +146,7 @@ merge commit 反推执行入口。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 6. 非目标
+## 8. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/governance_surface.py
@@ -426,6 +426,8 @@ REPO_INTEROP_COLLECTION_SURFACES = {
 }
 EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
+    "workspace_attach",
+    "recovery_writeback",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2121,7 +2123,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -9254,6 +9254,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-attach.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "workspace_attach",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-writeback.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "recovery_writeback",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/progress/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9332,6 +9350,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "optional",
                 "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-attach",
+                "summary": "Read workspace attach evidence without owning host lifecycle.",
+                "surfaces": ["admission"],
+                "operations": ["workspace_attach"],
+                "locator": "host/external-orchestrator-attach.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-writeback",
+                "summary": "Read recovery writeback evidence without authoring status truth.",
+                "surfaces": ["build"],
+                "operations": ["recovery_writeback"],
+                "locator": "host/external-orchestrator-writeback.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "build",
             },
         ],
         "shadow_surfaces": {
@@ -9695,6 +9733,9 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "pr-only-entry-block",
         "truth-poisoning-block",
         "optional-missing-warn",
+        "workspace-attach-present",
+        "recovery-writeback-present",
+        "direct-status-write-block",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9720,8 +9761,11 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            if not isinstance(operations, list) or "work_item_read" not in operations:
-                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
+            if not isinstance(operations, list) or not operations:
+                failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
+            elif any(operation not in allowed_operations for operation in operations):
+                failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
         payload = fixture.get("payload")
         expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
@@ -9730,8 +9774,8 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") != "work_item_read":
-                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                    failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))

--- a/skills/loom-build/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -78,14 +78,55 @@ merge commit 反推执行入口。
 - `requirement`
 - `fallback_to`
 
-`operations` 第一版至少允许：
+`operations` 至少允许：
 
 - `work_item_read`
+- `workspace_attach`
+- `recovery_writeback`
 
-后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
-`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
+fact-chain，不得新增第二状态面。
 
-## 5. Truth Boundary
+## 5. Workspace Attach
+
+外部 orchestrator 可以消费或调用 Loom `workspace attach` 语义来确认既有现场可用。
+
+它可以读取：
+
+- 当前 `Work Item`
+- `workspace_entry`
+- `recovery_entry`
+- attach / locate 输出中的 purity 与 checkpoint 摘要
+
+它不得：
+
+- 创建目录
+- 删除目录
+- 创建或删除 git worktree
+- 创建、更新或关闭 branch / PR
+- 接管 worker backend lifecycle
+
+attach 失败只能回退到 `workspace_entry`、`admission` 或宿主现场声明修复，不得回退到
+orchestrator 私有 action。
+
+## 6. Recovery Writeback
+
+外部 orchestrator 写回执行进展时，只能通过既有 `recovery writeback` 入口写恢复主入口。
+
+允许写回的 authored 字段固定为：
+
+- `current_checkpoint`
+- `current_stop`
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `recovery_boundary`
+- `current_lane`
+
+写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
+gate、review、validation、host action 或 closeout authored fields。
+
+## 7. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -105,7 +146,7 @@ merge commit 反推执行入口。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 6. 非目标
+## 8. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-build/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/governance_surface.py
@@ -426,6 +426,8 @@ REPO_INTEROP_COLLECTION_SURFACES = {
 }
 EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
+    "workspace_attach",
+    "recovery_writeback",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2121,7 +2123,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -9254,6 +9254,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-attach.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "workspace_attach",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-writeback.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "recovery_writeback",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/progress/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9332,6 +9350,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "optional",
                 "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-attach",
+                "summary": "Read workspace attach evidence without owning host lifecycle.",
+                "surfaces": ["admission"],
+                "operations": ["workspace_attach"],
+                "locator": "host/external-orchestrator-attach.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-writeback",
+                "summary": "Read recovery writeback evidence without authoring status truth.",
+                "surfaces": ["build"],
+                "operations": ["recovery_writeback"],
+                "locator": "host/external-orchestrator-writeback.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "build",
             },
         ],
         "shadow_surfaces": {
@@ -9695,6 +9733,9 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "pr-only-entry-block",
         "truth-poisoning-block",
         "optional-missing-warn",
+        "workspace-attach-present",
+        "recovery-writeback-present",
+        "direct-status-write-block",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9720,8 +9761,11 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            if not isinstance(operations, list) or "work_item_read" not in operations:
-                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
+            if not isinstance(operations, list) or not operations:
+                failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
+            elif any(operation not in allowed_operations for operation in operations):
+                failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
         payload = fixture.get("payload")
         expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
@@ -9730,8 +9774,8 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") != "work_item_read":
-                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                    failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -78,14 +78,55 @@ merge commit 反推执行入口。
 - `requirement`
 - `fallback_to`
 
-`operations` 第一版至少允许：
+`operations` 至少允许：
 
 - `work_item_read`
+- `workspace_attach`
+- `recovery_writeback`
 
-后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
-`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
+fact-chain，不得新增第二状态面。
 
-## 5. Truth Boundary
+## 5. Workspace Attach
+
+外部 orchestrator 可以消费或调用 Loom `workspace attach` 语义来确认既有现场可用。
+
+它可以读取：
+
+- 当前 `Work Item`
+- `workspace_entry`
+- `recovery_entry`
+- attach / locate 输出中的 purity 与 checkpoint 摘要
+
+它不得：
+
+- 创建目录
+- 删除目录
+- 创建或删除 git worktree
+- 创建、更新或关闭 branch / PR
+- 接管 worker backend lifecycle
+
+attach 失败只能回退到 `workspace_entry`、`admission` 或宿主现场声明修复，不得回退到
+orchestrator 私有 action。
+
+## 6. Recovery Writeback
+
+外部 orchestrator 写回执行进展时，只能通过既有 `recovery writeback` 入口写恢复主入口。
+
+允许写回的 authored 字段固定为：
+
+- `current_checkpoint`
+- `current_stop`
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `recovery_boundary`
+- `current_lane`
+
+写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
+gate、review、validation、host action 或 closeout authored fields。
+
+## 7. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -105,7 +146,7 @@ merge commit 反推执行入口。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 6. 非目标
+## 8. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/governance_surface.py
@@ -426,6 +426,8 @@ REPO_INTEROP_COLLECTION_SURFACES = {
 }
 EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
+    "workspace_attach",
+    "recovery_writeback",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2121,7 +2123,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -9254,6 +9254,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-attach.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "workspace_attach",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-writeback.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "recovery_writeback",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/progress/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9332,6 +9350,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "optional",
                 "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-attach",
+                "summary": "Read workspace attach evidence without owning host lifecycle.",
+                "surfaces": ["admission"],
+                "operations": ["workspace_attach"],
+                "locator": "host/external-orchestrator-attach.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-writeback",
+                "summary": "Read recovery writeback evidence without authoring status truth.",
+                "surfaces": ["build"],
+                "operations": ["recovery_writeback"],
+                "locator": "host/external-orchestrator-writeback.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "build",
             },
         ],
         "shadow_surfaces": {
@@ -9695,6 +9733,9 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "pr-only-entry-block",
         "truth-poisoning-block",
         "optional-missing-warn",
+        "workspace-attach-present",
+        "recovery-writeback-present",
+        "direct-status-write-block",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9720,8 +9761,11 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            if not isinstance(operations, list) or "work_item_read" not in operations:
-                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
+            if not isinstance(operations, list) or not operations:
+                failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
+            elif any(operation not in allowed_operations for operation in operations):
+                failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
         payload = fixture.get("payload")
         expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
@@ -9730,8 +9774,8 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") != "work_item_read":
-                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                    failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))

--- a/skills/loom-init/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -78,14 +78,55 @@ merge commit 反推执行入口。
 - `requirement`
 - `fallback_to`
 
-`operations` 第一版至少允许：
+`operations` 至少允许：
 
 - `work_item_read`
+- `workspace_attach`
+- `recovery_writeback`
 
-后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
-`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
+fact-chain，不得新增第二状态面。
 
-## 5. Truth Boundary
+## 5. Workspace Attach
+
+外部 orchestrator 可以消费或调用 Loom `workspace attach` 语义来确认既有现场可用。
+
+它可以读取：
+
+- 当前 `Work Item`
+- `workspace_entry`
+- `recovery_entry`
+- attach / locate 输出中的 purity 与 checkpoint 摘要
+
+它不得：
+
+- 创建目录
+- 删除目录
+- 创建或删除 git worktree
+- 创建、更新或关闭 branch / PR
+- 接管 worker backend lifecycle
+
+attach 失败只能回退到 `workspace_entry`、`admission` 或宿主现场声明修复，不得回退到
+orchestrator 私有 action。
+
+## 6. Recovery Writeback
+
+外部 orchestrator 写回执行进展时，只能通过既有 `recovery writeback` 入口写恢复主入口。
+
+允许写回的 authored 字段固定为：
+
+- `current_checkpoint`
+- `current_stop`
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `recovery_boundary`
+- `current_lane`
+
+写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
+gate、review、validation、host action 或 closeout authored fields。
+
+## 7. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -105,7 +146,7 @@ merge commit 反推执行入口。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 6. 非目标
+## 8. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-init/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/governance_surface.py
@@ -426,6 +426,8 @@ REPO_INTEROP_COLLECTION_SURFACES = {
 }
 EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
+    "workspace_attach",
+    "recovery_writeback",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2121,7 +2123,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -9254,6 +9254,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-attach.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "workspace_attach",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-writeback.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "recovery_writeback",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/progress/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9332,6 +9350,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "optional",
                 "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-attach",
+                "summary": "Read workspace attach evidence without owning host lifecycle.",
+                "surfaces": ["admission"],
+                "operations": ["workspace_attach"],
+                "locator": "host/external-orchestrator-attach.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-writeback",
+                "summary": "Read recovery writeback evidence without authoring status truth.",
+                "surfaces": ["build"],
+                "operations": ["recovery_writeback"],
+                "locator": "host/external-orchestrator-writeback.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "build",
             },
         ],
         "shadow_surfaces": {
@@ -9695,6 +9733,9 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "pr-only-entry-block",
         "truth-poisoning-block",
         "optional-missing-warn",
+        "workspace-attach-present",
+        "recovery-writeback-present",
+        "direct-status-write-block",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9720,8 +9761,11 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            if not isinstance(operations, list) or "work_item_read" not in operations:
-                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
+            if not isinstance(operations, list) or not operations:
+                failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
+            elif any(operation not in allowed_operations for operation in operations):
+                failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
         payload = fixture.get("payload")
         expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
@@ -9730,8 +9774,8 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") != "work_item_read":
-                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                    failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -78,14 +78,55 @@ merge commit 反推执行入口。
 - `requirement`
 - `fallback_to`
 
-`operations` 第一版至少允许：
+`operations` 至少允许：
 
 - `work_item_read`
+- `workspace_attach`
+- `recovery_writeback`
 
-后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
-`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
+fact-chain，不得新增第二状态面。
 
-## 5. Truth Boundary
+## 5. Workspace Attach
+
+外部 orchestrator 可以消费或调用 Loom `workspace attach` 语义来确认既有现场可用。
+
+它可以读取：
+
+- 当前 `Work Item`
+- `workspace_entry`
+- `recovery_entry`
+- attach / locate 输出中的 purity 与 checkpoint 摘要
+
+它不得：
+
+- 创建目录
+- 删除目录
+- 创建或删除 git worktree
+- 创建、更新或关闭 branch / PR
+- 接管 worker backend lifecycle
+
+attach 失败只能回退到 `workspace_entry`、`admission` 或宿主现场声明修复，不得回退到
+orchestrator 私有 action。
+
+## 6. Recovery Writeback
+
+外部 orchestrator 写回执行进展时，只能通过既有 `recovery writeback` 入口写恢复主入口。
+
+允许写回的 authored 字段固定为：
+
+- `current_checkpoint`
+- `current_stop`
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `recovery_boundary`
+- `current_lane`
+
+写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
+gate、review、validation、host action 或 closeout authored fields。
+
+## 7. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -105,7 +146,7 @@ merge commit 反推执行入口。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 6. 非目标
+## 8. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/governance_surface.py
@@ -426,6 +426,8 @@ REPO_INTEROP_COLLECTION_SURFACES = {
 }
 EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
+    "workspace_attach",
+    "recovery_writeback",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2121,7 +2123,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -9254,6 +9254,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-attach.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "workspace_attach",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-writeback.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "recovery_writeback",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/progress/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9332,6 +9350,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "optional",
                 "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-attach",
+                "summary": "Read workspace attach evidence without owning host lifecycle.",
+                "surfaces": ["admission"],
+                "operations": ["workspace_attach"],
+                "locator": "host/external-orchestrator-attach.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-writeback",
+                "summary": "Read recovery writeback evidence without authoring status truth.",
+                "surfaces": ["build"],
+                "operations": ["recovery_writeback"],
+                "locator": "host/external-orchestrator-writeback.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "build",
             },
         ],
         "shadow_surfaces": {
@@ -9695,6 +9733,9 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "pr-only-entry-block",
         "truth-poisoning-block",
         "optional-missing-warn",
+        "workspace-attach-present",
+        "recovery-writeback-present",
+        "direct-status-write-block",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9720,8 +9761,11 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            if not isinstance(operations, list) or "work_item_read" not in operations:
-                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
+            if not isinstance(operations, list) or not operations:
+                failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
+            elif any(operation not in allowed_operations for operation in operations):
+                failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
         payload = fixture.get("payload")
         expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
@@ -9730,8 +9774,8 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") != "work_item_read":
-                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                    failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -78,14 +78,55 @@ merge commit 反推执行入口。
 - `requirement`
 - `fallback_to`
 
-`operations` 第一版至少允许：
+`operations` 至少允许：
 
 - `work_item_read`
+- `workspace_attach`
+- `recovery_writeback`
 
-后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
-`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
+fact-chain，不得新增第二状态面。
 
-## 5. Truth Boundary
+## 5. Workspace Attach
+
+外部 orchestrator 可以消费或调用 Loom `workspace attach` 语义来确认既有现场可用。
+
+它可以读取：
+
+- 当前 `Work Item`
+- `workspace_entry`
+- `recovery_entry`
+- attach / locate 输出中的 purity 与 checkpoint 摘要
+
+它不得：
+
+- 创建目录
+- 删除目录
+- 创建或删除 git worktree
+- 创建、更新或关闭 branch / PR
+- 接管 worker backend lifecycle
+
+attach 失败只能回退到 `workspace_entry`、`admission` 或宿主现场声明修复，不得回退到
+orchestrator 私有 action。
+
+## 6. Recovery Writeback
+
+外部 orchestrator 写回执行进展时，只能通过既有 `recovery writeback` 入口写恢复主入口。
+
+允许写回的 authored 字段固定为：
+
+- `current_checkpoint`
+- `current_stop`
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `recovery_boundary`
+- `current_lane`
+
+写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
+gate、review、validation、host action 或 closeout authored fields。
+
+## 7. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -105,7 +146,7 @@ merge commit 反推执行入口。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 6. 非目标
+## 8. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -426,6 +426,8 @@ REPO_INTEROP_COLLECTION_SURFACES = {
 }
 EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
+    "workspace_attach",
+    "recovery_writeback",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2121,7 +2123,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -9254,6 +9254,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-attach.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "workspace_attach",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-writeback.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "recovery_writeback",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/progress/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9332,6 +9350,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "optional",
                 "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-attach",
+                "summary": "Read workspace attach evidence without owning host lifecycle.",
+                "surfaces": ["admission"],
+                "operations": ["workspace_attach"],
+                "locator": "host/external-orchestrator-attach.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-writeback",
+                "summary": "Read recovery writeback evidence without authoring status truth.",
+                "surfaces": ["build"],
+                "operations": ["recovery_writeback"],
+                "locator": "host/external-orchestrator-writeback.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "build",
             },
         ],
         "shadow_surfaces": {
@@ -9695,6 +9733,9 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "pr-only-entry-block",
         "truth-poisoning-block",
         "optional-missing-warn",
+        "workspace-attach-present",
+        "recovery-writeback-present",
+        "direct-status-write-block",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9720,8 +9761,11 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            if not isinstance(operations, list) or "work_item_read" not in operations:
-                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
+            if not isinstance(operations, list) or not operations:
+                failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
+            elif any(operation not in allowed_operations for operation in operations):
+                failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
         payload = fixture.get("payload")
         expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
@@ -9730,8 +9774,8 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") != "work_item_read":
-                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                    failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -78,14 +78,55 @@ merge commit 反推执行入口。
 - `requirement`
 - `fallback_to`
 
-`operations` 第一版至少允许：
+`operations` 至少允许：
 
 - `work_item_read`
+- `workspace_attach`
+- `recovery_writeback`
 
-后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
-`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
+fact-chain，不得新增第二状态面。
 
-## 5. Truth Boundary
+## 5. Workspace Attach
+
+外部 orchestrator 可以消费或调用 Loom `workspace attach` 语义来确认既有现场可用。
+
+它可以读取：
+
+- 当前 `Work Item`
+- `workspace_entry`
+- `recovery_entry`
+- attach / locate 输出中的 purity 与 checkpoint 摘要
+
+它不得：
+
+- 创建目录
+- 删除目录
+- 创建或删除 git worktree
+- 创建、更新或关闭 branch / PR
+- 接管 worker backend lifecycle
+
+attach 失败只能回退到 `workspace_entry`、`admission` 或宿主现场声明修复，不得回退到
+orchestrator 私有 action。
+
+## 6. Recovery Writeback
+
+外部 orchestrator 写回执行进展时，只能通过既有 `recovery writeback` 入口写恢复主入口。
+
+允许写回的 authored 字段固定为：
+
+- `current_checkpoint`
+- `current_stop`
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `recovery_boundary`
+- `current_lane`
+
+写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
+gate、review、validation、host action 或 closeout authored fields。
+
+## 7. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -105,7 +146,7 @@ merge commit 反推执行入口。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 6. 非目标
+## 8. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-resume/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/governance_surface.py
@@ -426,6 +426,8 @@ REPO_INTEROP_COLLECTION_SURFACES = {
 }
 EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
+    "workspace_attach",
+    "recovery_writeback",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2121,7 +2123,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -9254,6 +9254,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-attach.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "workspace_attach",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-writeback.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "recovery_writeback",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/progress/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9332,6 +9350,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "optional",
                 "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-attach",
+                "summary": "Read workspace attach evidence without owning host lifecycle.",
+                "surfaces": ["admission"],
+                "operations": ["workspace_attach"],
+                "locator": "host/external-orchestrator-attach.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-writeback",
+                "summary": "Read recovery writeback evidence without authoring status truth.",
+                "surfaces": ["build"],
+                "operations": ["recovery_writeback"],
+                "locator": "host/external-orchestrator-writeback.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "build",
             },
         ],
         "shadow_surfaces": {
@@ -9695,6 +9733,9 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "pr-only-entry-block",
         "truth-poisoning-block",
         "optional-missing-warn",
+        "workspace-attach-present",
+        "recovery-writeback-present",
+        "direct-status-write-block",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9720,8 +9761,11 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            if not isinstance(operations, list) or "work_item_read" not in operations:
-                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
+            if not isinstance(operations, list) or not operations:
+                failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
+            elif any(operation not in allowed_operations for operation in operations):
+                failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
         payload = fixture.get("payload")
         expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
@@ -9730,8 +9774,8 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") != "work_item_read":
-                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                    failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -78,14 +78,55 @@ merge commit 反推执行入口。
 - `requirement`
 - `fallback_to`
 
-`operations` 第一版至少允许：
+`operations` 至少允许：
 
 - `work_item_read`
+- `workspace_attach`
+- `recovery_writeback`
 
-后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
-`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
+fact-chain，不得新增第二状态面。
 
-## 5. Truth Boundary
+## 5. Workspace Attach
+
+外部 orchestrator 可以消费或调用 Loom `workspace attach` 语义来确认既有现场可用。
+
+它可以读取：
+
+- 当前 `Work Item`
+- `workspace_entry`
+- `recovery_entry`
+- attach / locate 输出中的 purity 与 checkpoint 摘要
+
+它不得：
+
+- 创建目录
+- 删除目录
+- 创建或删除 git worktree
+- 创建、更新或关闭 branch / PR
+- 接管 worker backend lifecycle
+
+attach 失败只能回退到 `workspace_entry`、`admission` 或宿主现场声明修复，不得回退到
+orchestrator 私有 action。
+
+## 6. Recovery Writeback
+
+外部 orchestrator 写回执行进展时，只能通过既有 `recovery writeback` 入口写恢复主入口。
+
+允许写回的 authored 字段固定为：
+
+- `current_checkpoint`
+- `current_stop`
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `recovery_boundary`
+- `current_lane`
+
+写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
+gate、review、validation、host action 或 closeout authored fields。
+
+## 7. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -105,7 +146,7 @@ merge commit 反推执行入口。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 6. 非目标
+## 8. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-retire/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/governance_surface.py
@@ -426,6 +426,8 @@ REPO_INTEROP_COLLECTION_SURFACES = {
 }
 EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
+    "workspace_attach",
+    "recovery_writeback",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2121,7 +2123,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -9254,6 +9254,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-attach.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "workspace_attach",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-writeback.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "recovery_writeback",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/progress/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9332,6 +9350,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "optional",
                 "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-attach",
+                "summary": "Read workspace attach evidence without owning host lifecycle.",
+                "surfaces": ["admission"],
+                "operations": ["workspace_attach"],
+                "locator": "host/external-orchestrator-attach.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-writeback",
+                "summary": "Read recovery writeback evidence without authoring status truth.",
+                "surfaces": ["build"],
+                "operations": ["recovery_writeback"],
+                "locator": "host/external-orchestrator-writeback.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "build",
             },
         ],
         "shadow_surfaces": {
@@ -9695,6 +9733,9 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "pr-only-entry-block",
         "truth-poisoning-block",
         "optional-missing-warn",
+        "workspace-attach-present",
+        "recovery-writeback-present",
+        "direct-status-write-block",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9720,8 +9761,11 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            if not isinstance(operations, list) or "work_item_read" not in operations:
-                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
+            if not isinstance(operations, list) or not operations:
+                failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
+            elif any(operation not in allowed_operations for operation in operations):
+                failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
         payload = fixture.get("payload")
         expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
@@ -9730,8 +9774,8 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") != "work_item_read":
-                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                    failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))

--- a/skills/loom-review/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -78,14 +78,55 @@ merge commit 反推执行入口。
 - `requirement`
 - `fallback_to`
 
-`operations` 第一版至少允许：
+`operations` 至少允许：
 
 - `work_item_read`
+- `workspace_attach`
+- `recovery_writeback`
 
-后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
-`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
+fact-chain，不得新增第二状态面。
 
-## 5. Truth Boundary
+## 5. Workspace Attach
+
+外部 orchestrator 可以消费或调用 Loom `workspace attach` 语义来确认既有现场可用。
+
+它可以读取：
+
+- 当前 `Work Item`
+- `workspace_entry`
+- `recovery_entry`
+- attach / locate 输出中的 purity 与 checkpoint 摘要
+
+它不得：
+
+- 创建目录
+- 删除目录
+- 创建或删除 git worktree
+- 创建、更新或关闭 branch / PR
+- 接管 worker backend lifecycle
+
+attach 失败只能回退到 `workspace_entry`、`admission` 或宿主现场声明修复，不得回退到
+orchestrator 私有 action。
+
+## 6. Recovery Writeback
+
+外部 orchestrator 写回执行进展时，只能通过既有 `recovery writeback` 入口写恢复主入口。
+
+允许写回的 authored 字段固定为：
+
+- `current_checkpoint`
+- `current_stop`
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `recovery_boundary`
+- `current_lane`
+
+写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
+gate、review、validation、host action 或 closeout authored fields。
+
+## 7. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -105,7 +146,7 @@ merge commit 反推执行入口。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 6. 非目标
+## 8. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -426,6 +426,8 @@ REPO_INTEROP_COLLECTION_SURFACES = {
 }
 EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
+    "workspace_attach",
+    "recovery_writeback",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2121,7 +2123,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -9254,6 +9254,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-attach.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "workspace_attach",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-writeback.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "recovery_writeback",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/progress/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9332,6 +9350,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "optional",
                 "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-attach",
+                "summary": "Read workspace attach evidence without owning host lifecycle.",
+                "surfaces": ["admission"],
+                "operations": ["workspace_attach"],
+                "locator": "host/external-orchestrator-attach.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-writeback",
+                "summary": "Read recovery writeback evidence without authoring status truth.",
+                "surfaces": ["build"],
+                "operations": ["recovery_writeback"],
+                "locator": "host/external-orchestrator-writeback.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "build",
             },
         ],
         "shadow_surfaces": {
@@ -9695,6 +9733,9 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "pr-only-entry-block",
         "truth-poisoning-block",
         "optional-missing-warn",
+        "workspace-attach-present",
+        "recovery-writeback-present",
+        "direct-status-write-block",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9720,8 +9761,11 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            if not isinstance(operations, list) or "work_item_read" not in operations:
-                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
+            if not isinstance(operations, list) or not operations:
+                failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
+            elif any(operation not in allowed_operations for operation in operations):
+                failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
         payload = fixture.get("payload")
         expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
@@ -9730,8 +9774,8 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") != "work_item_read":
-                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                    failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -78,14 +78,55 @@ merge commit 反推执行入口。
 - `requirement`
 - `fallback_to`
 
-`operations` 第一版至少允许：
+`operations` 至少允许：
 
 - `work_item_read`
+- `workspace_attach`
+- `recovery_writeback`
 
-后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
-`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
+fact-chain，不得新增第二状态面。
 
-## 5. Truth Boundary
+## 5. Workspace Attach
+
+外部 orchestrator 可以消费或调用 Loom `workspace attach` 语义来确认既有现场可用。
+
+它可以读取：
+
+- 当前 `Work Item`
+- `workspace_entry`
+- `recovery_entry`
+- attach / locate 输出中的 purity 与 checkpoint 摘要
+
+它不得：
+
+- 创建目录
+- 删除目录
+- 创建或删除 git worktree
+- 创建、更新或关闭 branch / PR
+- 接管 worker backend lifecycle
+
+attach 失败只能回退到 `workspace_entry`、`admission` 或宿主现场声明修复，不得回退到
+orchestrator 私有 action。
+
+## 6. Recovery Writeback
+
+外部 orchestrator 写回执行进展时，只能通过既有 `recovery writeback` 入口写恢复主入口。
+
+允许写回的 authored 字段固定为：
+
+- `current_checkpoint`
+- `current_stop`
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `recovery_boundary`
+- `current_lane`
+
+写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
+gate、review、validation、host action 或 closeout authored fields。
+
+## 7. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -105,7 +146,7 @@ merge commit 反推执行入口。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 6. 非目标
+## 8. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -426,6 +426,8 @@ REPO_INTEROP_COLLECTION_SURFACES = {
 }
 EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
+    "workspace_attach",
+    "recovery_writeback",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2121,7 +2123,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -9254,6 +9254,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-attach.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "workspace_attach",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-writeback.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "recovery_writeback",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/progress/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9332,6 +9350,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "optional",
                 "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-attach",
+                "summary": "Read workspace attach evidence without owning host lifecycle.",
+                "surfaces": ["admission"],
+                "operations": ["workspace_attach"],
+                "locator": "host/external-orchestrator-attach.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-writeback",
+                "summary": "Read recovery writeback evidence without authoring status truth.",
+                "surfaces": ["build"],
+                "operations": ["recovery_writeback"],
+                "locator": "host/external-orchestrator-writeback.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "build",
             },
         ],
         "shadow_surfaces": {
@@ -9695,6 +9733,9 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "pr-only-entry-block",
         "truth-poisoning-block",
         "optional-missing-warn",
+        "workspace-attach-present",
+        "recovery-writeback-present",
+        "direct-status-write-block",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9720,8 +9761,11 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            if not isinstance(operations, list) or "work_item_read" not in operations:
-                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
+            if not isinstance(operations, list) or not operations:
+                failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
+            elif any(operation not in allowed_operations for operation in operations):
+                failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
         payload = fixture.get("payload")
         expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
@@ -9730,8 +9774,8 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") != "work_item_read":
-                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                    failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))

--- a/skills/loom-story/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-story/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -78,14 +78,55 @@ merge commit 反推执行入口。
 - `requirement`
 - `fallback_to`
 
-`operations` 第一版至少允许：
+`operations` 至少允许：
 
 - `work_item_read`
+- `workspace_attach`
+- `recovery_writeback`
 
-后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
-`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
+fact-chain，不得新增第二状态面。
 
-## 5. Truth Boundary
+## 5. Workspace Attach
+
+外部 orchestrator 可以消费或调用 Loom `workspace attach` 语义来确认既有现场可用。
+
+它可以读取：
+
+- 当前 `Work Item`
+- `workspace_entry`
+- `recovery_entry`
+- attach / locate 输出中的 purity 与 checkpoint 摘要
+
+它不得：
+
+- 创建目录
+- 删除目录
+- 创建或删除 git worktree
+- 创建、更新或关闭 branch / PR
+- 接管 worker backend lifecycle
+
+attach 失败只能回退到 `workspace_entry`、`admission` 或宿主现场声明修复，不得回退到
+orchestrator 私有 action。
+
+## 6. Recovery Writeback
+
+外部 orchestrator 写回执行进展时，只能通过既有 `recovery writeback` 入口写恢复主入口。
+
+允许写回的 authored 字段固定为：
+
+- `current_checkpoint`
+- `current_stop`
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `recovery_boundary`
+- `current_lane`
+
+写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
+gate、review、validation、host action 或 closeout authored fields。
+
+## 7. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -105,7 +146,7 @@ merge commit 反推执行入口。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 6. 非目标
+## 8. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-story/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/governance_surface.py
@@ -426,6 +426,8 @@ REPO_INTEROP_COLLECTION_SURFACES = {
 }
 EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
+    "workspace_attach",
+    "recovery_writeback",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2121,7 +2123,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
@@ -9254,6 +9254,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-attach.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "workspace_attach",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-writeback.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "recovery_writeback",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/progress/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9332,6 +9350,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "optional",
                 "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-attach",
+                "summary": "Read workspace attach evidence without owning host lifecycle.",
+                "surfaces": ["admission"],
+                "operations": ["workspace_attach"],
+                "locator": "host/external-orchestrator-attach.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-writeback",
+                "summary": "Read recovery writeback evidence without authoring status truth.",
+                "surfaces": ["build"],
+                "operations": ["recovery_writeback"],
+                "locator": "host/external-orchestrator-writeback.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "build",
             },
         ],
         "shadow_surfaces": {
@@ -9695,6 +9733,9 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "pr-only-entry-block",
         "truth-poisoning-block",
         "optional-missing-warn",
+        "workspace-attach-present",
+        "recovery-writeback-present",
+        "direct-status-write-block",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9720,8 +9761,11 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            if not isinstance(operations, list) or "work_item_read" not in operations:
-                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
+            if not isinstance(operations, list) or not operations:
+                failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
+            elif any(operation not in allowed_operations for operation in operations):
+                failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
         payload = fixture.get("payload")
         expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
@@ -9730,8 +9774,8 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") != "work_item_read":
-                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                    failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))

--- a/skills/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/shared/references/harness/external-orchestrator-interop.md
@@ -78,14 +78,55 @@ merge commit 反推执行入口。
 - `requirement`
 - `fallback_to`
 
-`operations` 第一版至少允许：
+`operations` 至少允许：
 
 - `work_item_read`
+- `workspace_attach`
+- `recovery_writeback`
 
-后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
-`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
+fact-chain，不得新增第二状态面。
 
-## 5. Truth Boundary
+## 5. Workspace Attach
+
+外部 orchestrator 可以消费或调用 Loom `workspace attach` 语义来确认既有现场可用。
+
+它可以读取：
+
+- 当前 `Work Item`
+- `workspace_entry`
+- `recovery_entry`
+- attach / locate 输出中的 purity 与 checkpoint 摘要
+
+它不得：
+
+- 创建目录
+- 删除目录
+- 创建或删除 git worktree
+- 创建、更新或关闭 branch / PR
+- 接管 worker backend lifecycle
+
+attach 失败只能回退到 `workspace_entry`、`admission` 或宿主现场声明修复，不得回退到
+orchestrator 私有 action。
+
+## 6. Recovery Writeback
+
+外部 orchestrator 写回执行进展时，只能通过既有 `recovery writeback` 入口写恢复主入口。
+
+允许写回的 authored 字段固定为：
+
+- `current_checkpoint`
+- `current_stop`
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `recovery_boundary`
+- `current_lane`
+
+写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
+gate、review、validation、host action 或 closeout authored fields。
+
+## 7. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -105,7 +146,7 @@ merge commit 反推执行入口。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 6. 非目标
+## 8. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -426,6 +426,8 @@ REPO_INTEROP_COLLECTION_SURFACES = {
 }
 EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
+    "workspace_attach",
+    "recovery_writeback",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2121,7 +2123,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -9254,6 +9254,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-attach.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "workspace_attach",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-writeback.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "recovery_writeback",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/progress/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9332,6 +9350,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "optional",
                 "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-attach",
+                "summary": "Read workspace attach evidence without owning host lifecycle.",
+                "surfaces": ["admission"],
+                "operations": ["workspace_attach"],
+                "locator": "host/external-orchestrator-attach.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-writeback",
+                "summary": "Read recovery writeback evidence without authoring status truth.",
+                "surfaces": ["build"],
+                "operations": ["recovery_writeback"],
+                "locator": "host/external-orchestrator-writeback.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "build",
             },
         ],
         "shadow_surfaces": {
@@ -9695,6 +9733,9 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "pr-only-entry-block",
         "truth-poisoning-block",
         "optional-missing-warn",
+        "workspace-attach-present",
+        "recovery-writeback-present",
+        "direct-status-write-block",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9720,8 +9761,11 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            if not isinstance(operations, list) or "work_item_read" not in operations:
-                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
+            if not isinstance(operations, list) or not operations:
+                failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
+            elif any(operation not in allowed_operations for operation in operations):
+                failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
         payload = fixture.get("payload")
         expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
@@ -9730,8 +9774,8 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") != "work_item_read":
-                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                    failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))

--- a/src/skills/shared/references/harness/external-orchestrator-interop.md
+++ b/src/skills/shared/references/harness/external-orchestrator-interop.md
@@ -78,14 +78,55 @@ merge commit 反推执行入口。
 - `requirement`
 - `fallback_to`
 
-`operations` 第一版至少允许：
+`operations` 至少允许：
 
 - `work_item_read`
+- `workspace_attach`
+- `recovery_writeback`
 
-后续可扩展到 `workspace_attach`、`recovery_writeback`、`status_read` 与
-`gate_read`，但这些扩展仍必须消费同一 fact-chain，不得新增第二状态面。
+后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
+fact-chain，不得新增第二状态面。
 
-## 5. Truth Boundary
+## 5. Workspace Attach
+
+外部 orchestrator 可以消费或调用 Loom `workspace attach` 语义来确认既有现场可用。
+
+它可以读取：
+
+- 当前 `Work Item`
+- `workspace_entry`
+- `recovery_entry`
+- attach / locate 输出中的 purity 与 checkpoint 摘要
+
+它不得：
+
+- 创建目录
+- 删除目录
+- 创建或删除 git worktree
+- 创建、更新或关闭 branch / PR
+- 接管 worker backend lifecycle
+
+attach 失败只能回退到 `workspace_entry`、`admission` 或宿主现场声明修复，不得回退到
+orchestrator 私有 action。
+
+## 6. Recovery Writeback
+
+外部 orchestrator 写回执行进展时，只能通过既有 `recovery writeback` 入口写恢复主入口。
+
+允许写回的 authored 字段固定为：
+
+- `current_checkpoint`
+- `current_stop`
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `recovery_boundary`
+- `current_lane`
+
+写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
+gate、review、validation、host action 或 closeout authored fields。
+
+## 7. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -105,7 +146,7 @@ merge commit 反推执行入口。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 6. 非目标
+## 8. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/src/skills/shared/scripts/governance_surface.py
+++ b/src/skills/shared/scripts/governance_surface.py
@@ -426,6 +426,8 @@ REPO_INTEROP_COLLECTION_SURFACES = {
 }
 EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
+    "workspace_attach",
+    "recovery_writeback",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2121,7 +2123,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
                 )
     return missing_inputs, missing_optional
 

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -9254,6 +9254,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-attach.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "workspace_attach",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-writeback.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "recovery_writeback",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/progress/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9332,6 +9350,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "optional",
                 "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-attach",
+                "summary": "Read workspace attach evidence without owning host lifecycle.",
+                "surfaces": ["admission"],
+                "operations": ["workspace_attach"],
+                "locator": "host/external-orchestrator-attach.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-writeback",
+                "summary": "Read recovery writeback evidence without authoring status truth.",
+                "surfaces": ["build"],
+                "operations": ["recovery_writeback"],
+                "locator": "host/external-orchestrator-writeback.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "build",
             },
         ],
         "shadow_surfaces": {
@@ -9695,6 +9733,9 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "pr-only-entry-block",
         "truth-poisoning-block",
         "optional-missing-warn",
+        "workspace-attach-present",
+        "recovery-writeback-present",
+        "direct-status-write-block",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9720,8 +9761,11 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            if not isinstance(operations, list) or "work_item_read" not in operations:
-                failures.append(Failure(category, f"{name or index} entry must declare `work_item_read`"))
+            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
+            if not isinstance(operations, list) or not operations:
+                failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
+            elif any(operation not in allowed_operations for operation in operations):
+                failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
         payload = fixture.get("payload")
         expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
@@ -9730,8 +9774,8 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") != "work_item_read":
-                    failures.append(Failure(category, f"{name or index} payload operation must be `work_item_read`"))
+                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                    failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))


### PR DESCRIPTION
## Summary

- Closes #633; covers #634, #635, #636.
- Extends external orchestrator interop operations with `workspace_attach` and `recovery_writeback`.
- Freezes that attach only consumes existing Loom workspace semantics and does not own branch/PR/git worktree/worker lifecycle.
- Freezes recovery writeback as the only authored progress write path and blocks direct status/gate authored writes.
- Adds fixtures and `loom_check` coverage for attach present, recovery writeback present, and direct status/gate write pollution.

## Validation

- `python3 -m py_compile tools/loom_check.py tools/loom_flow.py tools/loom_init.py tools/loom_status.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py`
- `python3 tools/skills_surface.py generate`
- `python3 tools/skills_surface.py check`
- `python3 tools/host_adapter_check.py`
- `python3 tools/version_surface_check.py`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `git diff --check`
- `python3 tools/loom_check.py` (`checked 35 surfaces`)
- `npm --prefix packages/loom-installer run check:release`

## Non-goals

- Does not add status/gate consumer envelope; #637 owns that batch.
- Does not add fake orchestrator live conformance command; #641 owns that batch.
- Does not add daemon, scheduler state, tracker polling, or a second status surface.
