### PR TITLE
feat: define external orchestrator status gate consumption

### DIFF
--- a/docs/adoption/repo-interop-contract.md
+++ b/docs/adoption/repo-interop-contract.md
@@ -293,7 +293,7 @@ blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
 - `surfaces` 必须是非空数组
 - `surfaces[*]` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
 - `operations` 必须是非空数组
-- `operations[*]` 只允许 `work_item_read | workspace_attach | recovery_writeback`
+- `operations[*]` 只允许 `work_item_read | workspace_attach | recovery_writeback | status_read | gate_read`
 - `locator` 只描述 Loom 如何读取外部 orchestrator 的 retained read evidence，不描述如何调度任务
 - `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
 - `requirement` 只允许 `required | optional | advisory`
@@ -328,6 +328,15 @@ profile-local advisory evidence，不得污染 `orchestration-core`。
 `recovery_writeback` 声明只表示外部 orchestrator 可通过 Loom recovery writeback
 入口写恢复主入口。它不授权直接写 status、gate、review、validation、host action 或
 closeout authored fields。
+
+`status_read` 与 `gate_read` 声明只表示外部 orchestrator 可消费 Loom
+`status control plane v2` 与既有 gate chain 的派生读面。它们必须复用
+`loom-governance-status/v2` 字段、provenance 与 gate vocabulary，不得声明新的
+status schema、scheduler-owned verdict 或第二 gate truth。
+
+status / gate 读取失败时，`fallback_to` 只能指向 Loom checkpoint、gate 前置修复、
+`admission` 或 `binding_repair`。它不得指向 scheduler 私有 action、retry queue、
+tracker state 或 orchestrator-owned decision。
 
 ## 7. 与其他合同的关系
 

--- a/docs/evidence/fixtures/external-orchestrator-interop-fixtures.json
+++ b/docs/evidence/fixtures/external-orchestrator-interop-fixtures.json
@@ -206,6 +206,110 @@
         "failure": "truth_pollution",
         "fallback_to": "build"
       }
+    },
+    {
+      "name": "status-read-present",
+      "entry": {
+        "id": "fake-external-orchestrator-status-read",
+        "summary": "Consume status control plane v2 as a read-only external consumer view.",
+        "surfaces": ["merge_ready"],
+        "operations": ["status_read"],
+        "locator": ".loom/external-orchestrator/status-read.json",
+        "owner": "external-tool",
+        "requirement": "required",
+        "fallback_to": "current_checkpoint"
+      },
+      "payload": {
+        "schema_version": "loom-external-orchestrator-read/v1",
+        "operation": "status_read",
+        "entry_kind": "work_item",
+        "source_layer": "derived_surface",
+        "source_locator": ".loom/status/current.md",
+        "source_binding": {
+          "item_id": "INIT-0001",
+          "status_schema_version": "loom-governance-status/v2"
+        },
+        "consumed_as": "summary",
+        "status_fields": [
+          "result",
+          "current_gate",
+          "classifications",
+          "missing_inputs",
+          "head_binding",
+          "gate_chain",
+          "provenance"
+        ],
+        "fallback_to": "current_checkpoint"
+      },
+      "expect": {
+        "result": "pass"
+      }
+    },
+    {
+      "name": "gate-read-present",
+      "entry": {
+        "id": "fake-external-orchestrator-gate-read",
+        "summary": "Consume the existing Loom gate chain without authoring a gate verdict.",
+        "surfaces": ["merge_ready"],
+        "operations": ["gate_read"],
+        "locator": ".loom/external-orchestrator/gate-read.json",
+        "owner": "external-tool",
+        "requirement": "required",
+        "fallback_to": "review_gate"
+      },
+      "payload": {
+        "schema_version": "loom-external-orchestrator-read/v1",
+        "operation": "gate_read",
+        "entry_kind": "work_item",
+        "source_layer": "derived_surface",
+        "source_locator": ".loom/status/current.md",
+        "source_binding": {
+          "item_id": "INIT-0001",
+          "gate_chain": "status_control_plane_v2"
+        },
+        "consumed_as": "summary",
+        "gate_fields": [
+          "name",
+          "result",
+          "classification",
+          "missing_inputs",
+          "fallback_to"
+        ],
+        "fallback_to": "review_gate"
+      },
+      "expect": {
+        "result": "pass"
+      }
+    },
+    {
+      "name": "scheduler-private-fallback-block",
+      "entry": {
+        "id": "fake-external-orchestrator-private-fallback",
+        "summary": "Attempt to fallback to a scheduler-private action instead of a Loom checkpoint.",
+        "surfaces": ["merge_ready"],
+        "operations": ["gate_read"],
+        "locator": ".loom/external-orchestrator/private-fallback.json",
+        "owner": "external-tool",
+        "requirement": "required",
+        "fallback_to": "scheduler_retry_queue"
+      },
+      "payload": {
+        "schema_version": "loom-external-orchestrator-read/v1",
+        "operation": "gate_read",
+        "entry_kind": "work_item",
+        "source_layer": "derived_surface",
+        "source_locator": ".loom/status/current.md",
+        "source_binding": {
+          "item_id": "INIT-0001"
+        },
+        "consumed_as": "summary",
+        "fallback_to": "scheduler_retry_queue"
+      },
+      "expect": {
+        "result": "block",
+        "failure": "gate_failure.binding_failure",
+        "fallback_to": "current_checkpoint"
+      }
     }
   ]
 }

--- a/docs/methodology/harness/external-orchestrator-interop.md
+++ b/docs/methodology/harness/external-orchestrator-interop.md
@@ -83,9 +83,10 @@ merge commit 反推执行入口。
 - `work_item_read`
 - `workspace_attach`
 - `recovery_writeback`
+- `status_read`
+- `gate_read`
 
-后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
-fact-chain，不得新增第二状态面。
+`status_read` 与 `gate_read` 必须消费同一 fact-chain，不得新增第二状态面。
 
 ## 5. Workspace Attach
 
@@ -126,7 +127,35 @@ orchestrator 私有 action。
 写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
 gate、review、validation、host action 或 closeout authored fields。
 
-## 7. Truth Boundary
+## 7. Status / Gate Consumption
+
+外部 orchestrator 可以只读消费 `status control plane v2` 与现有 gate chain。
+
+它读取的状态必须与 Loom 本地入口同源：
+
+- `schema_version` 继续使用 `loom-governance-status/v2`
+- `result`、`current_gate`、`classifications`、`missing_inputs`、`head_binding`
+  与 `gate_chain` 来自同一个 status control plane
+- `provenance` 继续指向 Work Item、recovery entry、review / checkpoint / host mirror
+  等既有来源
+
+外部 orchestrator 视图只能是 consumer view。它可以裁剪字段以便消费，但不得定义
+新的 status schema、不得 authored `pass | block`、不得替换 gate chain。
+
+当 status/gate 读取无法消费时，回退只能指向 Loom checkpoint 或 gate 前置修复，例如：
+
+- `current_checkpoint`
+- `spec_gate`
+- `build_gate`
+- `review_gate`
+- `merge_gate`
+- `admission`
+- `binding_repair`
+
+不得回退到 scheduler 私有 action、retry queue、tracker state 或 orchestrator-owned
+decision。
+
+## 8. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -146,7 +175,7 @@ gate、review、validation、host action 或 closeout authored fields。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 8. 非目标
+## 9. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/docs/methodology/harness/status-surface-contract.md
+++ b/docs/methodology/harness/status-surface-contract.md
@@ -286,6 +286,30 @@
 `provenance` 是读取说明，不是新的 authored 字段组。它可以在 JSON 输出中按字段内联，也可以作为并列索引输出，但必须能被机械入口追溯到具体字段。
 若一个字段组混合消费多个来源，provenance 必须能下钻到字段级，不能用组级 provenance 掩盖局部 stale / drift。
 
+### 3.12 `external_orchestrator`
+
+当外部 orchestrator 只读消费 status / gate 时，状态面可以暴露派生 consumer view：
+
+- `schema_version`: 继续使用 `loom-governance-status/v2`
+- `view`: 固定为 `external_orchestrator_consumer`
+- `result`
+- `current_gate`
+- `classifications`
+- `missing_inputs`
+- `head_binding`
+- `gate_chain`
+- `allowed_operations`
+- `source_policy`
+- `provenance`
+- `recovery_readiness`
+
+该字段组只能投影本状态面的 `governance_status` 与 provenance。它不得定义第二套 status
+schema，不得 authored gate verdict，不得成为 scheduler state 或 tracker state。
+
+`allowed_operations` 只能声明 `status_read` 与 `gate_read`。`source_policy` 必须说明 status
+来自 `status control plane v2`、gate 来自现有 governance gate chain、writeback 只能回到
+recovery entry，失败回退只能指向 Loom checkpoint 或 gate 前置修复。
+
 ## 4. 总结果语义
 
 统一状态控制面本身只允许输出：

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.101",
+  "version": "0.1.102",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.101",
+      "version": "0.1.102",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.101",
+  "version": "0.1.102",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -83,9 +83,10 @@ merge commit 反推执行入口。
 - `work_item_read`
 - `workspace_attach`
 - `recovery_writeback`
+- `status_read`
+- `gate_read`
 
-后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
-fact-chain，不得新增第二状态面。
+`status_read` 与 `gate_read` 必须消费同一 fact-chain，不得新增第二状态面。
 
 ## 5. Workspace Attach
 
@@ -126,7 +127,35 @@ orchestrator 私有 action。
 写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
 gate、review、validation、host action 或 closeout authored fields。
 
-## 7. Truth Boundary
+## 7. Status / Gate Consumption
+
+外部 orchestrator 可以只读消费 `status control plane v2` 与现有 gate chain。
+
+它读取的状态必须与 Loom 本地入口同源：
+
+- `schema_version` 继续使用 `loom-governance-status/v2`
+- `result`、`current_gate`、`classifications`、`missing_inputs`、`head_binding`
+  与 `gate_chain` 来自同一个 status control plane
+- `provenance` 继续指向 Work Item、recovery entry、review / checkpoint / host mirror
+  等既有来源
+
+外部 orchestrator 视图只能是 consumer view。它可以裁剪字段以便消费，但不得定义
+新的 status schema、不得 authored `pass | block`、不得替换 gate chain。
+
+当 status/gate 读取无法消费时，回退只能指向 Loom checkpoint 或 gate 前置修复，例如：
+
+- `current_checkpoint`
+- `spec_gate`
+- `build_gate`
+- `review_gate`
+- `merge_gate`
+- `admission`
+- `binding_repair`
+
+不得回退到 scheduler 私有 action、retry queue、tracker state 或 orchestrator-owned
+decision。
+
+## 8. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -146,7 +175,7 @@ gate、review、validation、host action 或 closeout authored fields。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 8. 非目标
+## 9. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -286,6 +286,30 @@
 `provenance` 是读取说明，不是新的 authored 字段组。它可以在 JSON 输出中按字段内联，也可以作为并列索引输出，但必须能被机械入口追溯到具体字段。
 若一个字段组混合消费多个来源，provenance 必须能下钻到字段级，不能用组级 provenance 掩盖局部 stale / drift。
 
+### 3.12 `external_orchestrator`
+
+当外部 orchestrator 只读消费 status / gate 时，状态面可以暴露派生 consumer view：
+
+- `schema_version`: 继续使用 `loom-governance-status/v2`
+- `view`: 固定为 `external_orchestrator_consumer`
+- `result`
+- `current_gate`
+- `classifications`
+- `missing_inputs`
+- `head_binding`
+- `gate_chain`
+- `allowed_operations`
+- `source_policy`
+- `provenance`
+- `recovery_readiness`
+
+该字段组只能投影本状态面的 `governance_status` 与 provenance。它不得定义第二套 status
+schema，不得 authored gate verdict，不得成为 scheduler state 或 tracker state。
+
+`allowed_operations` 只能声明 `status_read` 与 `gate_read`。`source_policy` 必须说明 status
+来自 `status control plane v2`、gate 来自现有 governance gate chain、writeback 只能回到
+recovery entry，失败回退只能指向 Loom checkpoint 或 gate 前置修复。
+
 ## 4. 总结果语义
 
 统一状态控制面本身只允许输出：

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/governance_surface.py
@@ -428,6 +428,8 @@ EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
     "workspace_attach",
     "recovery_writeback",
+    "status_read",
+    "gate_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2123,7 +2125,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`, `status_read`, `gate_read`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -4666,6 +4666,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 classifications = governance_status.get("classifications")
                 if not isinstance(classifications, list):
                     failures.append(Failure("daily-execution-cli", "`loom_status` governance_status must include classifications"))
+            external_orchestrator = payload.get("external_orchestrator")
+            if not isinstance(external_orchestrator, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `external_orchestrator` consumer view"))
+            else:
+                if external_orchestrator.get("schema_version") != "loom-governance-status/v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse governance status schema v2"))
+                if external_orchestrator.get("view") != "external_orchestrator_consumer":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator view must be consumer-only"))
+                if external_orchestrator.get("result") not in {"pass", "block"}:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator result must be `pass` or `block`"))
+                if external_orchestrator.get("allowed_operations") != ["status_read", "gate_read"]:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must expose only read operations"))
+                if not isinstance(external_orchestrator.get("gate_chain"), list):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse gate_chain"))
+                source_policy = external_orchestrator.get("source_policy")
+                if not isinstance(source_policy, dict):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must include source_policy"))
+                elif source_policy.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator fallback must point to Loom checkpoint"))
+                elif source_policy.get("status_source") != "derived_from_status_control_plane_v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read status from status control plane v2"))
+                elif source_policy.get("gate_source") != "derived_from_governance_gate_chain":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read gates from the governance gate chain"))
+                external_provenance = external_orchestrator.get("provenance")
+                if not (
+                    isinstance(external_provenance, dict)
+                    or (isinstance(external_provenance, list) and external_provenance)
+                ):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must carry provenance"))
             closeout = payload.get("closeout")
             if not isinstance(closeout, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `closeout`"))
@@ -9272,6 +9301,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-status.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "status_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "status_schema_version": "loom-governance-status/v2"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-gate.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "gate_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "gate_chain": "status_control_plane_v2"},
+                "consumed_as": "summary",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9370,6 +9417,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "required",
                 "fallback_to": "build",
+            },
+            {
+                "id": "fake-external-orchestrator-status",
+                "summary": "Read status control plane v2 without defining a second status surface.",
+                "surfaces": ["merge_ready"],
+                "operations": ["status_read"],
+                "locator": "host/external-orchestrator-status.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "current_checkpoint",
+            },
+            {
+                "id": "fake-external-orchestrator-gate",
+                "summary": "Read the Loom gate chain without authoring a gate verdict.",
+                "surfaces": ["merge_ready"],
+                "operations": ["gate_read"],
+                "locator": "host/external-orchestrator-gate.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "review_gate",
             },
         ],
         "shadow_surfaces": {
@@ -9736,6 +9803,24 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "workspace-attach-present",
         "recovery-writeback-present",
         "direct-status-write-block",
+        "status-read-present",
+        "gate-read-present",
+        "scheduler-private-fallback-block",
+    }
+    allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"}
+    loom_fallbacks = {
+        "work_item",
+        "admission",
+        "binding_repair",
+        "current_checkpoint",
+        "spec_gate",
+        "build_gate",
+        "review_gate",
+        "merge_gate",
+        "merge_ready",
+        "build",
+        "review",
+        "closeout",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9746,6 +9831,7 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
         else:
             seen_names.add(name)
+        expect = fixture.get("expect")
         entry = fixture.get("entry")
         if not isinstance(entry, dict):
             failures.append(Failure(category, f"{name or index} entry must be an object"))
@@ -9761,23 +9847,35 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
             if not isinstance(operations, list) or not operations:
                 failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
             elif any(operation not in allowed_operations for operation in operations):
                 failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
+            fallback_to = entry.get("fallback_to")
+            if (
+                isinstance(fallback_to, str)
+                and fallback_to not in loom_fallbacks
+                and (not isinstance(expect, dict) or expect.get("result") != "block")
+            ):
+                failures.append(Failure(category, f"{name or index} fallback_to must point to a Loom checkpoint or gate repair surface"))
         payload = fixture.get("payload")
-        expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
             failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
         if payload is not None:
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                if payload.get("operation") not in allowed_operations:
                     failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                payload_fallback = payload.get("fallback_to")
+                if (
+                    isinstance(payload_fallback, str)
+                    and payload_fallback not in loom_fallbacks
+                    and (not isinstance(expect, dict) or expect.get("result") != "block")
+                ):
+                    failures.append(Failure(category, f"{name or index} payload fallback_to must point to a Loom checkpoint or gate repair surface"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
                 if forbidden and expect.get("result") != "block":
                     failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
@@ -9785,6 +9883,27 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
                     failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
                 if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
                     failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+                if payload.get("operation") in {"status_read", "gate_read"}:
+                    if payload.get("source_layer") != "derived_surface":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must consume the derived status surface"))
+                    if payload.get("consumed_as") != "summary":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must be consumed as summary, not authored truth"))
+                    if payload.get("operation") == "status_read":
+                        status_fields = payload.get("status_fields")
+                        required_status_fields = {"result", "current_gate", "classifications", "missing_inputs", "head_binding", "gate_chain", "provenance"}
+                        if not isinstance(status_fields, list) or not required_status_fields.issubset(set(status_fields)):
+                            failures.append(Failure(category, f"{name or index} status_read fixture must reuse status control plane v2 fields"))
+                    if payload.get("operation") == "gate_read":
+                        gate_fields = payload.get("gate_fields")
+                        required_gate_fields = {"name", "result", "classification", "missing_inputs", "fallback_to"}
+                        if expect.get("result") != "block" and (not isinstance(gate_fields, list) or not required_gate_fields.issubset(set(gate_fields))):
+                            failures.append(Failure(category, f"{name or index} gate_read fixture must reuse the existing gate chain fields"))
+                if name == "scheduler-private-fallback-block" and expect.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure(category, "scheduler-private fallback fixture must fallback to `current_checkpoint`"))
+                if name == "scheduler-private-fallback-block":
+                    entry_fallback = entry.get("fallback_to") if isinstance(entry, dict) else None
+                    if entry_fallback in loom_fallbacks or payload.get("fallback_to") in loom_fallbacks:
+                        failures.append(Failure(category, "scheduler-private fallback fixture must prove a private fallback is blocked"))
 
     missing = sorted(required_names - seen_names)
     if missing:

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_status.py
@@ -205,6 +205,50 @@ def governance_control_status(
     }
 
 
+def external_orchestrator_consumer_status(
+    *,
+    control_status: dict[str, object],
+    provenance: dict[str, object],
+    recovery_readiness: dict[str, object],
+) -> dict[str, object]:
+    gate_chain = control_status.get("gate_chain")
+    if not isinstance(gate_chain, list):
+        gate_chain = []
+    external_gates = []
+    for gate in gate_chain:
+        if not isinstance(gate, dict):
+            continue
+        external_gates.append(
+            {
+                "name": gate.get("name"),
+                "result": gate.get("result"),
+                "classification": gate.get("classification"),
+                "missing_inputs": gate.get("missing_inputs", []),
+                "fallback_to": gate.get("fallback_to"),
+            }
+        )
+
+    return {
+        "schema_version": control_status.get("schema_version", "loom-governance-status/v2"),
+        "view": "external_orchestrator_consumer",
+        "result": control_status.get("result", "block"),
+        "current_gate": control_status.get("current_gate"),
+        "classifications": control_status.get("classifications", []),
+        "missing_inputs": control_status.get("missing_inputs", []),
+        "head_binding": control_status.get("head_binding", {}),
+        "gate_chain": external_gates,
+        "allowed_operations": ["status_read", "gate_read"],
+        "source_policy": {
+            "status_source": "derived_from_status_control_plane_v2",
+            "gate_source": "derived_from_governance_gate_chain",
+            "writeback": "recovery_entry_only",
+            "fallback_to": "current_checkpoint",
+        },
+        "provenance": provenance,
+        "recovery_readiness": recovery_readiness,
+    }
+
+
 def closeout_status_payload(
     *,
     github_status: dict[str, object],
@@ -535,6 +579,14 @@ def main(argv: list[str]) -> int:
         if result == "pass"
         else "status surface is readable, but one or more governance gates are still blocking or stale."
     )
+    provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    external_orchestrator = external_orchestrator_consumer_status(
+        control_status=control_status,
+        provenance=provenance,
+        recovery_readiness=recovery_readiness,
+    )
+
     return emit(
         {
             "command": "status",
@@ -543,8 +595,8 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
-            "provenance": report_provenance(context["report"]),
-            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "provenance": provenance,
+            "recovery_readiness": recovery_readiness,
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
@@ -586,6 +638,7 @@ def main(argv: list[str]) -> int:
             "ci_check_presence": ci_check_presence,
             "host_enforcement": host_enforcement,
             "governance_status": control_status,
+            "external_orchestrator": external_orchestrator,
             "governance_surface": governance_surface,
             "github": github_status,
         }

--- a/skills/loom-build/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -83,9 +83,10 @@ merge commit 反推执行入口。
 - `work_item_read`
 - `workspace_attach`
 - `recovery_writeback`
+- `status_read`
+- `gate_read`
 
-后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
-fact-chain，不得新增第二状态面。
+`status_read` 与 `gate_read` 必须消费同一 fact-chain，不得新增第二状态面。
 
 ## 5. Workspace Attach
 
@@ -126,7 +127,35 @@ orchestrator 私有 action。
 写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
 gate、review、validation、host action 或 closeout authored fields。
 
-## 7. Truth Boundary
+## 7. Status / Gate Consumption
+
+外部 orchestrator 可以只读消费 `status control plane v2` 与现有 gate chain。
+
+它读取的状态必须与 Loom 本地入口同源：
+
+- `schema_version` 继续使用 `loom-governance-status/v2`
+- `result`、`current_gate`、`classifications`、`missing_inputs`、`head_binding`
+  与 `gate_chain` 来自同一个 status control plane
+- `provenance` 继续指向 Work Item、recovery entry、review / checkpoint / host mirror
+  等既有来源
+
+外部 orchestrator 视图只能是 consumer view。它可以裁剪字段以便消费，但不得定义
+新的 status schema、不得 authored `pass | block`、不得替换 gate chain。
+
+当 status/gate 读取无法消费时，回退只能指向 Loom checkpoint 或 gate 前置修复，例如：
+
+- `current_checkpoint`
+- `spec_gate`
+- `build_gate`
+- `review_gate`
+- `merge_gate`
+- `admission`
+- `binding_repair`
+
+不得回退到 scheduler 私有 action、retry queue、tracker state 或 orchestrator-owned
+decision。
+
+## 8. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -146,7 +175,7 @@ gate、review、validation、host action 或 closeout authored fields。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 8. 非目标
+## 9. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-build/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -286,6 +286,30 @@
 `provenance` 是读取说明，不是新的 authored 字段组。它可以在 JSON 输出中按字段内联，也可以作为并列索引输出，但必须能被机械入口追溯到具体字段。
 若一个字段组混合消费多个来源，provenance 必须能下钻到字段级，不能用组级 provenance 掩盖局部 stale / drift。
 
+### 3.12 `external_orchestrator`
+
+当外部 orchestrator 只读消费 status / gate 时，状态面可以暴露派生 consumer view：
+
+- `schema_version`: 继续使用 `loom-governance-status/v2`
+- `view`: 固定为 `external_orchestrator_consumer`
+- `result`
+- `current_gate`
+- `classifications`
+- `missing_inputs`
+- `head_binding`
+- `gate_chain`
+- `allowed_operations`
+- `source_policy`
+- `provenance`
+- `recovery_readiness`
+
+该字段组只能投影本状态面的 `governance_status` 与 provenance。它不得定义第二套 status
+schema，不得 authored gate verdict，不得成为 scheduler state 或 tracker state。
+
+`allowed_operations` 只能声明 `status_read` 与 `gate_read`。`source_policy` 必须说明 status
+来自 `status control plane v2`、gate 来自现有 governance gate chain、writeback 只能回到
+recovery entry，失败回退只能指向 Loom checkpoint 或 gate 前置修复。
+
 ## 4. 总结果语义
 
 统一状态控制面本身只允许输出：

--- a/skills/loom-build/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/governance_surface.py
@@ -428,6 +428,8 @@ EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
     "workspace_attach",
     "recovery_writeback",
+    "status_read",
+    "gate_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2123,7 +2125,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`, `status_read`, `gate_read`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -4666,6 +4666,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 classifications = governance_status.get("classifications")
                 if not isinstance(classifications, list):
                     failures.append(Failure("daily-execution-cli", "`loom_status` governance_status must include classifications"))
+            external_orchestrator = payload.get("external_orchestrator")
+            if not isinstance(external_orchestrator, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `external_orchestrator` consumer view"))
+            else:
+                if external_orchestrator.get("schema_version") != "loom-governance-status/v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse governance status schema v2"))
+                if external_orchestrator.get("view") != "external_orchestrator_consumer":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator view must be consumer-only"))
+                if external_orchestrator.get("result") not in {"pass", "block"}:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator result must be `pass` or `block`"))
+                if external_orchestrator.get("allowed_operations") != ["status_read", "gate_read"]:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must expose only read operations"))
+                if not isinstance(external_orchestrator.get("gate_chain"), list):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse gate_chain"))
+                source_policy = external_orchestrator.get("source_policy")
+                if not isinstance(source_policy, dict):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must include source_policy"))
+                elif source_policy.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator fallback must point to Loom checkpoint"))
+                elif source_policy.get("status_source") != "derived_from_status_control_plane_v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read status from status control plane v2"))
+                elif source_policy.get("gate_source") != "derived_from_governance_gate_chain":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read gates from the governance gate chain"))
+                external_provenance = external_orchestrator.get("provenance")
+                if not (
+                    isinstance(external_provenance, dict)
+                    or (isinstance(external_provenance, list) and external_provenance)
+                ):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must carry provenance"))
             closeout = payload.get("closeout")
             if not isinstance(closeout, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `closeout`"))
@@ -9272,6 +9301,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-status.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "status_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "status_schema_version": "loom-governance-status/v2"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-gate.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "gate_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "gate_chain": "status_control_plane_v2"},
+                "consumed_as": "summary",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9370,6 +9417,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "required",
                 "fallback_to": "build",
+            },
+            {
+                "id": "fake-external-orchestrator-status",
+                "summary": "Read status control plane v2 without defining a second status surface.",
+                "surfaces": ["merge_ready"],
+                "operations": ["status_read"],
+                "locator": "host/external-orchestrator-status.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "current_checkpoint",
+            },
+            {
+                "id": "fake-external-orchestrator-gate",
+                "summary": "Read the Loom gate chain without authoring a gate verdict.",
+                "surfaces": ["merge_ready"],
+                "operations": ["gate_read"],
+                "locator": "host/external-orchestrator-gate.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "review_gate",
             },
         ],
         "shadow_surfaces": {
@@ -9736,6 +9803,24 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "workspace-attach-present",
         "recovery-writeback-present",
         "direct-status-write-block",
+        "status-read-present",
+        "gate-read-present",
+        "scheduler-private-fallback-block",
+    }
+    allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"}
+    loom_fallbacks = {
+        "work_item",
+        "admission",
+        "binding_repair",
+        "current_checkpoint",
+        "spec_gate",
+        "build_gate",
+        "review_gate",
+        "merge_gate",
+        "merge_ready",
+        "build",
+        "review",
+        "closeout",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9746,6 +9831,7 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
         else:
             seen_names.add(name)
+        expect = fixture.get("expect")
         entry = fixture.get("entry")
         if not isinstance(entry, dict):
             failures.append(Failure(category, f"{name or index} entry must be an object"))
@@ -9761,23 +9847,35 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
             if not isinstance(operations, list) or not operations:
                 failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
             elif any(operation not in allowed_operations for operation in operations):
                 failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
+            fallback_to = entry.get("fallback_to")
+            if (
+                isinstance(fallback_to, str)
+                and fallback_to not in loom_fallbacks
+                and (not isinstance(expect, dict) or expect.get("result") != "block")
+            ):
+                failures.append(Failure(category, f"{name or index} fallback_to must point to a Loom checkpoint or gate repair surface"))
         payload = fixture.get("payload")
-        expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
             failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
         if payload is not None:
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                if payload.get("operation") not in allowed_operations:
                     failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                payload_fallback = payload.get("fallback_to")
+                if (
+                    isinstance(payload_fallback, str)
+                    and payload_fallback not in loom_fallbacks
+                    and (not isinstance(expect, dict) or expect.get("result") != "block")
+                ):
+                    failures.append(Failure(category, f"{name or index} payload fallback_to must point to a Loom checkpoint or gate repair surface"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
                 if forbidden and expect.get("result") != "block":
                     failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
@@ -9785,6 +9883,27 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
                     failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
                 if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
                     failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+                if payload.get("operation") in {"status_read", "gate_read"}:
+                    if payload.get("source_layer") != "derived_surface":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must consume the derived status surface"))
+                    if payload.get("consumed_as") != "summary":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must be consumed as summary, not authored truth"))
+                    if payload.get("operation") == "status_read":
+                        status_fields = payload.get("status_fields")
+                        required_status_fields = {"result", "current_gate", "classifications", "missing_inputs", "head_binding", "gate_chain", "provenance"}
+                        if not isinstance(status_fields, list) or not required_status_fields.issubset(set(status_fields)):
+                            failures.append(Failure(category, f"{name or index} status_read fixture must reuse status control plane v2 fields"))
+                    if payload.get("operation") == "gate_read":
+                        gate_fields = payload.get("gate_fields")
+                        required_gate_fields = {"name", "result", "classification", "missing_inputs", "fallback_to"}
+                        if expect.get("result") != "block" and (not isinstance(gate_fields, list) or not required_gate_fields.issubset(set(gate_fields))):
+                            failures.append(Failure(category, f"{name or index} gate_read fixture must reuse the existing gate chain fields"))
+                if name == "scheduler-private-fallback-block" and expect.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure(category, "scheduler-private fallback fixture must fallback to `current_checkpoint`"))
+                if name == "scheduler-private-fallback-block":
+                    entry_fallback = entry.get("fallback_to") if isinstance(entry, dict) else None
+                    if entry_fallback in loom_fallbacks or payload.get("fallback_to") in loom_fallbacks:
+                        failures.append(Failure(category, "scheduler-private fallback fixture must prove a private fallback is blocked"))
 
     missing = sorted(required_names - seen_names)
     if missing:

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_status.py
@@ -205,6 +205,50 @@ def governance_control_status(
     }
 
 
+def external_orchestrator_consumer_status(
+    *,
+    control_status: dict[str, object],
+    provenance: dict[str, object],
+    recovery_readiness: dict[str, object],
+) -> dict[str, object]:
+    gate_chain = control_status.get("gate_chain")
+    if not isinstance(gate_chain, list):
+        gate_chain = []
+    external_gates = []
+    for gate in gate_chain:
+        if not isinstance(gate, dict):
+            continue
+        external_gates.append(
+            {
+                "name": gate.get("name"),
+                "result": gate.get("result"),
+                "classification": gate.get("classification"),
+                "missing_inputs": gate.get("missing_inputs", []),
+                "fallback_to": gate.get("fallback_to"),
+            }
+        )
+
+    return {
+        "schema_version": control_status.get("schema_version", "loom-governance-status/v2"),
+        "view": "external_orchestrator_consumer",
+        "result": control_status.get("result", "block"),
+        "current_gate": control_status.get("current_gate"),
+        "classifications": control_status.get("classifications", []),
+        "missing_inputs": control_status.get("missing_inputs", []),
+        "head_binding": control_status.get("head_binding", {}),
+        "gate_chain": external_gates,
+        "allowed_operations": ["status_read", "gate_read"],
+        "source_policy": {
+            "status_source": "derived_from_status_control_plane_v2",
+            "gate_source": "derived_from_governance_gate_chain",
+            "writeback": "recovery_entry_only",
+            "fallback_to": "current_checkpoint",
+        },
+        "provenance": provenance,
+        "recovery_readiness": recovery_readiness,
+    }
+
+
 def closeout_status_payload(
     *,
     github_status: dict[str, object],
@@ -535,6 +579,14 @@ def main(argv: list[str]) -> int:
         if result == "pass"
         else "status surface is readable, but one or more governance gates are still blocking or stale."
     )
+    provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    external_orchestrator = external_orchestrator_consumer_status(
+        control_status=control_status,
+        provenance=provenance,
+        recovery_readiness=recovery_readiness,
+    )
+
     return emit(
         {
             "command": "status",
@@ -543,8 +595,8 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
-            "provenance": report_provenance(context["report"]),
-            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "provenance": provenance,
+            "recovery_readiness": recovery_readiness,
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
@@ -586,6 +638,7 @@ def main(argv: list[str]) -> int:
             "ci_check_presence": ci_check_presence,
             "host_enforcement": host_enforcement,
             "governance_status": control_status,
+            "external_orchestrator": external_orchestrator,
             "governance_surface": governance_surface,
             "github": github_status,
         }

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -83,9 +83,10 @@ merge commit 反推执行入口。
 - `work_item_read`
 - `workspace_attach`
 - `recovery_writeback`
+- `status_read`
+- `gate_read`
 
-后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
-fact-chain，不得新增第二状态面。
+`status_read` 与 `gate_read` 必须消费同一 fact-chain，不得新增第二状态面。
 
 ## 5. Workspace Attach
 
@@ -126,7 +127,35 @@ orchestrator 私有 action。
 写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
 gate、review、validation、host action 或 closeout authored fields。
 
-## 7. Truth Boundary
+## 7. Status / Gate Consumption
+
+外部 orchestrator 可以只读消费 `status control plane v2` 与现有 gate chain。
+
+它读取的状态必须与 Loom 本地入口同源：
+
+- `schema_version` 继续使用 `loom-governance-status/v2`
+- `result`、`current_gate`、`classifications`、`missing_inputs`、`head_binding`
+  与 `gate_chain` 来自同一个 status control plane
+- `provenance` 继续指向 Work Item、recovery entry、review / checkpoint / host mirror
+  等既有来源
+
+外部 orchestrator 视图只能是 consumer view。它可以裁剪字段以便消费，但不得定义
+新的 status schema、不得 authored `pass | block`、不得替换 gate chain。
+
+当 status/gate 读取无法消费时，回退只能指向 Loom checkpoint 或 gate 前置修复，例如：
+
+- `current_checkpoint`
+- `spec_gate`
+- `build_gate`
+- `review_gate`
+- `merge_gate`
+- `admission`
+- `binding_repair`
+
+不得回退到 scheduler 私有 action、retry queue、tracker state 或 orchestrator-owned
+decision。
+
+## 8. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -146,7 +175,7 @@ gate、review、validation、host action 或 closeout authored fields。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 8. 非目标
+## 9. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -286,6 +286,30 @@
 `provenance` 是读取说明，不是新的 authored 字段组。它可以在 JSON 输出中按字段内联，也可以作为并列索引输出，但必须能被机械入口追溯到具体字段。
 若一个字段组混合消费多个来源，provenance 必须能下钻到字段级，不能用组级 provenance 掩盖局部 stale / drift。
 
+### 3.12 `external_orchestrator`
+
+当外部 orchestrator 只读消费 status / gate 时，状态面可以暴露派生 consumer view：
+
+- `schema_version`: 继续使用 `loom-governance-status/v2`
+- `view`: 固定为 `external_orchestrator_consumer`
+- `result`
+- `current_gate`
+- `classifications`
+- `missing_inputs`
+- `head_binding`
+- `gate_chain`
+- `allowed_operations`
+- `source_policy`
+- `provenance`
+- `recovery_readiness`
+
+该字段组只能投影本状态面的 `governance_status` 与 provenance。它不得定义第二套 status
+schema，不得 authored gate verdict，不得成为 scheduler state 或 tracker state。
+
+`allowed_operations` 只能声明 `status_read` 与 `gate_read`。`source_policy` 必须说明 status
+来自 `status control plane v2`、gate 来自现有 governance gate chain、writeback 只能回到
+recovery entry，失败回退只能指向 Loom checkpoint 或 gate 前置修复。
+
 ## 4. 总结果语义
 
 统一状态控制面本身只允许输出：

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/governance_surface.py
@@ -428,6 +428,8 @@ EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
     "workspace_attach",
     "recovery_writeback",
+    "status_read",
+    "gate_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2123,7 +2125,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`, `status_read`, `gate_read`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -4666,6 +4666,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 classifications = governance_status.get("classifications")
                 if not isinstance(classifications, list):
                     failures.append(Failure("daily-execution-cli", "`loom_status` governance_status must include classifications"))
+            external_orchestrator = payload.get("external_orchestrator")
+            if not isinstance(external_orchestrator, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `external_orchestrator` consumer view"))
+            else:
+                if external_orchestrator.get("schema_version") != "loom-governance-status/v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse governance status schema v2"))
+                if external_orchestrator.get("view") != "external_orchestrator_consumer":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator view must be consumer-only"))
+                if external_orchestrator.get("result") not in {"pass", "block"}:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator result must be `pass` or `block`"))
+                if external_orchestrator.get("allowed_operations") != ["status_read", "gate_read"]:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must expose only read operations"))
+                if not isinstance(external_orchestrator.get("gate_chain"), list):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse gate_chain"))
+                source_policy = external_orchestrator.get("source_policy")
+                if not isinstance(source_policy, dict):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must include source_policy"))
+                elif source_policy.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator fallback must point to Loom checkpoint"))
+                elif source_policy.get("status_source") != "derived_from_status_control_plane_v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read status from status control plane v2"))
+                elif source_policy.get("gate_source") != "derived_from_governance_gate_chain":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read gates from the governance gate chain"))
+                external_provenance = external_orchestrator.get("provenance")
+                if not (
+                    isinstance(external_provenance, dict)
+                    or (isinstance(external_provenance, list) and external_provenance)
+                ):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must carry provenance"))
             closeout = payload.get("closeout")
             if not isinstance(closeout, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `closeout`"))
@@ -9272,6 +9301,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-status.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "status_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "status_schema_version": "loom-governance-status/v2"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-gate.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "gate_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "gate_chain": "status_control_plane_v2"},
+                "consumed_as": "summary",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9370,6 +9417,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "required",
                 "fallback_to": "build",
+            },
+            {
+                "id": "fake-external-orchestrator-status",
+                "summary": "Read status control plane v2 without defining a second status surface.",
+                "surfaces": ["merge_ready"],
+                "operations": ["status_read"],
+                "locator": "host/external-orchestrator-status.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "current_checkpoint",
+            },
+            {
+                "id": "fake-external-orchestrator-gate",
+                "summary": "Read the Loom gate chain without authoring a gate verdict.",
+                "surfaces": ["merge_ready"],
+                "operations": ["gate_read"],
+                "locator": "host/external-orchestrator-gate.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "review_gate",
             },
         ],
         "shadow_surfaces": {
@@ -9736,6 +9803,24 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "workspace-attach-present",
         "recovery-writeback-present",
         "direct-status-write-block",
+        "status-read-present",
+        "gate-read-present",
+        "scheduler-private-fallback-block",
+    }
+    allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"}
+    loom_fallbacks = {
+        "work_item",
+        "admission",
+        "binding_repair",
+        "current_checkpoint",
+        "spec_gate",
+        "build_gate",
+        "review_gate",
+        "merge_gate",
+        "merge_ready",
+        "build",
+        "review",
+        "closeout",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9746,6 +9831,7 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
         else:
             seen_names.add(name)
+        expect = fixture.get("expect")
         entry = fixture.get("entry")
         if not isinstance(entry, dict):
             failures.append(Failure(category, f"{name or index} entry must be an object"))
@@ -9761,23 +9847,35 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
             if not isinstance(operations, list) or not operations:
                 failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
             elif any(operation not in allowed_operations for operation in operations):
                 failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
+            fallback_to = entry.get("fallback_to")
+            if (
+                isinstance(fallback_to, str)
+                and fallback_to not in loom_fallbacks
+                and (not isinstance(expect, dict) or expect.get("result") != "block")
+            ):
+                failures.append(Failure(category, f"{name or index} fallback_to must point to a Loom checkpoint or gate repair surface"))
         payload = fixture.get("payload")
-        expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
             failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
         if payload is not None:
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                if payload.get("operation") not in allowed_operations:
                     failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                payload_fallback = payload.get("fallback_to")
+                if (
+                    isinstance(payload_fallback, str)
+                    and payload_fallback not in loom_fallbacks
+                    and (not isinstance(expect, dict) or expect.get("result") != "block")
+                ):
+                    failures.append(Failure(category, f"{name or index} payload fallback_to must point to a Loom checkpoint or gate repair surface"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
                 if forbidden and expect.get("result") != "block":
                     failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
@@ -9785,6 +9883,27 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
                     failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
                 if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
                     failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+                if payload.get("operation") in {"status_read", "gate_read"}:
+                    if payload.get("source_layer") != "derived_surface":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must consume the derived status surface"))
+                    if payload.get("consumed_as") != "summary":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must be consumed as summary, not authored truth"))
+                    if payload.get("operation") == "status_read":
+                        status_fields = payload.get("status_fields")
+                        required_status_fields = {"result", "current_gate", "classifications", "missing_inputs", "head_binding", "gate_chain", "provenance"}
+                        if not isinstance(status_fields, list) or not required_status_fields.issubset(set(status_fields)):
+                            failures.append(Failure(category, f"{name or index} status_read fixture must reuse status control plane v2 fields"))
+                    if payload.get("operation") == "gate_read":
+                        gate_fields = payload.get("gate_fields")
+                        required_gate_fields = {"name", "result", "classification", "missing_inputs", "fallback_to"}
+                        if expect.get("result") != "block" and (not isinstance(gate_fields, list) or not required_gate_fields.issubset(set(gate_fields))):
+                            failures.append(Failure(category, f"{name or index} gate_read fixture must reuse the existing gate chain fields"))
+                if name == "scheduler-private-fallback-block" and expect.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure(category, "scheduler-private fallback fixture must fallback to `current_checkpoint`"))
+                if name == "scheduler-private-fallback-block":
+                    entry_fallback = entry.get("fallback_to") if isinstance(entry, dict) else None
+                    if entry_fallback in loom_fallbacks or payload.get("fallback_to") in loom_fallbacks:
+                        failures.append(Failure(category, "scheduler-private fallback fixture must prove a private fallback is blocked"))
 
     missing = sorted(required_names - seen_names)
     if missing:

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_status.py
@@ -205,6 +205,50 @@ def governance_control_status(
     }
 
 
+def external_orchestrator_consumer_status(
+    *,
+    control_status: dict[str, object],
+    provenance: dict[str, object],
+    recovery_readiness: dict[str, object],
+) -> dict[str, object]:
+    gate_chain = control_status.get("gate_chain")
+    if not isinstance(gate_chain, list):
+        gate_chain = []
+    external_gates = []
+    for gate in gate_chain:
+        if not isinstance(gate, dict):
+            continue
+        external_gates.append(
+            {
+                "name": gate.get("name"),
+                "result": gate.get("result"),
+                "classification": gate.get("classification"),
+                "missing_inputs": gate.get("missing_inputs", []),
+                "fallback_to": gate.get("fallback_to"),
+            }
+        )
+
+    return {
+        "schema_version": control_status.get("schema_version", "loom-governance-status/v2"),
+        "view": "external_orchestrator_consumer",
+        "result": control_status.get("result", "block"),
+        "current_gate": control_status.get("current_gate"),
+        "classifications": control_status.get("classifications", []),
+        "missing_inputs": control_status.get("missing_inputs", []),
+        "head_binding": control_status.get("head_binding", {}),
+        "gate_chain": external_gates,
+        "allowed_operations": ["status_read", "gate_read"],
+        "source_policy": {
+            "status_source": "derived_from_status_control_plane_v2",
+            "gate_source": "derived_from_governance_gate_chain",
+            "writeback": "recovery_entry_only",
+            "fallback_to": "current_checkpoint",
+        },
+        "provenance": provenance,
+        "recovery_readiness": recovery_readiness,
+    }
+
+
 def closeout_status_payload(
     *,
     github_status: dict[str, object],
@@ -535,6 +579,14 @@ def main(argv: list[str]) -> int:
         if result == "pass"
         else "status surface is readable, but one or more governance gates are still blocking or stale."
     )
+    provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    external_orchestrator = external_orchestrator_consumer_status(
+        control_status=control_status,
+        provenance=provenance,
+        recovery_readiness=recovery_readiness,
+    )
+
     return emit(
         {
             "command": "status",
@@ -543,8 +595,8 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
-            "provenance": report_provenance(context["report"]),
-            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "provenance": provenance,
+            "recovery_readiness": recovery_readiness,
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
@@ -586,6 +638,7 @@ def main(argv: list[str]) -> int:
             "ci_check_presence": ci_check_presence,
             "host_enforcement": host_enforcement,
             "governance_status": control_status,
+            "external_orchestrator": external_orchestrator,
             "governance_surface": governance_surface,
             "github": github_status,
         }

--- a/skills/loom-init/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -83,9 +83,10 @@ merge commit 反推执行入口。
 - `work_item_read`
 - `workspace_attach`
 - `recovery_writeback`
+- `status_read`
+- `gate_read`
 
-后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
-fact-chain，不得新增第二状态面。
+`status_read` 与 `gate_read` 必须消费同一 fact-chain，不得新增第二状态面。
 
 ## 5. Workspace Attach
 
@@ -126,7 +127,35 @@ orchestrator 私有 action。
 写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
 gate、review、validation、host action 或 closeout authored fields。
 
-## 7. Truth Boundary
+## 7. Status / Gate Consumption
+
+外部 orchestrator 可以只读消费 `status control plane v2` 与现有 gate chain。
+
+它读取的状态必须与 Loom 本地入口同源：
+
+- `schema_version` 继续使用 `loom-governance-status/v2`
+- `result`、`current_gate`、`classifications`、`missing_inputs`、`head_binding`
+  与 `gate_chain` 来自同一个 status control plane
+- `provenance` 继续指向 Work Item、recovery entry、review / checkpoint / host mirror
+  等既有来源
+
+外部 orchestrator 视图只能是 consumer view。它可以裁剪字段以便消费，但不得定义
+新的 status schema、不得 authored `pass | block`、不得替换 gate chain。
+
+当 status/gate 读取无法消费时，回退只能指向 Loom checkpoint 或 gate 前置修复，例如：
+
+- `current_checkpoint`
+- `spec_gate`
+- `build_gate`
+- `review_gate`
+- `merge_gate`
+- `admission`
+- `binding_repair`
+
+不得回退到 scheduler 私有 action、retry queue、tracker state 或 orchestrator-owned
+decision。
+
+## 8. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -146,7 +175,7 @@ gate、review、validation、host action 或 closeout authored fields。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 8. 非目标
+## 9. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-init/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -286,6 +286,30 @@
 `provenance` 是读取说明，不是新的 authored 字段组。它可以在 JSON 输出中按字段内联，也可以作为并列索引输出，但必须能被机械入口追溯到具体字段。
 若一个字段组混合消费多个来源，provenance 必须能下钻到字段级，不能用组级 provenance 掩盖局部 stale / drift。
 
+### 3.12 `external_orchestrator`
+
+当外部 orchestrator 只读消费 status / gate 时，状态面可以暴露派生 consumer view：
+
+- `schema_version`: 继续使用 `loom-governance-status/v2`
+- `view`: 固定为 `external_orchestrator_consumer`
+- `result`
+- `current_gate`
+- `classifications`
+- `missing_inputs`
+- `head_binding`
+- `gate_chain`
+- `allowed_operations`
+- `source_policy`
+- `provenance`
+- `recovery_readiness`
+
+该字段组只能投影本状态面的 `governance_status` 与 provenance。它不得定义第二套 status
+schema，不得 authored gate verdict，不得成为 scheduler state 或 tracker state。
+
+`allowed_operations` 只能声明 `status_read` 与 `gate_read`。`source_policy` 必须说明 status
+来自 `status control plane v2`、gate 来自现有 governance gate chain、writeback 只能回到
+recovery entry，失败回退只能指向 Loom checkpoint 或 gate 前置修复。
+
 ## 4. 总结果语义
 
 统一状态控制面本身只允许输出：

--- a/skills/loom-init/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/governance_surface.py
@@ -428,6 +428,8 @@ EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
     "workspace_attach",
     "recovery_writeback",
+    "status_read",
+    "gate_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2123,7 +2125,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`, `status_read`, `gate_read`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -4666,6 +4666,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 classifications = governance_status.get("classifications")
                 if not isinstance(classifications, list):
                     failures.append(Failure("daily-execution-cli", "`loom_status` governance_status must include classifications"))
+            external_orchestrator = payload.get("external_orchestrator")
+            if not isinstance(external_orchestrator, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `external_orchestrator` consumer view"))
+            else:
+                if external_orchestrator.get("schema_version") != "loom-governance-status/v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse governance status schema v2"))
+                if external_orchestrator.get("view") != "external_orchestrator_consumer":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator view must be consumer-only"))
+                if external_orchestrator.get("result") not in {"pass", "block"}:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator result must be `pass` or `block`"))
+                if external_orchestrator.get("allowed_operations") != ["status_read", "gate_read"]:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must expose only read operations"))
+                if not isinstance(external_orchestrator.get("gate_chain"), list):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse gate_chain"))
+                source_policy = external_orchestrator.get("source_policy")
+                if not isinstance(source_policy, dict):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must include source_policy"))
+                elif source_policy.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator fallback must point to Loom checkpoint"))
+                elif source_policy.get("status_source") != "derived_from_status_control_plane_v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read status from status control plane v2"))
+                elif source_policy.get("gate_source") != "derived_from_governance_gate_chain":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read gates from the governance gate chain"))
+                external_provenance = external_orchestrator.get("provenance")
+                if not (
+                    isinstance(external_provenance, dict)
+                    or (isinstance(external_provenance, list) and external_provenance)
+                ):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must carry provenance"))
             closeout = payload.get("closeout")
             if not isinstance(closeout, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `closeout`"))
@@ -9272,6 +9301,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-status.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "status_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "status_schema_version": "loom-governance-status/v2"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-gate.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "gate_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "gate_chain": "status_control_plane_v2"},
+                "consumed_as": "summary",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9370,6 +9417,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "required",
                 "fallback_to": "build",
+            },
+            {
+                "id": "fake-external-orchestrator-status",
+                "summary": "Read status control plane v2 without defining a second status surface.",
+                "surfaces": ["merge_ready"],
+                "operations": ["status_read"],
+                "locator": "host/external-orchestrator-status.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "current_checkpoint",
+            },
+            {
+                "id": "fake-external-orchestrator-gate",
+                "summary": "Read the Loom gate chain without authoring a gate verdict.",
+                "surfaces": ["merge_ready"],
+                "operations": ["gate_read"],
+                "locator": "host/external-orchestrator-gate.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "review_gate",
             },
         ],
         "shadow_surfaces": {
@@ -9736,6 +9803,24 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "workspace-attach-present",
         "recovery-writeback-present",
         "direct-status-write-block",
+        "status-read-present",
+        "gate-read-present",
+        "scheduler-private-fallback-block",
+    }
+    allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"}
+    loom_fallbacks = {
+        "work_item",
+        "admission",
+        "binding_repair",
+        "current_checkpoint",
+        "spec_gate",
+        "build_gate",
+        "review_gate",
+        "merge_gate",
+        "merge_ready",
+        "build",
+        "review",
+        "closeout",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9746,6 +9831,7 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
         else:
             seen_names.add(name)
+        expect = fixture.get("expect")
         entry = fixture.get("entry")
         if not isinstance(entry, dict):
             failures.append(Failure(category, f"{name or index} entry must be an object"))
@@ -9761,23 +9847,35 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
             if not isinstance(operations, list) or not operations:
                 failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
             elif any(operation not in allowed_operations for operation in operations):
                 failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
+            fallback_to = entry.get("fallback_to")
+            if (
+                isinstance(fallback_to, str)
+                and fallback_to not in loom_fallbacks
+                and (not isinstance(expect, dict) or expect.get("result") != "block")
+            ):
+                failures.append(Failure(category, f"{name or index} fallback_to must point to a Loom checkpoint or gate repair surface"))
         payload = fixture.get("payload")
-        expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
             failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
         if payload is not None:
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                if payload.get("operation") not in allowed_operations:
                     failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                payload_fallback = payload.get("fallback_to")
+                if (
+                    isinstance(payload_fallback, str)
+                    and payload_fallback not in loom_fallbacks
+                    and (not isinstance(expect, dict) or expect.get("result") != "block")
+                ):
+                    failures.append(Failure(category, f"{name or index} payload fallback_to must point to a Loom checkpoint or gate repair surface"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
                 if forbidden and expect.get("result") != "block":
                     failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
@@ -9785,6 +9883,27 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
                     failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
                 if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
                     failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+                if payload.get("operation") in {"status_read", "gate_read"}:
+                    if payload.get("source_layer") != "derived_surface":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must consume the derived status surface"))
+                    if payload.get("consumed_as") != "summary":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must be consumed as summary, not authored truth"))
+                    if payload.get("operation") == "status_read":
+                        status_fields = payload.get("status_fields")
+                        required_status_fields = {"result", "current_gate", "classifications", "missing_inputs", "head_binding", "gate_chain", "provenance"}
+                        if not isinstance(status_fields, list) or not required_status_fields.issubset(set(status_fields)):
+                            failures.append(Failure(category, f"{name or index} status_read fixture must reuse status control plane v2 fields"))
+                    if payload.get("operation") == "gate_read":
+                        gate_fields = payload.get("gate_fields")
+                        required_gate_fields = {"name", "result", "classification", "missing_inputs", "fallback_to"}
+                        if expect.get("result") != "block" and (not isinstance(gate_fields, list) or not required_gate_fields.issubset(set(gate_fields))):
+                            failures.append(Failure(category, f"{name or index} gate_read fixture must reuse the existing gate chain fields"))
+                if name == "scheduler-private-fallback-block" and expect.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure(category, "scheduler-private fallback fixture must fallback to `current_checkpoint`"))
+                if name == "scheduler-private-fallback-block":
+                    entry_fallback = entry.get("fallback_to") if isinstance(entry, dict) else None
+                    if entry_fallback in loom_fallbacks or payload.get("fallback_to") in loom_fallbacks:
+                        failures.append(Failure(category, "scheduler-private fallback fixture must prove a private fallback is blocked"))
 
     missing = sorted(required_names - seen_names)
     if missing:

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_status.py
@@ -205,6 +205,50 @@ def governance_control_status(
     }
 
 
+def external_orchestrator_consumer_status(
+    *,
+    control_status: dict[str, object],
+    provenance: dict[str, object],
+    recovery_readiness: dict[str, object],
+) -> dict[str, object]:
+    gate_chain = control_status.get("gate_chain")
+    if not isinstance(gate_chain, list):
+        gate_chain = []
+    external_gates = []
+    for gate in gate_chain:
+        if not isinstance(gate, dict):
+            continue
+        external_gates.append(
+            {
+                "name": gate.get("name"),
+                "result": gate.get("result"),
+                "classification": gate.get("classification"),
+                "missing_inputs": gate.get("missing_inputs", []),
+                "fallback_to": gate.get("fallback_to"),
+            }
+        )
+
+    return {
+        "schema_version": control_status.get("schema_version", "loom-governance-status/v2"),
+        "view": "external_orchestrator_consumer",
+        "result": control_status.get("result", "block"),
+        "current_gate": control_status.get("current_gate"),
+        "classifications": control_status.get("classifications", []),
+        "missing_inputs": control_status.get("missing_inputs", []),
+        "head_binding": control_status.get("head_binding", {}),
+        "gate_chain": external_gates,
+        "allowed_operations": ["status_read", "gate_read"],
+        "source_policy": {
+            "status_source": "derived_from_status_control_plane_v2",
+            "gate_source": "derived_from_governance_gate_chain",
+            "writeback": "recovery_entry_only",
+            "fallback_to": "current_checkpoint",
+        },
+        "provenance": provenance,
+        "recovery_readiness": recovery_readiness,
+    }
+
+
 def closeout_status_payload(
     *,
     github_status: dict[str, object],
@@ -535,6 +579,14 @@ def main(argv: list[str]) -> int:
         if result == "pass"
         else "status surface is readable, but one or more governance gates are still blocking or stale."
     )
+    provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    external_orchestrator = external_orchestrator_consumer_status(
+        control_status=control_status,
+        provenance=provenance,
+        recovery_readiness=recovery_readiness,
+    )
+
     return emit(
         {
             "command": "status",
@@ -543,8 +595,8 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
-            "provenance": report_provenance(context["report"]),
-            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "provenance": provenance,
+            "recovery_readiness": recovery_readiness,
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
@@ -586,6 +638,7 @@ def main(argv: list[str]) -> int:
             "ci_check_presence": ci_check_presence,
             "host_enforcement": host_enforcement,
             "governance_status": control_status,
+            "external_orchestrator": external_orchestrator,
             "governance_surface": governance_surface,
             "github": github_status,
         }

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -83,9 +83,10 @@ merge commit 反推执行入口。
 - `work_item_read`
 - `workspace_attach`
 - `recovery_writeback`
+- `status_read`
+- `gate_read`
 
-后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
-fact-chain，不得新增第二状态面。
+`status_read` 与 `gate_read` 必须消费同一 fact-chain，不得新增第二状态面。
 
 ## 5. Workspace Attach
 
@@ -126,7 +127,35 @@ orchestrator 私有 action。
 写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
 gate、review、validation、host action 或 closeout authored fields。
 
-## 7. Truth Boundary
+## 7. Status / Gate Consumption
+
+外部 orchestrator 可以只读消费 `status control plane v2` 与现有 gate chain。
+
+它读取的状态必须与 Loom 本地入口同源：
+
+- `schema_version` 继续使用 `loom-governance-status/v2`
+- `result`、`current_gate`、`classifications`、`missing_inputs`、`head_binding`
+  与 `gate_chain` 来自同一个 status control plane
+- `provenance` 继续指向 Work Item、recovery entry、review / checkpoint / host mirror
+  等既有来源
+
+外部 orchestrator 视图只能是 consumer view。它可以裁剪字段以便消费，但不得定义
+新的 status schema、不得 authored `pass | block`、不得替换 gate chain。
+
+当 status/gate 读取无法消费时，回退只能指向 Loom checkpoint 或 gate 前置修复，例如：
+
+- `current_checkpoint`
+- `spec_gate`
+- `build_gate`
+- `review_gate`
+- `merge_gate`
+- `admission`
+- `binding_repair`
+
+不得回退到 scheduler 私有 action、retry queue、tracker state 或 orchestrator-owned
+decision。
+
+## 8. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -146,7 +175,7 @@ gate、review、validation、host action 或 closeout authored fields。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 8. 非目标
+## 9. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -286,6 +286,30 @@
 `provenance` 是读取说明，不是新的 authored 字段组。它可以在 JSON 输出中按字段内联，也可以作为并列索引输出，但必须能被机械入口追溯到具体字段。
 若一个字段组混合消费多个来源，provenance 必须能下钻到字段级，不能用组级 provenance 掩盖局部 stale / drift。
 
+### 3.12 `external_orchestrator`
+
+当外部 orchestrator 只读消费 status / gate 时，状态面可以暴露派生 consumer view：
+
+- `schema_version`: 继续使用 `loom-governance-status/v2`
+- `view`: 固定为 `external_orchestrator_consumer`
+- `result`
+- `current_gate`
+- `classifications`
+- `missing_inputs`
+- `head_binding`
+- `gate_chain`
+- `allowed_operations`
+- `source_policy`
+- `provenance`
+- `recovery_readiness`
+
+该字段组只能投影本状态面的 `governance_status` 与 provenance。它不得定义第二套 status
+schema，不得 authored gate verdict，不得成为 scheduler state 或 tracker state。
+
+`allowed_operations` 只能声明 `status_read` 与 `gate_read`。`source_policy` 必须说明 status
+来自 `status control plane v2`、gate 来自现有 governance gate chain、writeback 只能回到
+recovery entry，失败回退只能指向 Loom checkpoint 或 gate 前置修复。
+
 ## 4. 总结果语义
 
 统一状态控制面本身只允许输出：

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/governance_surface.py
@@ -428,6 +428,8 @@ EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
     "workspace_attach",
     "recovery_writeback",
+    "status_read",
+    "gate_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2123,7 +2125,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`, `status_read`, `gate_read`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -4666,6 +4666,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 classifications = governance_status.get("classifications")
                 if not isinstance(classifications, list):
                     failures.append(Failure("daily-execution-cli", "`loom_status` governance_status must include classifications"))
+            external_orchestrator = payload.get("external_orchestrator")
+            if not isinstance(external_orchestrator, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `external_orchestrator` consumer view"))
+            else:
+                if external_orchestrator.get("schema_version") != "loom-governance-status/v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse governance status schema v2"))
+                if external_orchestrator.get("view") != "external_orchestrator_consumer":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator view must be consumer-only"))
+                if external_orchestrator.get("result") not in {"pass", "block"}:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator result must be `pass` or `block`"))
+                if external_orchestrator.get("allowed_operations") != ["status_read", "gate_read"]:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must expose only read operations"))
+                if not isinstance(external_orchestrator.get("gate_chain"), list):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse gate_chain"))
+                source_policy = external_orchestrator.get("source_policy")
+                if not isinstance(source_policy, dict):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must include source_policy"))
+                elif source_policy.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator fallback must point to Loom checkpoint"))
+                elif source_policy.get("status_source") != "derived_from_status_control_plane_v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read status from status control plane v2"))
+                elif source_policy.get("gate_source") != "derived_from_governance_gate_chain":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read gates from the governance gate chain"))
+                external_provenance = external_orchestrator.get("provenance")
+                if not (
+                    isinstance(external_provenance, dict)
+                    or (isinstance(external_provenance, list) and external_provenance)
+                ):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must carry provenance"))
             closeout = payload.get("closeout")
             if not isinstance(closeout, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `closeout`"))
@@ -9272,6 +9301,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-status.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "status_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "status_schema_version": "loom-governance-status/v2"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-gate.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "gate_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "gate_chain": "status_control_plane_v2"},
+                "consumed_as": "summary",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9370,6 +9417,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "required",
                 "fallback_to": "build",
+            },
+            {
+                "id": "fake-external-orchestrator-status",
+                "summary": "Read status control plane v2 without defining a second status surface.",
+                "surfaces": ["merge_ready"],
+                "operations": ["status_read"],
+                "locator": "host/external-orchestrator-status.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "current_checkpoint",
+            },
+            {
+                "id": "fake-external-orchestrator-gate",
+                "summary": "Read the Loom gate chain without authoring a gate verdict.",
+                "surfaces": ["merge_ready"],
+                "operations": ["gate_read"],
+                "locator": "host/external-orchestrator-gate.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "review_gate",
             },
         ],
         "shadow_surfaces": {
@@ -9736,6 +9803,24 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "workspace-attach-present",
         "recovery-writeback-present",
         "direct-status-write-block",
+        "status-read-present",
+        "gate-read-present",
+        "scheduler-private-fallback-block",
+    }
+    allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"}
+    loom_fallbacks = {
+        "work_item",
+        "admission",
+        "binding_repair",
+        "current_checkpoint",
+        "spec_gate",
+        "build_gate",
+        "review_gate",
+        "merge_gate",
+        "merge_ready",
+        "build",
+        "review",
+        "closeout",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9746,6 +9831,7 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
         else:
             seen_names.add(name)
+        expect = fixture.get("expect")
         entry = fixture.get("entry")
         if not isinstance(entry, dict):
             failures.append(Failure(category, f"{name or index} entry must be an object"))
@@ -9761,23 +9847,35 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
             if not isinstance(operations, list) or not operations:
                 failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
             elif any(operation not in allowed_operations for operation in operations):
                 failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
+            fallback_to = entry.get("fallback_to")
+            if (
+                isinstance(fallback_to, str)
+                and fallback_to not in loom_fallbacks
+                and (not isinstance(expect, dict) or expect.get("result") != "block")
+            ):
+                failures.append(Failure(category, f"{name or index} fallback_to must point to a Loom checkpoint or gate repair surface"))
         payload = fixture.get("payload")
-        expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
             failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
         if payload is not None:
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                if payload.get("operation") not in allowed_operations:
                     failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                payload_fallback = payload.get("fallback_to")
+                if (
+                    isinstance(payload_fallback, str)
+                    and payload_fallback not in loom_fallbacks
+                    and (not isinstance(expect, dict) or expect.get("result") != "block")
+                ):
+                    failures.append(Failure(category, f"{name or index} payload fallback_to must point to a Loom checkpoint or gate repair surface"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
                 if forbidden and expect.get("result") != "block":
                     failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
@@ -9785,6 +9883,27 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
                     failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
                 if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
                     failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+                if payload.get("operation") in {"status_read", "gate_read"}:
+                    if payload.get("source_layer") != "derived_surface":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must consume the derived status surface"))
+                    if payload.get("consumed_as") != "summary":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must be consumed as summary, not authored truth"))
+                    if payload.get("operation") == "status_read":
+                        status_fields = payload.get("status_fields")
+                        required_status_fields = {"result", "current_gate", "classifications", "missing_inputs", "head_binding", "gate_chain", "provenance"}
+                        if not isinstance(status_fields, list) or not required_status_fields.issubset(set(status_fields)):
+                            failures.append(Failure(category, f"{name or index} status_read fixture must reuse status control plane v2 fields"))
+                    if payload.get("operation") == "gate_read":
+                        gate_fields = payload.get("gate_fields")
+                        required_gate_fields = {"name", "result", "classification", "missing_inputs", "fallback_to"}
+                        if expect.get("result") != "block" and (not isinstance(gate_fields, list) or not required_gate_fields.issubset(set(gate_fields))):
+                            failures.append(Failure(category, f"{name or index} gate_read fixture must reuse the existing gate chain fields"))
+                if name == "scheduler-private-fallback-block" and expect.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure(category, "scheduler-private fallback fixture must fallback to `current_checkpoint`"))
+                if name == "scheduler-private-fallback-block":
+                    entry_fallback = entry.get("fallback_to") if isinstance(entry, dict) else None
+                    if entry_fallback in loom_fallbacks or payload.get("fallback_to") in loom_fallbacks:
+                        failures.append(Failure(category, "scheduler-private fallback fixture must prove a private fallback is blocked"))
 
     missing = sorted(required_names - seen_names)
     if missing:

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_status.py
@@ -205,6 +205,50 @@ def governance_control_status(
     }
 
 
+def external_orchestrator_consumer_status(
+    *,
+    control_status: dict[str, object],
+    provenance: dict[str, object],
+    recovery_readiness: dict[str, object],
+) -> dict[str, object]:
+    gate_chain = control_status.get("gate_chain")
+    if not isinstance(gate_chain, list):
+        gate_chain = []
+    external_gates = []
+    for gate in gate_chain:
+        if not isinstance(gate, dict):
+            continue
+        external_gates.append(
+            {
+                "name": gate.get("name"),
+                "result": gate.get("result"),
+                "classification": gate.get("classification"),
+                "missing_inputs": gate.get("missing_inputs", []),
+                "fallback_to": gate.get("fallback_to"),
+            }
+        )
+
+    return {
+        "schema_version": control_status.get("schema_version", "loom-governance-status/v2"),
+        "view": "external_orchestrator_consumer",
+        "result": control_status.get("result", "block"),
+        "current_gate": control_status.get("current_gate"),
+        "classifications": control_status.get("classifications", []),
+        "missing_inputs": control_status.get("missing_inputs", []),
+        "head_binding": control_status.get("head_binding", {}),
+        "gate_chain": external_gates,
+        "allowed_operations": ["status_read", "gate_read"],
+        "source_policy": {
+            "status_source": "derived_from_status_control_plane_v2",
+            "gate_source": "derived_from_governance_gate_chain",
+            "writeback": "recovery_entry_only",
+            "fallback_to": "current_checkpoint",
+        },
+        "provenance": provenance,
+        "recovery_readiness": recovery_readiness,
+    }
+
+
 def closeout_status_payload(
     *,
     github_status: dict[str, object],
@@ -535,6 +579,14 @@ def main(argv: list[str]) -> int:
         if result == "pass"
         else "status surface is readable, but one or more governance gates are still blocking or stale."
     )
+    provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    external_orchestrator = external_orchestrator_consumer_status(
+        control_status=control_status,
+        provenance=provenance,
+        recovery_readiness=recovery_readiness,
+    )
+
     return emit(
         {
             "command": "status",
@@ -543,8 +595,8 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
-            "provenance": report_provenance(context["report"]),
-            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "provenance": provenance,
+            "recovery_readiness": recovery_readiness,
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
@@ -586,6 +638,7 @@ def main(argv: list[str]) -> int:
             "ci_check_presence": ci_check_presence,
             "host_enforcement": host_enforcement,
             "governance_status": control_status,
+            "external_orchestrator": external_orchestrator,
             "governance_surface": governance_surface,
             "github": github_status,
         }

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -83,9 +83,10 @@ merge commit 反推执行入口。
 - `work_item_read`
 - `workspace_attach`
 - `recovery_writeback`
+- `status_read`
+- `gate_read`
 
-后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
-fact-chain，不得新增第二状态面。
+`status_read` 与 `gate_read` 必须消费同一 fact-chain，不得新增第二状态面。
 
 ## 5. Workspace Attach
 
@@ -126,7 +127,35 @@ orchestrator 私有 action。
 写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
 gate、review、validation、host action 或 closeout authored fields。
 
-## 7. Truth Boundary
+## 7. Status / Gate Consumption
+
+外部 orchestrator 可以只读消费 `status control plane v2` 与现有 gate chain。
+
+它读取的状态必须与 Loom 本地入口同源：
+
+- `schema_version` 继续使用 `loom-governance-status/v2`
+- `result`、`current_gate`、`classifications`、`missing_inputs`、`head_binding`
+  与 `gate_chain` 来自同一个 status control plane
+- `provenance` 继续指向 Work Item、recovery entry、review / checkpoint / host mirror
+  等既有来源
+
+外部 orchestrator 视图只能是 consumer view。它可以裁剪字段以便消费，但不得定义
+新的 status schema、不得 authored `pass | block`、不得替换 gate chain。
+
+当 status/gate 读取无法消费时，回退只能指向 Loom checkpoint 或 gate 前置修复，例如：
+
+- `current_checkpoint`
+- `spec_gate`
+- `build_gate`
+- `review_gate`
+- `merge_gate`
+- `admission`
+- `binding_repair`
+
+不得回退到 scheduler 私有 action、retry queue、tracker state 或 orchestrator-owned
+decision。
+
+## 8. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -146,7 +175,7 @@ gate、review、validation、host action 或 closeout authored fields。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 8. 非目标
+## 9. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -286,6 +286,30 @@
 `provenance` 是读取说明，不是新的 authored 字段组。它可以在 JSON 输出中按字段内联，也可以作为并列索引输出，但必须能被机械入口追溯到具体字段。
 若一个字段组混合消费多个来源，provenance 必须能下钻到字段级，不能用组级 provenance 掩盖局部 stale / drift。
 
+### 3.12 `external_orchestrator`
+
+当外部 orchestrator 只读消费 status / gate 时，状态面可以暴露派生 consumer view：
+
+- `schema_version`: 继续使用 `loom-governance-status/v2`
+- `view`: 固定为 `external_orchestrator_consumer`
+- `result`
+- `current_gate`
+- `classifications`
+- `missing_inputs`
+- `head_binding`
+- `gate_chain`
+- `allowed_operations`
+- `source_policy`
+- `provenance`
+- `recovery_readiness`
+
+该字段组只能投影本状态面的 `governance_status` 与 provenance。它不得定义第二套 status
+schema，不得 authored gate verdict，不得成为 scheduler state 或 tracker state。
+
+`allowed_operations` 只能声明 `status_read` 与 `gate_read`。`source_policy` 必须说明 status
+来自 `status control plane v2`、gate 来自现有 governance gate chain、writeback 只能回到
+recovery entry，失败回退只能指向 Loom checkpoint 或 gate 前置修复。
+
 ## 4. 总结果语义
 
 统一状态控制面本身只允许输出：

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -428,6 +428,8 @@ EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
     "workspace_attach",
     "recovery_writeback",
+    "status_read",
+    "gate_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2123,7 +2125,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`, `status_read`, `gate_read`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -4666,6 +4666,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 classifications = governance_status.get("classifications")
                 if not isinstance(classifications, list):
                     failures.append(Failure("daily-execution-cli", "`loom_status` governance_status must include classifications"))
+            external_orchestrator = payload.get("external_orchestrator")
+            if not isinstance(external_orchestrator, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `external_orchestrator` consumer view"))
+            else:
+                if external_orchestrator.get("schema_version") != "loom-governance-status/v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse governance status schema v2"))
+                if external_orchestrator.get("view") != "external_orchestrator_consumer":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator view must be consumer-only"))
+                if external_orchestrator.get("result") not in {"pass", "block"}:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator result must be `pass` or `block`"))
+                if external_orchestrator.get("allowed_operations") != ["status_read", "gate_read"]:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must expose only read operations"))
+                if not isinstance(external_orchestrator.get("gate_chain"), list):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse gate_chain"))
+                source_policy = external_orchestrator.get("source_policy")
+                if not isinstance(source_policy, dict):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must include source_policy"))
+                elif source_policy.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator fallback must point to Loom checkpoint"))
+                elif source_policy.get("status_source") != "derived_from_status_control_plane_v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read status from status control plane v2"))
+                elif source_policy.get("gate_source") != "derived_from_governance_gate_chain":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read gates from the governance gate chain"))
+                external_provenance = external_orchestrator.get("provenance")
+                if not (
+                    isinstance(external_provenance, dict)
+                    or (isinstance(external_provenance, list) and external_provenance)
+                ):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must carry provenance"))
             closeout = payload.get("closeout")
             if not isinstance(closeout, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `closeout`"))
@@ -9272,6 +9301,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-status.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "status_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "status_schema_version": "loom-governance-status/v2"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-gate.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "gate_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "gate_chain": "status_control_plane_v2"},
+                "consumed_as": "summary",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9370,6 +9417,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "required",
                 "fallback_to": "build",
+            },
+            {
+                "id": "fake-external-orchestrator-status",
+                "summary": "Read status control plane v2 without defining a second status surface.",
+                "surfaces": ["merge_ready"],
+                "operations": ["status_read"],
+                "locator": "host/external-orchestrator-status.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "current_checkpoint",
+            },
+            {
+                "id": "fake-external-orchestrator-gate",
+                "summary": "Read the Loom gate chain without authoring a gate verdict.",
+                "surfaces": ["merge_ready"],
+                "operations": ["gate_read"],
+                "locator": "host/external-orchestrator-gate.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "review_gate",
             },
         ],
         "shadow_surfaces": {
@@ -9736,6 +9803,24 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "workspace-attach-present",
         "recovery-writeback-present",
         "direct-status-write-block",
+        "status-read-present",
+        "gate-read-present",
+        "scheduler-private-fallback-block",
+    }
+    allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"}
+    loom_fallbacks = {
+        "work_item",
+        "admission",
+        "binding_repair",
+        "current_checkpoint",
+        "spec_gate",
+        "build_gate",
+        "review_gate",
+        "merge_gate",
+        "merge_ready",
+        "build",
+        "review",
+        "closeout",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9746,6 +9831,7 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
         else:
             seen_names.add(name)
+        expect = fixture.get("expect")
         entry = fixture.get("entry")
         if not isinstance(entry, dict):
             failures.append(Failure(category, f"{name or index} entry must be an object"))
@@ -9761,23 +9847,35 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
             if not isinstance(operations, list) or not operations:
                 failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
             elif any(operation not in allowed_operations for operation in operations):
                 failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
+            fallback_to = entry.get("fallback_to")
+            if (
+                isinstance(fallback_to, str)
+                and fallback_to not in loom_fallbacks
+                and (not isinstance(expect, dict) or expect.get("result") != "block")
+            ):
+                failures.append(Failure(category, f"{name or index} fallback_to must point to a Loom checkpoint or gate repair surface"))
         payload = fixture.get("payload")
-        expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
             failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
         if payload is not None:
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                if payload.get("operation") not in allowed_operations:
                     failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                payload_fallback = payload.get("fallback_to")
+                if (
+                    isinstance(payload_fallback, str)
+                    and payload_fallback not in loom_fallbacks
+                    and (not isinstance(expect, dict) or expect.get("result") != "block")
+                ):
+                    failures.append(Failure(category, f"{name or index} payload fallback_to must point to a Loom checkpoint or gate repair surface"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
                 if forbidden and expect.get("result") != "block":
                     failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
@@ -9785,6 +9883,27 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
                     failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
                 if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
                     failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+                if payload.get("operation") in {"status_read", "gate_read"}:
+                    if payload.get("source_layer") != "derived_surface":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must consume the derived status surface"))
+                    if payload.get("consumed_as") != "summary":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must be consumed as summary, not authored truth"))
+                    if payload.get("operation") == "status_read":
+                        status_fields = payload.get("status_fields")
+                        required_status_fields = {"result", "current_gate", "classifications", "missing_inputs", "head_binding", "gate_chain", "provenance"}
+                        if not isinstance(status_fields, list) or not required_status_fields.issubset(set(status_fields)):
+                            failures.append(Failure(category, f"{name or index} status_read fixture must reuse status control plane v2 fields"))
+                    if payload.get("operation") == "gate_read":
+                        gate_fields = payload.get("gate_fields")
+                        required_gate_fields = {"name", "result", "classification", "missing_inputs", "fallback_to"}
+                        if expect.get("result") != "block" and (not isinstance(gate_fields, list) or not required_gate_fields.issubset(set(gate_fields))):
+                            failures.append(Failure(category, f"{name or index} gate_read fixture must reuse the existing gate chain fields"))
+                if name == "scheduler-private-fallback-block" and expect.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure(category, "scheduler-private fallback fixture must fallback to `current_checkpoint`"))
+                if name == "scheduler-private-fallback-block":
+                    entry_fallback = entry.get("fallback_to") if isinstance(entry, dict) else None
+                    if entry_fallback in loom_fallbacks or payload.get("fallback_to") in loom_fallbacks:
+                        failures.append(Failure(category, "scheduler-private fallback fixture must prove a private fallback is blocked"))
 
     missing = sorted(required_names - seen_names)
     if missing:

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_status.py
@@ -205,6 +205,50 @@ def governance_control_status(
     }
 
 
+def external_orchestrator_consumer_status(
+    *,
+    control_status: dict[str, object],
+    provenance: dict[str, object],
+    recovery_readiness: dict[str, object],
+) -> dict[str, object]:
+    gate_chain = control_status.get("gate_chain")
+    if not isinstance(gate_chain, list):
+        gate_chain = []
+    external_gates = []
+    for gate in gate_chain:
+        if not isinstance(gate, dict):
+            continue
+        external_gates.append(
+            {
+                "name": gate.get("name"),
+                "result": gate.get("result"),
+                "classification": gate.get("classification"),
+                "missing_inputs": gate.get("missing_inputs", []),
+                "fallback_to": gate.get("fallback_to"),
+            }
+        )
+
+    return {
+        "schema_version": control_status.get("schema_version", "loom-governance-status/v2"),
+        "view": "external_orchestrator_consumer",
+        "result": control_status.get("result", "block"),
+        "current_gate": control_status.get("current_gate"),
+        "classifications": control_status.get("classifications", []),
+        "missing_inputs": control_status.get("missing_inputs", []),
+        "head_binding": control_status.get("head_binding", {}),
+        "gate_chain": external_gates,
+        "allowed_operations": ["status_read", "gate_read"],
+        "source_policy": {
+            "status_source": "derived_from_status_control_plane_v2",
+            "gate_source": "derived_from_governance_gate_chain",
+            "writeback": "recovery_entry_only",
+            "fallback_to": "current_checkpoint",
+        },
+        "provenance": provenance,
+        "recovery_readiness": recovery_readiness,
+    }
+
+
 def closeout_status_payload(
     *,
     github_status: dict[str, object],
@@ -535,6 +579,14 @@ def main(argv: list[str]) -> int:
         if result == "pass"
         else "status surface is readable, but one or more governance gates are still blocking or stale."
     )
+    provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    external_orchestrator = external_orchestrator_consumer_status(
+        control_status=control_status,
+        provenance=provenance,
+        recovery_readiness=recovery_readiness,
+    )
+
     return emit(
         {
             "command": "status",
@@ -543,8 +595,8 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
-            "provenance": report_provenance(context["report"]),
-            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "provenance": provenance,
+            "recovery_readiness": recovery_readiness,
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
@@ -586,6 +638,7 @@ def main(argv: list[str]) -> int:
             "ci_check_presence": ci_check_presence,
             "host_enforcement": host_enforcement,
             "governance_status": control_status,
+            "external_orchestrator": external_orchestrator,
             "governance_surface": governance_surface,
             "github": github_status,
         }

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -83,9 +83,10 @@ merge commit 反推执行入口。
 - `work_item_read`
 - `workspace_attach`
 - `recovery_writeback`
+- `status_read`
+- `gate_read`
 
-后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
-fact-chain，不得新增第二状态面。
+`status_read` 与 `gate_read` 必须消费同一 fact-chain，不得新增第二状态面。
 
 ## 5. Workspace Attach
 
@@ -126,7 +127,35 @@ orchestrator 私有 action。
 写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
 gate、review、validation、host action 或 closeout authored fields。
 
-## 7. Truth Boundary
+## 7. Status / Gate Consumption
+
+外部 orchestrator 可以只读消费 `status control plane v2` 与现有 gate chain。
+
+它读取的状态必须与 Loom 本地入口同源：
+
+- `schema_version` 继续使用 `loom-governance-status/v2`
+- `result`、`current_gate`、`classifications`、`missing_inputs`、`head_binding`
+  与 `gate_chain` 来自同一个 status control plane
+- `provenance` 继续指向 Work Item、recovery entry、review / checkpoint / host mirror
+  等既有来源
+
+外部 orchestrator 视图只能是 consumer view。它可以裁剪字段以便消费，但不得定义
+新的 status schema、不得 authored `pass | block`、不得替换 gate chain。
+
+当 status/gate 读取无法消费时，回退只能指向 Loom checkpoint 或 gate 前置修复，例如：
+
+- `current_checkpoint`
+- `spec_gate`
+- `build_gate`
+- `review_gate`
+- `merge_gate`
+- `admission`
+- `binding_repair`
+
+不得回退到 scheduler 私有 action、retry queue、tracker state 或 orchestrator-owned
+decision。
+
+## 8. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -146,7 +175,7 @@ gate、review、validation、host action 或 closeout authored fields。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 8. 非目标
+## 9. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -286,6 +286,30 @@
 `provenance` 是读取说明，不是新的 authored 字段组。它可以在 JSON 输出中按字段内联，也可以作为并列索引输出，但必须能被机械入口追溯到具体字段。
 若一个字段组混合消费多个来源，provenance 必须能下钻到字段级，不能用组级 provenance 掩盖局部 stale / drift。
 
+### 3.12 `external_orchestrator`
+
+当外部 orchestrator 只读消费 status / gate 时，状态面可以暴露派生 consumer view：
+
+- `schema_version`: 继续使用 `loom-governance-status/v2`
+- `view`: 固定为 `external_orchestrator_consumer`
+- `result`
+- `current_gate`
+- `classifications`
+- `missing_inputs`
+- `head_binding`
+- `gate_chain`
+- `allowed_operations`
+- `source_policy`
+- `provenance`
+- `recovery_readiness`
+
+该字段组只能投影本状态面的 `governance_status` 与 provenance。它不得定义第二套 status
+schema，不得 authored gate verdict，不得成为 scheduler state 或 tracker state。
+
+`allowed_operations` 只能声明 `status_read` 与 `gate_read`。`source_policy` 必须说明 status
+来自 `status control plane v2`、gate 来自现有 governance gate chain、writeback 只能回到
+recovery entry，失败回退只能指向 Loom checkpoint 或 gate 前置修复。
+
 ## 4. 总结果语义
 
 统一状态控制面本身只允许输出：

--- a/skills/loom-resume/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/governance_surface.py
@@ -428,6 +428,8 @@ EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
     "workspace_attach",
     "recovery_writeback",
+    "status_read",
+    "gate_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2123,7 +2125,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`, `status_read`, `gate_read`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -4666,6 +4666,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 classifications = governance_status.get("classifications")
                 if not isinstance(classifications, list):
                     failures.append(Failure("daily-execution-cli", "`loom_status` governance_status must include classifications"))
+            external_orchestrator = payload.get("external_orchestrator")
+            if not isinstance(external_orchestrator, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `external_orchestrator` consumer view"))
+            else:
+                if external_orchestrator.get("schema_version") != "loom-governance-status/v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse governance status schema v2"))
+                if external_orchestrator.get("view") != "external_orchestrator_consumer":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator view must be consumer-only"))
+                if external_orchestrator.get("result") not in {"pass", "block"}:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator result must be `pass` or `block`"))
+                if external_orchestrator.get("allowed_operations") != ["status_read", "gate_read"]:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must expose only read operations"))
+                if not isinstance(external_orchestrator.get("gate_chain"), list):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse gate_chain"))
+                source_policy = external_orchestrator.get("source_policy")
+                if not isinstance(source_policy, dict):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must include source_policy"))
+                elif source_policy.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator fallback must point to Loom checkpoint"))
+                elif source_policy.get("status_source") != "derived_from_status_control_plane_v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read status from status control plane v2"))
+                elif source_policy.get("gate_source") != "derived_from_governance_gate_chain":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read gates from the governance gate chain"))
+                external_provenance = external_orchestrator.get("provenance")
+                if not (
+                    isinstance(external_provenance, dict)
+                    or (isinstance(external_provenance, list) and external_provenance)
+                ):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must carry provenance"))
             closeout = payload.get("closeout")
             if not isinstance(closeout, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `closeout`"))
@@ -9272,6 +9301,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-status.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "status_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "status_schema_version": "loom-governance-status/v2"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-gate.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "gate_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "gate_chain": "status_control_plane_v2"},
+                "consumed_as": "summary",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9370,6 +9417,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "required",
                 "fallback_to": "build",
+            },
+            {
+                "id": "fake-external-orchestrator-status",
+                "summary": "Read status control plane v2 without defining a second status surface.",
+                "surfaces": ["merge_ready"],
+                "operations": ["status_read"],
+                "locator": "host/external-orchestrator-status.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "current_checkpoint",
+            },
+            {
+                "id": "fake-external-orchestrator-gate",
+                "summary": "Read the Loom gate chain without authoring a gate verdict.",
+                "surfaces": ["merge_ready"],
+                "operations": ["gate_read"],
+                "locator": "host/external-orchestrator-gate.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "review_gate",
             },
         ],
         "shadow_surfaces": {
@@ -9736,6 +9803,24 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "workspace-attach-present",
         "recovery-writeback-present",
         "direct-status-write-block",
+        "status-read-present",
+        "gate-read-present",
+        "scheduler-private-fallback-block",
+    }
+    allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"}
+    loom_fallbacks = {
+        "work_item",
+        "admission",
+        "binding_repair",
+        "current_checkpoint",
+        "spec_gate",
+        "build_gate",
+        "review_gate",
+        "merge_gate",
+        "merge_ready",
+        "build",
+        "review",
+        "closeout",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9746,6 +9831,7 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
         else:
             seen_names.add(name)
+        expect = fixture.get("expect")
         entry = fixture.get("entry")
         if not isinstance(entry, dict):
             failures.append(Failure(category, f"{name or index} entry must be an object"))
@@ -9761,23 +9847,35 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
             if not isinstance(operations, list) or not operations:
                 failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
             elif any(operation not in allowed_operations for operation in operations):
                 failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
+            fallback_to = entry.get("fallback_to")
+            if (
+                isinstance(fallback_to, str)
+                and fallback_to not in loom_fallbacks
+                and (not isinstance(expect, dict) or expect.get("result") != "block")
+            ):
+                failures.append(Failure(category, f"{name or index} fallback_to must point to a Loom checkpoint or gate repair surface"))
         payload = fixture.get("payload")
-        expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
             failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
         if payload is not None:
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                if payload.get("operation") not in allowed_operations:
                     failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                payload_fallback = payload.get("fallback_to")
+                if (
+                    isinstance(payload_fallback, str)
+                    and payload_fallback not in loom_fallbacks
+                    and (not isinstance(expect, dict) or expect.get("result") != "block")
+                ):
+                    failures.append(Failure(category, f"{name or index} payload fallback_to must point to a Loom checkpoint or gate repair surface"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
                 if forbidden and expect.get("result") != "block":
                     failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
@@ -9785,6 +9883,27 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
                     failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
                 if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
                     failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+                if payload.get("operation") in {"status_read", "gate_read"}:
+                    if payload.get("source_layer") != "derived_surface":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must consume the derived status surface"))
+                    if payload.get("consumed_as") != "summary":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must be consumed as summary, not authored truth"))
+                    if payload.get("operation") == "status_read":
+                        status_fields = payload.get("status_fields")
+                        required_status_fields = {"result", "current_gate", "classifications", "missing_inputs", "head_binding", "gate_chain", "provenance"}
+                        if not isinstance(status_fields, list) or not required_status_fields.issubset(set(status_fields)):
+                            failures.append(Failure(category, f"{name or index} status_read fixture must reuse status control plane v2 fields"))
+                    if payload.get("operation") == "gate_read":
+                        gate_fields = payload.get("gate_fields")
+                        required_gate_fields = {"name", "result", "classification", "missing_inputs", "fallback_to"}
+                        if expect.get("result") != "block" and (not isinstance(gate_fields, list) or not required_gate_fields.issubset(set(gate_fields))):
+                            failures.append(Failure(category, f"{name or index} gate_read fixture must reuse the existing gate chain fields"))
+                if name == "scheduler-private-fallback-block" and expect.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure(category, "scheduler-private fallback fixture must fallback to `current_checkpoint`"))
+                if name == "scheduler-private-fallback-block":
+                    entry_fallback = entry.get("fallback_to") if isinstance(entry, dict) else None
+                    if entry_fallback in loom_fallbacks or payload.get("fallback_to") in loom_fallbacks:
+                        failures.append(Failure(category, "scheduler-private fallback fixture must prove a private fallback is blocked"))
 
     missing = sorted(required_names - seen_names)
     if missing:

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_status.py
@@ -205,6 +205,50 @@ def governance_control_status(
     }
 
 
+def external_orchestrator_consumer_status(
+    *,
+    control_status: dict[str, object],
+    provenance: dict[str, object],
+    recovery_readiness: dict[str, object],
+) -> dict[str, object]:
+    gate_chain = control_status.get("gate_chain")
+    if not isinstance(gate_chain, list):
+        gate_chain = []
+    external_gates = []
+    for gate in gate_chain:
+        if not isinstance(gate, dict):
+            continue
+        external_gates.append(
+            {
+                "name": gate.get("name"),
+                "result": gate.get("result"),
+                "classification": gate.get("classification"),
+                "missing_inputs": gate.get("missing_inputs", []),
+                "fallback_to": gate.get("fallback_to"),
+            }
+        )
+
+    return {
+        "schema_version": control_status.get("schema_version", "loom-governance-status/v2"),
+        "view": "external_orchestrator_consumer",
+        "result": control_status.get("result", "block"),
+        "current_gate": control_status.get("current_gate"),
+        "classifications": control_status.get("classifications", []),
+        "missing_inputs": control_status.get("missing_inputs", []),
+        "head_binding": control_status.get("head_binding", {}),
+        "gate_chain": external_gates,
+        "allowed_operations": ["status_read", "gate_read"],
+        "source_policy": {
+            "status_source": "derived_from_status_control_plane_v2",
+            "gate_source": "derived_from_governance_gate_chain",
+            "writeback": "recovery_entry_only",
+            "fallback_to": "current_checkpoint",
+        },
+        "provenance": provenance,
+        "recovery_readiness": recovery_readiness,
+    }
+
+
 def closeout_status_payload(
     *,
     github_status: dict[str, object],
@@ -535,6 +579,14 @@ def main(argv: list[str]) -> int:
         if result == "pass"
         else "status surface is readable, but one or more governance gates are still blocking or stale."
     )
+    provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    external_orchestrator = external_orchestrator_consumer_status(
+        control_status=control_status,
+        provenance=provenance,
+        recovery_readiness=recovery_readiness,
+    )
+
     return emit(
         {
             "command": "status",
@@ -543,8 +595,8 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
-            "provenance": report_provenance(context["report"]),
-            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "provenance": provenance,
+            "recovery_readiness": recovery_readiness,
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
@@ -586,6 +638,7 @@ def main(argv: list[str]) -> int:
             "ci_check_presence": ci_check_presence,
             "host_enforcement": host_enforcement,
             "governance_status": control_status,
+            "external_orchestrator": external_orchestrator,
             "governance_surface": governance_surface,
             "github": github_status,
         }

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -83,9 +83,10 @@ merge commit 反推执行入口。
 - `work_item_read`
 - `workspace_attach`
 - `recovery_writeback`
+- `status_read`
+- `gate_read`
 
-后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
-fact-chain，不得新增第二状态面。
+`status_read` 与 `gate_read` 必须消费同一 fact-chain，不得新增第二状态面。
 
 ## 5. Workspace Attach
 
@@ -126,7 +127,35 @@ orchestrator 私有 action。
 写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
 gate、review、validation、host action 或 closeout authored fields。
 
-## 7. Truth Boundary
+## 7. Status / Gate Consumption
+
+外部 orchestrator 可以只读消费 `status control plane v2` 与现有 gate chain。
+
+它读取的状态必须与 Loom 本地入口同源：
+
+- `schema_version` 继续使用 `loom-governance-status/v2`
+- `result`、`current_gate`、`classifications`、`missing_inputs`、`head_binding`
+  与 `gate_chain` 来自同一个 status control plane
+- `provenance` 继续指向 Work Item、recovery entry、review / checkpoint / host mirror
+  等既有来源
+
+外部 orchestrator 视图只能是 consumer view。它可以裁剪字段以便消费，但不得定义
+新的 status schema、不得 authored `pass | block`、不得替换 gate chain。
+
+当 status/gate 读取无法消费时，回退只能指向 Loom checkpoint 或 gate 前置修复，例如：
+
+- `current_checkpoint`
+- `spec_gate`
+- `build_gate`
+- `review_gate`
+- `merge_gate`
+- `admission`
+- `binding_repair`
+
+不得回退到 scheduler 私有 action、retry queue、tracker state 或 orchestrator-owned
+decision。
+
+## 8. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -146,7 +175,7 @@ gate、review、validation、host action 或 closeout authored fields。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 8. 非目标
+## 9. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -286,6 +286,30 @@
 `provenance` 是读取说明，不是新的 authored 字段组。它可以在 JSON 输出中按字段内联，也可以作为并列索引输出，但必须能被机械入口追溯到具体字段。
 若一个字段组混合消费多个来源，provenance 必须能下钻到字段级，不能用组级 provenance 掩盖局部 stale / drift。
 
+### 3.12 `external_orchestrator`
+
+当外部 orchestrator 只读消费 status / gate 时，状态面可以暴露派生 consumer view：
+
+- `schema_version`: 继续使用 `loom-governance-status/v2`
+- `view`: 固定为 `external_orchestrator_consumer`
+- `result`
+- `current_gate`
+- `classifications`
+- `missing_inputs`
+- `head_binding`
+- `gate_chain`
+- `allowed_operations`
+- `source_policy`
+- `provenance`
+- `recovery_readiness`
+
+该字段组只能投影本状态面的 `governance_status` 与 provenance。它不得定义第二套 status
+schema，不得 authored gate verdict，不得成为 scheduler state 或 tracker state。
+
+`allowed_operations` 只能声明 `status_read` 与 `gate_read`。`source_policy` 必须说明 status
+来自 `status control plane v2`、gate 来自现有 governance gate chain、writeback 只能回到
+recovery entry，失败回退只能指向 Loom checkpoint 或 gate 前置修复。
+
 ## 4. 总结果语义
 
 统一状态控制面本身只允许输出：

--- a/skills/loom-retire/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/governance_surface.py
@@ -428,6 +428,8 @@ EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
     "workspace_attach",
     "recovery_writeback",
+    "status_read",
+    "gate_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2123,7 +2125,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`, `status_read`, `gate_read`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -4666,6 +4666,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 classifications = governance_status.get("classifications")
                 if not isinstance(classifications, list):
                     failures.append(Failure("daily-execution-cli", "`loom_status` governance_status must include classifications"))
+            external_orchestrator = payload.get("external_orchestrator")
+            if not isinstance(external_orchestrator, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `external_orchestrator` consumer view"))
+            else:
+                if external_orchestrator.get("schema_version") != "loom-governance-status/v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse governance status schema v2"))
+                if external_orchestrator.get("view") != "external_orchestrator_consumer":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator view must be consumer-only"))
+                if external_orchestrator.get("result") not in {"pass", "block"}:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator result must be `pass` or `block`"))
+                if external_orchestrator.get("allowed_operations") != ["status_read", "gate_read"]:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must expose only read operations"))
+                if not isinstance(external_orchestrator.get("gate_chain"), list):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse gate_chain"))
+                source_policy = external_orchestrator.get("source_policy")
+                if not isinstance(source_policy, dict):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must include source_policy"))
+                elif source_policy.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator fallback must point to Loom checkpoint"))
+                elif source_policy.get("status_source") != "derived_from_status_control_plane_v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read status from status control plane v2"))
+                elif source_policy.get("gate_source") != "derived_from_governance_gate_chain":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read gates from the governance gate chain"))
+                external_provenance = external_orchestrator.get("provenance")
+                if not (
+                    isinstance(external_provenance, dict)
+                    or (isinstance(external_provenance, list) and external_provenance)
+                ):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must carry provenance"))
             closeout = payload.get("closeout")
             if not isinstance(closeout, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `closeout`"))
@@ -9272,6 +9301,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-status.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "status_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "status_schema_version": "loom-governance-status/v2"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-gate.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "gate_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "gate_chain": "status_control_plane_v2"},
+                "consumed_as": "summary",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9370,6 +9417,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "required",
                 "fallback_to": "build",
+            },
+            {
+                "id": "fake-external-orchestrator-status",
+                "summary": "Read status control plane v2 without defining a second status surface.",
+                "surfaces": ["merge_ready"],
+                "operations": ["status_read"],
+                "locator": "host/external-orchestrator-status.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "current_checkpoint",
+            },
+            {
+                "id": "fake-external-orchestrator-gate",
+                "summary": "Read the Loom gate chain without authoring a gate verdict.",
+                "surfaces": ["merge_ready"],
+                "operations": ["gate_read"],
+                "locator": "host/external-orchestrator-gate.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "review_gate",
             },
         ],
         "shadow_surfaces": {
@@ -9736,6 +9803,24 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "workspace-attach-present",
         "recovery-writeback-present",
         "direct-status-write-block",
+        "status-read-present",
+        "gate-read-present",
+        "scheduler-private-fallback-block",
+    }
+    allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"}
+    loom_fallbacks = {
+        "work_item",
+        "admission",
+        "binding_repair",
+        "current_checkpoint",
+        "spec_gate",
+        "build_gate",
+        "review_gate",
+        "merge_gate",
+        "merge_ready",
+        "build",
+        "review",
+        "closeout",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9746,6 +9831,7 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
         else:
             seen_names.add(name)
+        expect = fixture.get("expect")
         entry = fixture.get("entry")
         if not isinstance(entry, dict):
             failures.append(Failure(category, f"{name or index} entry must be an object"))
@@ -9761,23 +9847,35 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
             if not isinstance(operations, list) or not operations:
                 failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
             elif any(operation not in allowed_operations for operation in operations):
                 failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
+            fallback_to = entry.get("fallback_to")
+            if (
+                isinstance(fallback_to, str)
+                and fallback_to not in loom_fallbacks
+                and (not isinstance(expect, dict) or expect.get("result") != "block")
+            ):
+                failures.append(Failure(category, f"{name or index} fallback_to must point to a Loom checkpoint or gate repair surface"))
         payload = fixture.get("payload")
-        expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
             failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
         if payload is not None:
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                if payload.get("operation") not in allowed_operations:
                     failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                payload_fallback = payload.get("fallback_to")
+                if (
+                    isinstance(payload_fallback, str)
+                    and payload_fallback not in loom_fallbacks
+                    and (not isinstance(expect, dict) or expect.get("result") != "block")
+                ):
+                    failures.append(Failure(category, f"{name or index} payload fallback_to must point to a Loom checkpoint or gate repair surface"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
                 if forbidden and expect.get("result") != "block":
                     failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
@@ -9785,6 +9883,27 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
                     failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
                 if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
                     failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+                if payload.get("operation") in {"status_read", "gate_read"}:
+                    if payload.get("source_layer") != "derived_surface":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must consume the derived status surface"))
+                    if payload.get("consumed_as") != "summary":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must be consumed as summary, not authored truth"))
+                    if payload.get("operation") == "status_read":
+                        status_fields = payload.get("status_fields")
+                        required_status_fields = {"result", "current_gate", "classifications", "missing_inputs", "head_binding", "gate_chain", "provenance"}
+                        if not isinstance(status_fields, list) or not required_status_fields.issubset(set(status_fields)):
+                            failures.append(Failure(category, f"{name or index} status_read fixture must reuse status control plane v2 fields"))
+                    if payload.get("operation") == "gate_read":
+                        gate_fields = payload.get("gate_fields")
+                        required_gate_fields = {"name", "result", "classification", "missing_inputs", "fallback_to"}
+                        if expect.get("result") != "block" and (not isinstance(gate_fields, list) or not required_gate_fields.issubset(set(gate_fields))):
+                            failures.append(Failure(category, f"{name or index} gate_read fixture must reuse the existing gate chain fields"))
+                if name == "scheduler-private-fallback-block" and expect.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure(category, "scheduler-private fallback fixture must fallback to `current_checkpoint`"))
+                if name == "scheduler-private-fallback-block":
+                    entry_fallback = entry.get("fallback_to") if isinstance(entry, dict) else None
+                    if entry_fallback in loom_fallbacks or payload.get("fallback_to") in loom_fallbacks:
+                        failures.append(Failure(category, "scheduler-private fallback fixture must prove a private fallback is blocked"))
 
     missing = sorted(required_names - seen_names)
     if missing:

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_status.py
@@ -205,6 +205,50 @@ def governance_control_status(
     }
 
 
+def external_orchestrator_consumer_status(
+    *,
+    control_status: dict[str, object],
+    provenance: dict[str, object],
+    recovery_readiness: dict[str, object],
+) -> dict[str, object]:
+    gate_chain = control_status.get("gate_chain")
+    if not isinstance(gate_chain, list):
+        gate_chain = []
+    external_gates = []
+    for gate in gate_chain:
+        if not isinstance(gate, dict):
+            continue
+        external_gates.append(
+            {
+                "name": gate.get("name"),
+                "result": gate.get("result"),
+                "classification": gate.get("classification"),
+                "missing_inputs": gate.get("missing_inputs", []),
+                "fallback_to": gate.get("fallback_to"),
+            }
+        )
+
+    return {
+        "schema_version": control_status.get("schema_version", "loom-governance-status/v2"),
+        "view": "external_orchestrator_consumer",
+        "result": control_status.get("result", "block"),
+        "current_gate": control_status.get("current_gate"),
+        "classifications": control_status.get("classifications", []),
+        "missing_inputs": control_status.get("missing_inputs", []),
+        "head_binding": control_status.get("head_binding", {}),
+        "gate_chain": external_gates,
+        "allowed_operations": ["status_read", "gate_read"],
+        "source_policy": {
+            "status_source": "derived_from_status_control_plane_v2",
+            "gate_source": "derived_from_governance_gate_chain",
+            "writeback": "recovery_entry_only",
+            "fallback_to": "current_checkpoint",
+        },
+        "provenance": provenance,
+        "recovery_readiness": recovery_readiness,
+    }
+
+
 def closeout_status_payload(
     *,
     github_status: dict[str, object],
@@ -535,6 +579,14 @@ def main(argv: list[str]) -> int:
         if result == "pass"
         else "status surface is readable, but one or more governance gates are still blocking or stale."
     )
+    provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    external_orchestrator = external_orchestrator_consumer_status(
+        control_status=control_status,
+        provenance=provenance,
+        recovery_readiness=recovery_readiness,
+    )
+
     return emit(
         {
             "command": "status",
@@ -543,8 +595,8 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
-            "provenance": report_provenance(context["report"]),
-            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "provenance": provenance,
+            "recovery_readiness": recovery_readiness,
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
@@ -586,6 +638,7 @@ def main(argv: list[str]) -> int:
             "ci_check_presence": ci_check_presence,
             "host_enforcement": host_enforcement,
             "governance_status": control_status,
+            "external_orchestrator": external_orchestrator,
             "governance_surface": governance_surface,
             "github": github_status,
         }

--- a/skills/loom-review/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -83,9 +83,10 @@ merge commit 反推执行入口。
 - `work_item_read`
 - `workspace_attach`
 - `recovery_writeback`
+- `status_read`
+- `gate_read`
 
-后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
-fact-chain，不得新增第二状态面。
+`status_read` 与 `gate_read` 必须消费同一 fact-chain，不得新增第二状态面。
 
 ## 5. Workspace Attach
 
@@ -126,7 +127,35 @@ orchestrator 私有 action。
 写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
 gate、review、validation、host action 或 closeout authored fields。
 
-## 7. Truth Boundary
+## 7. Status / Gate Consumption
+
+外部 orchestrator 可以只读消费 `status control plane v2` 与现有 gate chain。
+
+它读取的状态必须与 Loom 本地入口同源：
+
+- `schema_version` 继续使用 `loom-governance-status/v2`
+- `result`、`current_gate`、`classifications`、`missing_inputs`、`head_binding`
+  与 `gate_chain` 来自同一个 status control plane
+- `provenance` 继续指向 Work Item、recovery entry、review / checkpoint / host mirror
+  等既有来源
+
+外部 orchestrator 视图只能是 consumer view。它可以裁剪字段以便消费，但不得定义
+新的 status schema、不得 authored `pass | block`、不得替换 gate chain。
+
+当 status/gate 读取无法消费时，回退只能指向 Loom checkpoint 或 gate 前置修复，例如：
+
+- `current_checkpoint`
+- `spec_gate`
+- `build_gate`
+- `review_gate`
+- `merge_gate`
+- `admission`
+- `binding_repair`
+
+不得回退到 scheduler 私有 action、retry queue、tracker state 或 orchestrator-owned
+decision。
+
+## 8. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -146,7 +175,7 @@ gate、review、validation、host action 或 closeout authored fields。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 8. 非目标
+## 9. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-review/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -286,6 +286,30 @@
 `provenance` 是读取说明，不是新的 authored 字段组。它可以在 JSON 输出中按字段内联，也可以作为并列索引输出，但必须能被机械入口追溯到具体字段。
 若一个字段组混合消费多个来源，provenance 必须能下钻到字段级，不能用组级 provenance 掩盖局部 stale / drift。
 
+### 3.12 `external_orchestrator`
+
+当外部 orchestrator 只读消费 status / gate 时，状态面可以暴露派生 consumer view：
+
+- `schema_version`: 继续使用 `loom-governance-status/v2`
+- `view`: 固定为 `external_orchestrator_consumer`
+- `result`
+- `current_gate`
+- `classifications`
+- `missing_inputs`
+- `head_binding`
+- `gate_chain`
+- `allowed_operations`
+- `source_policy`
+- `provenance`
+- `recovery_readiness`
+
+该字段组只能投影本状态面的 `governance_status` 与 provenance。它不得定义第二套 status
+schema，不得 authored gate verdict，不得成为 scheduler state 或 tracker state。
+
+`allowed_operations` 只能声明 `status_read` 与 `gate_read`。`source_policy` 必须说明 status
+来自 `status control plane v2`、gate 来自现有 governance gate chain、writeback 只能回到
+recovery entry，失败回退只能指向 Loom checkpoint 或 gate 前置修复。
+
 ## 4. 总结果语义
 
 统一状态控制面本身只允许输出：

--- a/skills/loom-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -428,6 +428,8 @@ EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
     "workspace_attach",
     "recovery_writeback",
+    "status_read",
+    "gate_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2123,7 +2125,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`, `status_read`, `gate_read`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -4666,6 +4666,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 classifications = governance_status.get("classifications")
                 if not isinstance(classifications, list):
                     failures.append(Failure("daily-execution-cli", "`loom_status` governance_status must include classifications"))
+            external_orchestrator = payload.get("external_orchestrator")
+            if not isinstance(external_orchestrator, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `external_orchestrator` consumer view"))
+            else:
+                if external_orchestrator.get("schema_version") != "loom-governance-status/v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse governance status schema v2"))
+                if external_orchestrator.get("view") != "external_orchestrator_consumer":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator view must be consumer-only"))
+                if external_orchestrator.get("result") not in {"pass", "block"}:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator result must be `pass` or `block`"))
+                if external_orchestrator.get("allowed_operations") != ["status_read", "gate_read"]:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must expose only read operations"))
+                if not isinstance(external_orchestrator.get("gate_chain"), list):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse gate_chain"))
+                source_policy = external_orchestrator.get("source_policy")
+                if not isinstance(source_policy, dict):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must include source_policy"))
+                elif source_policy.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator fallback must point to Loom checkpoint"))
+                elif source_policy.get("status_source") != "derived_from_status_control_plane_v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read status from status control plane v2"))
+                elif source_policy.get("gate_source") != "derived_from_governance_gate_chain":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read gates from the governance gate chain"))
+                external_provenance = external_orchestrator.get("provenance")
+                if not (
+                    isinstance(external_provenance, dict)
+                    or (isinstance(external_provenance, list) and external_provenance)
+                ):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must carry provenance"))
             closeout = payload.get("closeout")
             if not isinstance(closeout, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `closeout`"))
@@ -9272,6 +9301,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-status.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "status_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "status_schema_version": "loom-governance-status/v2"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-gate.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "gate_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "gate_chain": "status_control_plane_v2"},
+                "consumed_as": "summary",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9370,6 +9417,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "required",
                 "fallback_to": "build",
+            },
+            {
+                "id": "fake-external-orchestrator-status",
+                "summary": "Read status control plane v2 without defining a second status surface.",
+                "surfaces": ["merge_ready"],
+                "operations": ["status_read"],
+                "locator": "host/external-orchestrator-status.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "current_checkpoint",
+            },
+            {
+                "id": "fake-external-orchestrator-gate",
+                "summary": "Read the Loom gate chain without authoring a gate verdict.",
+                "surfaces": ["merge_ready"],
+                "operations": ["gate_read"],
+                "locator": "host/external-orchestrator-gate.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "review_gate",
             },
         ],
         "shadow_surfaces": {
@@ -9736,6 +9803,24 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "workspace-attach-present",
         "recovery-writeback-present",
         "direct-status-write-block",
+        "status-read-present",
+        "gate-read-present",
+        "scheduler-private-fallback-block",
+    }
+    allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"}
+    loom_fallbacks = {
+        "work_item",
+        "admission",
+        "binding_repair",
+        "current_checkpoint",
+        "spec_gate",
+        "build_gate",
+        "review_gate",
+        "merge_gate",
+        "merge_ready",
+        "build",
+        "review",
+        "closeout",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9746,6 +9831,7 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
         else:
             seen_names.add(name)
+        expect = fixture.get("expect")
         entry = fixture.get("entry")
         if not isinstance(entry, dict):
             failures.append(Failure(category, f"{name or index} entry must be an object"))
@@ -9761,23 +9847,35 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
             if not isinstance(operations, list) or not operations:
                 failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
             elif any(operation not in allowed_operations for operation in operations):
                 failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
+            fallback_to = entry.get("fallback_to")
+            if (
+                isinstance(fallback_to, str)
+                and fallback_to not in loom_fallbacks
+                and (not isinstance(expect, dict) or expect.get("result") != "block")
+            ):
+                failures.append(Failure(category, f"{name or index} fallback_to must point to a Loom checkpoint or gate repair surface"))
         payload = fixture.get("payload")
-        expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
             failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
         if payload is not None:
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                if payload.get("operation") not in allowed_operations:
                     failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                payload_fallback = payload.get("fallback_to")
+                if (
+                    isinstance(payload_fallback, str)
+                    and payload_fallback not in loom_fallbacks
+                    and (not isinstance(expect, dict) or expect.get("result") != "block")
+                ):
+                    failures.append(Failure(category, f"{name or index} payload fallback_to must point to a Loom checkpoint or gate repair surface"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
                 if forbidden and expect.get("result") != "block":
                     failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
@@ -9785,6 +9883,27 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
                     failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
                 if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
                     failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+                if payload.get("operation") in {"status_read", "gate_read"}:
+                    if payload.get("source_layer") != "derived_surface":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must consume the derived status surface"))
+                    if payload.get("consumed_as") != "summary":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must be consumed as summary, not authored truth"))
+                    if payload.get("operation") == "status_read":
+                        status_fields = payload.get("status_fields")
+                        required_status_fields = {"result", "current_gate", "classifications", "missing_inputs", "head_binding", "gate_chain", "provenance"}
+                        if not isinstance(status_fields, list) or not required_status_fields.issubset(set(status_fields)):
+                            failures.append(Failure(category, f"{name or index} status_read fixture must reuse status control plane v2 fields"))
+                    if payload.get("operation") == "gate_read":
+                        gate_fields = payload.get("gate_fields")
+                        required_gate_fields = {"name", "result", "classification", "missing_inputs", "fallback_to"}
+                        if expect.get("result") != "block" and (not isinstance(gate_fields, list) or not required_gate_fields.issubset(set(gate_fields))):
+                            failures.append(Failure(category, f"{name or index} gate_read fixture must reuse the existing gate chain fields"))
+                if name == "scheduler-private-fallback-block" and expect.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure(category, "scheduler-private fallback fixture must fallback to `current_checkpoint`"))
+                if name == "scheduler-private-fallback-block":
+                    entry_fallback = entry.get("fallback_to") if isinstance(entry, dict) else None
+                    if entry_fallback in loom_fallbacks or payload.get("fallback_to") in loom_fallbacks:
+                        failures.append(Failure(category, "scheduler-private fallback fixture must prove a private fallback is blocked"))
 
     missing = sorted(required_names - seen_names)
     if missing:

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_status.py
@@ -205,6 +205,50 @@ def governance_control_status(
     }
 
 
+def external_orchestrator_consumer_status(
+    *,
+    control_status: dict[str, object],
+    provenance: dict[str, object],
+    recovery_readiness: dict[str, object],
+) -> dict[str, object]:
+    gate_chain = control_status.get("gate_chain")
+    if not isinstance(gate_chain, list):
+        gate_chain = []
+    external_gates = []
+    for gate in gate_chain:
+        if not isinstance(gate, dict):
+            continue
+        external_gates.append(
+            {
+                "name": gate.get("name"),
+                "result": gate.get("result"),
+                "classification": gate.get("classification"),
+                "missing_inputs": gate.get("missing_inputs", []),
+                "fallback_to": gate.get("fallback_to"),
+            }
+        )
+
+    return {
+        "schema_version": control_status.get("schema_version", "loom-governance-status/v2"),
+        "view": "external_orchestrator_consumer",
+        "result": control_status.get("result", "block"),
+        "current_gate": control_status.get("current_gate"),
+        "classifications": control_status.get("classifications", []),
+        "missing_inputs": control_status.get("missing_inputs", []),
+        "head_binding": control_status.get("head_binding", {}),
+        "gate_chain": external_gates,
+        "allowed_operations": ["status_read", "gate_read"],
+        "source_policy": {
+            "status_source": "derived_from_status_control_plane_v2",
+            "gate_source": "derived_from_governance_gate_chain",
+            "writeback": "recovery_entry_only",
+            "fallback_to": "current_checkpoint",
+        },
+        "provenance": provenance,
+        "recovery_readiness": recovery_readiness,
+    }
+
+
 def closeout_status_payload(
     *,
     github_status: dict[str, object],
@@ -535,6 +579,14 @@ def main(argv: list[str]) -> int:
         if result == "pass"
         else "status surface is readable, but one or more governance gates are still blocking or stale."
     )
+    provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    external_orchestrator = external_orchestrator_consumer_status(
+        control_status=control_status,
+        provenance=provenance,
+        recovery_readiness=recovery_readiness,
+    )
+
     return emit(
         {
             "command": "status",
@@ -543,8 +595,8 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
-            "provenance": report_provenance(context["report"]),
-            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "provenance": provenance,
+            "recovery_readiness": recovery_readiness,
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
@@ -586,6 +638,7 @@ def main(argv: list[str]) -> int:
             "ci_check_presence": ci_check_presence,
             "host_enforcement": host_enforcement,
             "governance_status": control_status,
+            "external_orchestrator": external_orchestrator,
             "governance_surface": governance_surface,
             "github": github_status,
         }

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -83,9 +83,10 @@ merge commit 反推执行入口。
 - `work_item_read`
 - `workspace_attach`
 - `recovery_writeback`
+- `status_read`
+- `gate_read`
 
-后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
-fact-chain，不得新增第二状态面。
+`status_read` 与 `gate_read` 必须消费同一 fact-chain，不得新增第二状态面。
 
 ## 5. Workspace Attach
 
@@ -126,7 +127,35 @@ orchestrator 私有 action。
 写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
 gate、review、validation、host action 或 closeout authored fields。
 
-## 7. Truth Boundary
+## 7. Status / Gate Consumption
+
+外部 orchestrator 可以只读消费 `status control plane v2` 与现有 gate chain。
+
+它读取的状态必须与 Loom 本地入口同源：
+
+- `schema_version` 继续使用 `loom-governance-status/v2`
+- `result`、`current_gate`、`classifications`、`missing_inputs`、`head_binding`
+  与 `gate_chain` 来自同一个 status control plane
+- `provenance` 继续指向 Work Item、recovery entry、review / checkpoint / host mirror
+  等既有来源
+
+外部 orchestrator 视图只能是 consumer view。它可以裁剪字段以便消费，但不得定义
+新的 status schema、不得 authored `pass | block`、不得替换 gate chain。
+
+当 status/gate 读取无法消费时，回退只能指向 Loom checkpoint 或 gate 前置修复，例如：
+
+- `current_checkpoint`
+- `spec_gate`
+- `build_gate`
+- `review_gate`
+- `merge_gate`
+- `admission`
+- `binding_repair`
+
+不得回退到 scheduler 私有 action、retry queue、tracker state 或 orchestrator-owned
+decision。
+
+## 8. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -146,7 +175,7 @@ gate、review、validation、host action 或 closeout authored fields。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 8. 非目标
+## 9. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -286,6 +286,30 @@
 `provenance` 是读取说明，不是新的 authored 字段组。它可以在 JSON 输出中按字段内联，也可以作为并列索引输出，但必须能被机械入口追溯到具体字段。
 若一个字段组混合消费多个来源，provenance 必须能下钻到字段级，不能用组级 provenance 掩盖局部 stale / drift。
 
+### 3.12 `external_orchestrator`
+
+当外部 orchestrator 只读消费 status / gate 时，状态面可以暴露派生 consumer view：
+
+- `schema_version`: 继续使用 `loom-governance-status/v2`
+- `view`: 固定为 `external_orchestrator_consumer`
+- `result`
+- `current_gate`
+- `classifications`
+- `missing_inputs`
+- `head_binding`
+- `gate_chain`
+- `allowed_operations`
+- `source_policy`
+- `provenance`
+- `recovery_readiness`
+
+该字段组只能投影本状态面的 `governance_status` 与 provenance。它不得定义第二套 status
+schema，不得 authored gate verdict，不得成为 scheduler state 或 tracker state。
+
+`allowed_operations` 只能声明 `status_read` 与 `gate_read`。`source_policy` 必须说明 status
+来自 `status control plane v2`、gate 来自现有 governance gate chain、writeback 只能回到
+recovery entry，失败回退只能指向 Loom checkpoint 或 gate 前置修复。
+
 ## 4. 总结果语义
 
 统一状态控制面本身只允许输出：

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -428,6 +428,8 @@ EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
     "workspace_attach",
     "recovery_writeback",
+    "status_read",
+    "gate_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2123,7 +2125,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`, `status_read`, `gate_read`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -4666,6 +4666,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 classifications = governance_status.get("classifications")
                 if not isinstance(classifications, list):
                     failures.append(Failure("daily-execution-cli", "`loom_status` governance_status must include classifications"))
+            external_orchestrator = payload.get("external_orchestrator")
+            if not isinstance(external_orchestrator, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `external_orchestrator` consumer view"))
+            else:
+                if external_orchestrator.get("schema_version") != "loom-governance-status/v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse governance status schema v2"))
+                if external_orchestrator.get("view") != "external_orchestrator_consumer":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator view must be consumer-only"))
+                if external_orchestrator.get("result") not in {"pass", "block"}:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator result must be `pass` or `block`"))
+                if external_orchestrator.get("allowed_operations") != ["status_read", "gate_read"]:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must expose only read operations"))
+                if not isinstance(external_orchestrator.get("gate_chain"), list):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse gate_chain"))
+                source_policy = external_orchestrator.get("source_policy")
+                if not isinstance(source_policy, dict):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must include source_policy"))
+                elif source_policy.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator fallback must point to Loom checkpoint"))
+                elif source_policy.get("status_source") != "derived_from_status_control_plane_v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read status from status control plane v2"))
+                elif source_policy.get("gate_source") != "derived_from_governance_gate_chain":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read gates from the governance gate chain"))
+                external_provenance = external_orchestrator.get("provenance")
+                if not (
+                    isinstance(external_provenance, dict)
+                    or (isinstance(external_provenance, list) and external_provenance)
+                ):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must carry provenance"))
             closeout = payload.get("closeout")
             if not isinstance(closeout, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `closeout`"))
@@ -9272,6 +9301,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-status.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "status_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "status_schema_version": "loom-governance-status/v2"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-gate.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "gate_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "gate_chain": "status_control_plane_v2"},
+                "consumed_as": "summary",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9370,6 +9417,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "required",
                 "fallback_to": "build",
+            },
+            {
+                "id": "fake-external-orchestrator-status",
+                "summary": "Read status control plane v2 without defining a second status surface.",
+                "surfaces": ["merge_ready"],
+                "operations": ["status_read"],
+                "locator": "host/external-orchestrator-status.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "current_checkpoint",
+            },
+            {
+                "id": "fake-external-orchestrator-gate",
+                "summary": "Read the Loom gate chain without authoring a gate verdict.",
+                "surfaces": ["merge_ready"],
+                "operations": ["gate_read"],
+                "locator": "host/external-orchestrator-gate.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "review_gate",
             },
         ],
         "shadow_surfaces": {
@@ -9736,6 +9803,24 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "workspace-attach-present",
         "recovery-writeback-present",
         "direct-status-write-block",
+        "status-read-present",
+        "gate-read-present",
+        "scheduler-private-fallback-block",
+    }
+    allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"}
+    loom_fallbacks = {
+        "work_item",
+        "admission",
+        "binding_repair",
+        "current_checkpoint",
+        "spec_gate",
+        "build_gate",
+        "review_gate",
+        "merge_gate",
+        "merge_ready",
+        "build",
+        "review",
+        "closeout",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9746,6 +9831,7 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
         else:
             seen_names.add(name)
+        expect = fixture.get("expect")
         entry = fixture.get("entry")
         if not isinstance(entry, dict):
             failures.append(Failure(category, f"{name or index} entry must be an object"))
@@ -9761,23 +9847,35 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
             if not isinstance(operations, list) or not operations:
                 failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
             elif any(operation not in allowed_operations for operation in operations):
                 failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
+            fallback_to = entry.get("fallback_to")
+            if (
+                isinstance(fallback_to, str)
+                and fallback_to not in loom_fallbacks
+                and (not isinstance(expect, dict) or expect.get("result") != "block")
+            ):
+                failures.append(Failure(category, f"{name or index} fallback_to must point to a Loom checkpoint or gate repair surface"))
         payload = fixture.get("payload")
-        expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
             failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
         if payload is not None:
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                if payload.get("operation") not in allowed_operations:
                     failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                payload_fallback = payload.get("fallback_to")
+                if (
+                    isinstance(payload_fallback, str)
+                    and payload_fallback not in loom_fallbacks
+                    and (not isinstance(expect, dict) or expect.get("result") != "block")
+                ):
+                    failures.append(Failure(category, f"{name or index} payload fallback_to must point to a Loom checkpoint or gate repair surface"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
                 if forbidden and expect.get("result") != "block":
                     failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
@@ -9785,6 +9883,27 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
                     failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
                 if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
                     failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+                if payload.get("operation") in {"status_read", "gate_read"}:
+                    if payload.get("source_layer") != "derived_surface":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must consume the derived status surface"))
+                    if payload.get("consumed_as") != "summary":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must be consumed as summary, not authored truth"))
+                    if payload.get("operation") == "status_read":
+                        status_fields = payload.get("status_fields")
+                        required_status_fields = {"result", "current_gate", "classifications", "missing_inputs", "head_binding", "gate_chain", "provenance"}
+                        if not isinstance(status_fields, list) or not required_status_fields.issubset(set(status_fields)):
+                            failures.append(Failure(category, f"{name or index} status_read fixture must reuse status control plane v2 fields"))
+                    if payload.get("operation") == "gate_read":
+                        gate_fields = payload.get("gate_fields")
+                        required_gate_fields = {"name", "result", "classification", "missing_inputs", "fallback_to"}
+                        if expect.get("result") != "block" and (not isinstance(gate_fields, list) or not required_gate_fields.issubset(set(gate_fields))):
+                            failures.append(Failure(category, f"{name or index} gate_read fixture must reuse the existing gate chain fields"))
+                if name == "scheduler-private-fallback-block" and expect.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure(category, "scheduler-private fallback fixture must fallback to `current_checkpoint`"))
+                if name == "scheduler-private-fallback-block":
+                    entry_fallback = entry.get("fallback_to") if isinstance(entry, dict) else None
+                    if entry_fallback in loom_fallbacks or payload.get("fallback_to") in loom_fallbacks:
+                        failures.append(Failure(category, "scheduler-private fallback fixture must prove a private fallback is blocked"))
 
     missing = sorted(required_names - seen_names)
     if missing:

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_status.py
@@ -205,6 +205,50 @@ def governance_control_status(
     }
 
 
+def external_orchestrator_consumer_status(
+    *,
+    control_status: dict[str, object],
+    provenance: dict[str, object],
+    recovery_readiness: dict[str, object],
+) -> dict[str, object]:
+    gate_chain = control_status.get("gate_chain")
+    if not isinstance(gate_chain, list):
+        gate_chain = []
+    external_gates = []
+    for gate in gate_chain:
+        if not isinstance(gate, dict):
+            continue
+        external_gates.append(
+            {
+                "name": gate.get("name"),
+                "result": gate.get("result"),
+                "classification": gate.get("classification"),
+                "missing_inputs": gate.get("missing_inputs", []),
+                "fallback_to": gate.get("fallback_to"),
+            }
+        )
+
+    return {
+        "schema_version": control_status.get("schema_version", "loom-governance-status/v2"),
+        "view": "external_orchestrator_consumer",
+        "result": control_status.get("result", "block"),
+        "current_gate": control_status.get("current_gate"),
+        "classifications": control_status.get("classifications", []),
+        "missing_inputs": control_status.get("missing_inputs", []),
+        "head_binding": control_status.get("head_binding", {}),
+        "gate_chain": external_gates,
+        "allowed_operations": ["status_read", "gate_read"],
+        "source_policy": {
+            "status_source": "derived_from_status_control_plane_v2",
+            "gate_source": "derived_from_governance_gate_chain",
+            "writeback": "recovery_entry_only",
+            "fallback_to": "current_checkpoint",
+        },
+        "provenance": provenance,
+        "recovery_readiness": recovery_readiness,
+    }
+
+
 def closeout_status_payload(
     *,
     github_status: dict[str, object],
@@ -535,6 +579,14 @@ def main(argv: list[str]) -> int:
         if result == "pass"
         else "status surface is readable, but one or more governance gates are still blocking or stale."
     )
+    provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    external_orchestrator = external_orchestrator_consumer_status(
+        control_status=control_status,
+        provenance=provenance,
+        recovery_readiness=recovery_readiness,
+    )
+
     return emit(
         {
             "command": "status",
@@ -543,8 +595,8 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
-            "provenance": report_provenance(context["report"]),
-            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "provenance": provenance,
+            "recovery_readiness": recovery_readiness,
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
@@ -586,6 +638,7 @@ def main(argv: list[str]) -> int:
             "ci_check_presence": ci_check_presence,
             "host_enforcement": host_enforcement,
             "governance_status": control_status,
+            "external_orchestrator": external_orchestrator,
             "governance_surface": governance_surface,
             "github": github_status,
         }

--- a/skills/loom-story/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/loom-story/.loom-runtime/shared/references/harness/external-orchestrator-interop.md
@@ -83,9 +83,10 @@ merge commit 反推执行入口。
 - `work_item_read`
 - `workspace_attach`
 - `recovery_writeback`
+- `status_read`
+- `gate_read`
 
-后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
-fact-chain，不得新增第二状态面。
+`status_read` 与 `gate_read` 必须消费同一 fact-chain，不得新增第二状态面。
 
 ## 5. Workspace Attach
 
@@ -126,7 +127,35 @@ orchestrator 私有 action。
 写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
 gate、review、validation、host action 或 closeout authored fields。
 
-## 7. Truth Boundary
+## 7. Status / Gate Consumption
+
+外部 orchestrator 可以只读消费 `status control plane v2` 与现有 gate chain。
+
+它读取的状态必须与 Loom 本地入口同源：
+
+- `schema_version` 继续使用 `loom-governance-status/v2`
+- `result`、`current_gate`、`classifications`、`missing_inputs`、`head_binding`
+  与 `gate_chain` 来自同一个 status control plane
+- `provenance` 继续指向 Work Item、recovery entry、review / checkpoint / host mirror
+  等既有来源
+
+外部 orchestrator 视图只能是 consumer view。它可以裁剪字段以便消费，但不得定义
+新的 status schema、不得 authored `pass | block`、不得替换 gate chain。
+
+当 status/gate 读取无法消费时，回退只能指向 Loom checkpoint 或 gate 前置修复，例如：
+
+- `current_checkpoint`
+- `spec_gate`
+- `build_gate`
+- `review_gate`
+- `merge_gate`
+- `admission`
+- `binding_repair`
+
+不得回退到 scheduler 私有 action、retry queue、tracker state 或 orchestrator-owned
+decision。
+
+## 8. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -146,7 +175,7 @@ gate、review、validation、host action 或 closeout authored fields。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 8. 非目标
+## 9. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/loom-story/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-story/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -286,6 +286,30 @@
 `provenance` 是读取说明，不是新的 authored 字段组。它可以在 JSON 输出中按字段内联，也可以作为并列索引输出，但必须能被机械入口追溯到具体字段。
 若一个字段组混合消费多个来源，provenance 必须能下钻到字段级，不能用组级 provenance 掩盖局部 stale / drift。
 
+### 3.12 `external_orchestrator`
+
+当外部 orchestrator 只读消费 status / gate 时，状态面可以暴露派生 consumer view：
+
+- `schema_version`: 继续使用 `loom-governance-status/v2`
+- `view`: 固定为 `external_orchestrator_consumer`
+- `result`
+- `current_gate`
+- `classifications`
+- `missing_inputs`
+- `head_binding`
+- `gate_chain`
+- `allowed_operations`
+- `source_policy`
+- `provenance`
+- `recovery_readiness`
+
+该字段组只能投影本状态面的 `governance_status` 与 provenance。它不得定义第二套 status
+schema，不得 authored gate verdict，不得成为 scheduler state 或 tracker state。
+
+`allowed_operations` 只能声明 `status_read` 与 `gate_read`。`source_policy` 必须说明 status
+来自 `status control plane v2`、gate 来自现有 governance gate chain、writeback 只能回到
+recovery entry，失败回退只能指向 Loom checkpoint 或 gate 前置修复。
+
 ## 4. 总结果语义
 
 统一状态控制面本身只允许输出：

--- a/skills/loom-story/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/governance_surface.py
@@ -428,6 +428,8 @@ EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
     "workspace_attach",
     "recovery_writeback",
+    "status_read",
+    "gate_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2123,7 +2125,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`, `status_read`, `gate_read`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
@@ -4666,6 +4666,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 classifications = governance_status.get("classifications")
                 if not isinstance(classifications, list):
                     failures.append(Failure("daily-execution-cli", "`loom_status` governance_status must include classifications"))
+            external_orchestrator = payload.get("external_orchestrator")
+            if not isinstance(external_orchestrator, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `external_orchestrator` consumer view"))
+            else:
+                if external_orchestrator.get("schema_version") != "loom-governance-status/v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse governance status schema v2"))
+                if external_orchestrator.get("view") != "external_orchestrator_consumer":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator view must be consumer-only"))
+                if external_orchestrator.get("result") not in {"pass", "block"}:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator result must be `pass` or `block`"))
+                if external_orchestrator.get("allowed_operations") != ["status_read", "gate_read"]:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must expose only read operations"))
+                if not isinstance(external_orchestrator.get("gate_chain"), list):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse gate_chain"))
+                source_policy = external_orchestrator.get("source_policy")
+                if not isinstance(source_policy, dict):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must include source_policy"))
+                elif source_policy.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator fallback must point to Loom checkpoint"))
+                elif source_policy.get("status_source") != "derived_from_status_control_plane_v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read status from status control plane v2"))
+                elif source_policy.get("gate_source") != "derived_from_governance_gate_chain":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read gates from the governance gate chain"))
+                external_provenance = external_orchestrator.get("provenance")
+                if not (
+                    isinstance(external_provenance, dict)
+                    or (isinstance(external_provenance, list) and external_provenance)
+                ):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must carry provenance"))
             closeout = payload.get("closeout")
             if not isinstance(closeout, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `closeout`"))
@@ -9272,6 +9301,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-status.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "status_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "status_schema_version": "loom-governance-status/v2"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-gate.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "gate_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "gate_chain": "status_control_plane_v2"},
+                "consumed_as": "summary",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9370,6 +9417,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "required",
                 "fallback_to": "build",
+            },
+            {
+                "id": "fake-external-orchestrator-status",
+                "summary": "Read status control plane v2 without defining a second status surface.",
+                "surfaces": ["merge_ready"],
+                "operations": ["status_read"],
+                "locator": "host/external-orchestrator-status.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "current_checkpoint",
+            },
+            {
+                "id": "fake-external-orchestrator-gate",
+                "summary": "Read the Loom gate chain without authoring a gate verdict.",
+                "surfaces": ["merge_ready"],
+                "operations": ["gate_read"],
+                "locator": "host/external-orchestrator-gate.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "review_gate",
             },
         ],
         "shadow_surfaces": {
@@ -9736,6 +9803,24 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "workspace-attach-present",
         "recovery-writeback-present",
         "direct-status-write-block",
+        "status-read-present",
+        "gate-read-present",
+        "scheduler-private-fallback-block",
+    }
+    allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"}
+    loom_fallbacks = {
+        "work_item",
+        "admission",
+        "binding_repair",
+        "current_checkpoint",
+        "spec_gate",
+        "build_gate",
+        "review_gate",
+        "merge_gate",
+        "merge_ready",
+        "build",
+        "review",
+        "closeout",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9746,6 +9831,7 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
         else:
             seen_names.add(name)
+        expect = fixture.get("expect")
         entry = fixture.get("entry")
         if not isinstance(entry, dict):
             failures.append(Failure(category, f"{name or index} entry must be an object"))
@@ -9761,23 +9847,35 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
             if not isinstance(operations, list) or not operations:
                 failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
             elif any(operation not in allowed_operations for operation in operations):
                 failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
+            fallback_to = entry.get("fallback_to")
+            if (
+                isinstance(fallback_to, str)
+                and fallback_to not in loom_fallbacks
+                and (not isinstance(expect, dict) or expect.get("result") != "block")
+            ):
+                failures.append(Failure(category, f"{name or index} fallback_to must point to a Loom checkpoint or gate repair surface"))
         payload = fixture.get("payload")
-        expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
             failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
         if payload is not None:
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                if payload.get("operation") not in allowed_operations:
                     failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                payload_fallback = payload.get("fallback_to")
+                if (
+                    isinstance(payload_fallback, str)
+                    and payload_fallback not in loom_fallbacks
+                    and (not isinstance(expect, dict) or expect.get("result") != "block")
+                ):
+                    failures.append(Failure(category, f"{name or index} payload fallback_to must point to a Loom checkpoint or gate repair surface"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
                 if forbidden and expect.get("result") != "block":
                     failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
@@ -9785,6 +9883,27 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
                     failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
                 if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
                     failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+                if payload.get("operation") in {"status_read", "gate_read"}:
+                    if payload.get("source_layer") != "derived_surface":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must consume the derived status surface"))
+                    if payload.get("consumed_as") != "summary":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must be consumed as summary, not authored truth"))
+                    if payload.get("operation") == "status_read":
+                        status_fields = payload.get("status_fields")
+                        required_status_fields = {"result", "current_gate", "classifications", "missing_inputs", "head_binding", "gate_chain", "provenance"}
+                        if not isinstance(status_fields, list) or not required_status_fields.issubset(set(status_fields)):
+                            failures.append(Failure(category, f"{name or index} status_read fixture must reuse status control plane v2 fields"))
+                    if payload.get("operation") == "gate_read":
+                        gate_fields = payload.get("gate_fields")
+                        required_gate_fields = {"name", "result", "classification", "missing_inputs", "fallback_to"}
+                        if expect.get("result") != "block" and (not isinstance(gate_fields, list) or not required_gate_fields.issubset(set(gate_fields))):
+                            failures.append(Failure(category, f"{name or index} gate_read fixture must reuse the existing gate chain fields"))
+                if name == "scheduler-private-fallback-block" and expect.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure(category, "scheduler-private fallback fixture must fallback to `current_checkpoint`"))
+                if name == "scheduler-private-fallback-block":
+                    entry_fallback = entry.get("fallback_to") if isinstance(entry, dict) else None
+                    if entry_fallback in loom_fallbacks or payload.get("fallback_to") in loom_fallbacks:
+                        failures.append(Failure(category, "scheduler-private fallback fixture must prove a private fallback is blocked"))
 
     missing = sorted(required_names - seen_names)
     if missing:

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_status.py
@@ -205,6 +205,50 @@ def governance_control_status(
     }
 
 
+def external_orchestrator_consumer_status(
+    *,
+    control_status: dict[str, object],
+    provenance: dict[str, object],
+    recovery_readiness: dict[str, object],
+) -> dict[str, object]:
+    gate_chain = control_status.get("gate_chain")
+    if not isinstance(gate_chain, list):
+        gate_chain = []
+    external_gates = []
+    for gate in gate_chain:
+        if not isinstance(gate, dict):
+            continue
+        external_gates.append(
+            {
+                "name": gate.get("name"),
+                "result": gate.get("result"),
+                "classification": gate.get("classification"),
+                "missing_inputs": gate.get("missing_inputs", []),
+                "fallback_to": gate.get("fallback_to"),
+            }
+        )
+
+    return {
+        "schema_version": control_status.get("schema_version", "loom-governance-status/v2"),
+        "view": "external_orchestrator_consumer",
+        "result": control_status.get("result", "block"),
+        "current_gate": control_status.get("current_gate"),
+        "classifications": control_status.get("classifications", []),
+        "missing_inputs": control_status.get("missing_inputs", []),
+        "head_binding": control_status.get("head_binding", {}),
+        "gate_chain": external_gates,
+        "allowed_operations": ["status_read", "gate_read"],
+        "source_policy": {
+            "status_source": "derived_from_status_control_plane_v2",
+            "gate_source": "derived_from_governance_gate_chain",
+            "writeback": "recovery_entry_only",
+            "fallback_to": "current_checkpoint",
+        },
+        "provenance": provenance,
+        "recovery_readiness": recovery_readiness,
+    }
+
+
 def closeout_status_payload(
     *,
     github_status: dict[str, object],
@@ -535,6 +579,14 @@ def main(argv: list[str]) -> int:
         if result == "pass"
         else "status surface is readable, but one or more governance gates are still blocking or stale."
     )
+    provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    external_orchestrator = external_orchestrator_consumer_status(
+        control_status=control_status,
+        provenance=provenance,
+        recovery_readiness=recovery_readiness,
+    )
+
     return emit(
         {
             "command": "status",
@@ -543,8 +595,8 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
-            "provenance": report_provenance(context["report"]),
-            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "provenance": provenance,
+            "recovery_readiness": recovery_readiness,
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
@@ -586,6 +638,7 @@ def main(argv: list[str]) -> int:
             "ci_check_presence": ci_check_presence,
             "host_enforcement": host_enforcement,
             "governance_status": control_status,
+            "external_orchestrator": external_orchestrator,
             "governance_surface": governance_surface,
             "github": github_status,
         }

--- a/skills/shared/references/harness/external-orchestrator-interop.md
+++ b/skills/shared/references/harness/external-orchestrator-interop.md
@@ -83,9 +83,10 @@ merge commit 反推执行入口。
 - `work_item_read`
 - `workspace_attach`
 - `recovery_writeback`
+- `status_read`
+- `gate_read`
 
-后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
-fact-chain，不得新增第二状态面。
+`status_read` 与 `gate_read` 必须消费同一 fact-chain，不得新增第二状态面。
 
 ## 5. Workspace Attach
 
@@ -126,7 +127,35 @@ orchestrator 私有 action。
 写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
 gate、review、validation、host action 或 closeout authored fields。
 
-## 7. Truth Boundary
+## 7. Status / Gate Consumption
+
+外部 orchestrator 可以只读消费 `status control plane v2` 与现有 gate chain。
+
+它读取的状态必须与 Loom 本地入口同源：
+
+- `schema_version` 继续使用 `loom-governance-status/v2`
+- `result`、`current_gate`、`classifications`、`missing_inputs`、`head_binding`
+  与 `gate_chain` 来自同一个 status control plane
+- `provenance` 继续指向 Work Item、recovery entry、review / checkpoint / host mirror
+  等既有来源
+
+外部 orchestrator 视图只能是 consumer view。它可以裁剪字段以便消费，但不得定义
+新的 status schema、不得 authored `pass | block`、不得替换 gate chain。
+
+当 status/gate 读取无法消费时，回退只能指向 Loom checkpoint 或 gate 前置修复，例如：
+
+- `current_checkpoint`
+- `spec_gate`
+- `build_gate`
+- `review_gate`
+- `merge_gate`
+- `admission`
+- `binding_repair`
+
+不得回退到 scheduler 私有 action、retry queue、tracker state 或 orchestrator-owned
+decision。
+
+## 8. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -146,7 +175,7 @@ gate、review、validation、host action 或 closeout authored fields。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 8. 非目标
+## 9. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/skills/shared/references/harness/status-surface-contract.md
+++ b/skills/shared/references/harness/status-surface-contract.md
@@ -286,6 +286,30 @@
 `provenance` 是读取说明，不是新的 authored 字段组。它可以在 JSON 输出中按字段内联，也可以作为并列索引输出，但必须能被机械入口追溯到具体字段。
 若一个字段组混合消费多个来源，provenance 必须能下钻到字段级，不能用组级 provenance 掩盖局部 stale / drift。
 
+### 3.12 `external_orchestrator`
+
+当外部 orchestrator 只读消费 status / gate 时，状态面可以暴露派生 consumer view：
+
+- `schema_version`: 继续使用 `loom-governance-status/v2`
+- `view`: 固定为 `external_orchestrator_consumer`
+- `result`
+- `current_gate`
+- `classifications`
+- `missing_inputs`
+- `head_binding`
+- `gate_chain`
+- `allowed_operations`
+- `source_policy`
+- `provenance`
+- `recovery_readiness`
+
+该字段组只能投影本状态面的 `governance_status` 与 provenance。它不得定义第二套 status
+schema，不得 authored gate verdict，不得成为 scheduler state 或 tracker state。
+
+`allowed_operations` 只能声明 `status_read` 与 `gate_read`。`source_policy` 必须说明 status
+来自 `status control plane v2`、gate 来自现有 governance gate chain、writeback 只能回到
+recovery entry，失败回退只能指向 Loom checkpoint 或 gate 前置修复。
+
 ## 4. 总结果语义
 
 统一状态控制面本身只允许输出：

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -428,6 +428,8 @@ EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
     "workspace_attach",
     "recovery_writeback",
+    "status_read",
+    "gate_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2123,7 +2125,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`, `status_read`, `gate_read`"
                 )
     return missing_inputs, missing_optional
 

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -4666,6 +4666,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 classifications = governance_status.get("classifications")
                 if not isinstance(classifications, list):
                     failures.append(Failure("daily-execution-cli", "`loom_status` governance_status must include classifications"))
+            external_orchestrator = payload.get("external_orchestrator")
+            if not isinstance(external_orchestrator, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `external_orchestrator` consumer view"))
+            else:
+                if external_orchestrator.get("schema_version") != "loom-governance-status/v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse governance status schema v2"))
+                if external_orchestrator.get("view") != "external_orchestrator_consumer":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator view must be consumer-only"))
+                if external_orchestrator.get("result") not in {"pass", "block"}:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator result must be `pass` or `block`"))
+                if external_orchestrator.get("allowed_operations") != ["status_read", "gate_read"]:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must expose only read operations"))
+                if not isinstance(external_orchestrator.get("gate_chain"), list):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse gate_chain"))
+                source_policy = external_orchestrator.get("source_policy")
+                if not isinstance(source_policy, dict):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must include source_policy"))
+                elif source_policy.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator fallback must point to Loom checkpoint"))
+                elif source_policy.get("status_source") != "derived_from_status_control_plane_v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read status from status control plane v2"))
+                elif source_policy.get("gate_source") != "derived_from_governance_gate_chain":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read gates from the governance gate chain"))
+                external_provenance = external_orchestrator.get("provenance")
+                if not (
+                    isinstance(external_provenance, dict)
+                    or (isinstance(external_provenance, list) and external_provenance)
+                ):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must carry provenance"))
             closeout = payload.get("closeout")
             if not isinstance(closeout, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `closeout`"))
@@ -9272,6 +9301,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-status.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "status_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "status_schema_version": "loom-governance-status/v2"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-gate.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "gate_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "gate_chain": "status_control_plane_v2"},
+                "consumed_as": "summary",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9370,6 +9417,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "required",
                 "fallback_to": "build",
+            },
+            {
+                "id": "fake-external-orchestrator-status",
+                "summary": "Read status control plane v2 without defining a second status surface.",
+                "surfaces": ["merge_ready"],
+                "operations": ["status_read"],
+                "locator": "host/external-orchestrator-status.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "current_checkpoint",
+            },
+            {
+                "id": "fake-external-orchestrator-gate",
+                "summary": "Read the Loom gate chain without authoring a gate verdict.",
+                "surfaces": ["merge_ready"],
+                "operations": ["gate_read"],
+                "locator": "host/external-orchestrator-gate.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "review_gate",
             },
         ],
         "shadow_surfaces": {
@@ -9736,6 +9803,24 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "workspace-attach-present",
         "recovery-writeback-present",
         "direct-status-write-block",
+        "status-read-present",
+        "gate-read-present",
+        "scheduler-private-fallback-block",
+    }
+    allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"}
+    loom_fallbacks = {
+        "work_item",
+        "admission",
+        "binding_repair",
+        "current_checkpoint",
+        "spec_gate",
+        "build_gate",
+        "review_gate",
+        "merge_gate",
+        "merge_ready",
+        "build",
+        "review",
+        "closeout",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9746,6 +9831,7 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
         else:
             seen_names.add(name)
+        expect = fixture.get("expect")
         entry = fixture.get("entry")
         if not isinstance(entry, dict):
             failures.append(Failure(category, f"{name or index} entry must be an object"))
@@ -9761,23 +9847,35 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
             if not isinstance(operations, list) or not operations:
                 failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
             elif any(operation not in allowed_operations for operation in operations):
                 failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
+            fallback_to = entry.get("fallback_to")
+            if (
+                isinstance(fallback_to, str)
+                and fallback_to not in loom_fallbacks
+                and (not isinstance(expect, dict) or expect.get("result") != "block")
+            ):
+                failures.append(Failure(category, f"{name or index} fallback_to must point to a Loom checkpoint or gate repair surface"))
         payload = fixture.get("payload")
-        expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
             failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
         if payload is not None:
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                if payload.get("operation") not in allowed_operations:
                     failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                payload_fallback = payload.get("fallback_to")
+                if (
+                    isinstance(payload_fallback, str)
+                    and payload_fallback not in loom_fallbacks
+                    and (not isinstance(expect, dict) or expect.get("result") != "block")
+                ):
+                    failures.append(Failure(category, f"{name or index} payload fallback_to must point to a Loom checkpoint or gate repair surface"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
                 if forbidden and expect.get("result") != "block":
                     failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
@@ -9785,6 +9883,27 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
                     failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
                 if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
                     failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+                if payload.get("operation") in {"status_read", "gate_read"}:
+                    if payload.get("source_layer") != "derived_surface":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must consume the derived status surface"))
+                    if payload.get("consumed_as") != "summary":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must be consumed as summary, not authored truth"))
+                    if payload.get("operation") == "status_read":
+                        status_fields = payload.get("status_fields")
+                        required_status_fields = {"result", "current_gate", "classifications", "missing_inputs", "head_binding", "gate_chain", "provenance"}
+                        if not isinstance(status_fields, list) or not required_status_fields.issubset(set(status_fields)):
+                            failures.append(Failure(category, f"{name or index} status_read fixture must reuse status control plane v2 fields"))
+                    if payload.get("operation") == "gate_read":
+                        gate_fields = payload.get("gate_fields")
+                        required_gate_fields = {"name", "result", "classification", "missing_inputs", "fallback_to"}
+                        if expect.get("result") != "block" and (not isinstance(gate_fields, list) or not required_gate_fields.issubset(set(gate_fields))):
+                            failures.append(Failure(category, f"{name or index} gate_read fixture must reuse the existing gate chain fields"))
+                if name == "scheduler-private-fallback-block" and expect.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure(category, "scheduler-private fallback fixture must fallback to `current_checkpoint`"))
+                if name == "scheduler-private-fallback-block":
+                    entry_fallback = entry.get("fallback_to") if isinstance(entry, dict) else None
+                    if entry_fallback in loom_fallbacks or payload.get("fallback_to") in loom_fallbacks:
+                        failures.append(Failure(category, "scheduler-private fallback fixture must prove a private fallback is blocked"))
 
     missing = sorted(required_names - seen_names)
     if missing:

--- a/skills/shared/scripts/loom_status.py
+++ b/skills/shared/scripts/loom_status.py
@@ -205,6 +205,50 @@ def governance_control_status(
     }
 
 
+def external_orchestrator_consumer_status(
+    *,
+    control_status: dict[str, object],
+    provenance: dict[str, object],
+    recovery_readiness: dict[str, object],
+) -> dict[str, object]:
+    gate_chain = control_status.get("gate_chain")
+    if not isinstance(gate_chain, list):
+        gate_chain = []
+    external_gates = []
+    for gate in gate_chain:
+        if not isinstance(gate, dict):
+            continue
+        external_gates.append(
+            {
+                "name": gate.get("name"),
+                "result": gate.get("result"),
+                "classification": gate.get("classification"),
+                "missing_inputs": gate.get("missing_inputs", []),
+                "fallback_to": gate.get("fallback_to"),
+            }
+        )
+
+    return {
+        "schema_version": control_status.get("schema_version", "loom-governance-status/v2"),
+        "view": "external_orchestrator_consumer",
+        "result": control_status.get("result", "block"),
+        "current_gate": control_status.get("current_gate"),
+        "classifications": control_status.get("classifications", []),
+        "missing_inputs": control_status.get("missing_inputs", []),
+        "head_binding": control_status.get("head_binding", {}),
+        "gate_chain": external_gates,
+        "allowed_operations": ["status_read", "gate_read"],
+        "source_policy": {
+            "status_source": "derived_from_status_control_plane_v2",
+            "gate_source": "derived_from_governance_gate_chain",
+            "writeback": "recovery_entry_only",
+            "fallback_to": "current_checkpoint",
+        },
+        "provenance": provenance,
+        "recovery_readiness": recovery_readiness,
+    }
+
+
 def closeout_status_payload(
     *,
     github_status: dict[str, object],
@@ -535,6 +579,14 @@ def main(argv: list[str]) -> int:
         if result == "pass"
         else "status surface is readable, but one or more governance gates are still blocking or stale."
     )
+    provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    external_orchestrator = external_orchestrator_consumer_status(
+        control_status=control_status,
+        provenance=provenance,
+        recovery_readiness=recovery_readiness,
+    )
+
     return emit(
         {
             "command": "status",
@@ -543,8 +595,8 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
-            "provenance": report_provenance(context["report"]),
-            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "provenance": provenance,
+            "recovery_readiness": recovery_readiness,
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
@@ -586,6 +638,7 @@ def main(argv: list[str]) -> int:
             "ci_check_presence": ci_check_presence,
             "host_enforcement": host_enforcement,
             "governance_status": control_status,
+            "external_orchestrator": external_orchestrator,
             "governance_surface": governance_surface,
             "github": github_status,
         }

--- a/src/skills/shared/references/harness/external-orchestrator-interop.md
+++ b/src/skills/shared/references/harness/external-orchestrator-interop.md
@@ -83,9 +83,10 @@ merge commit 反推执行入口。
 - `work_item_read`
 - `workspace_attach`
 - `recovery_writeback`
+- `status_read`
+- `gate_read`
 
-后续可扩展到 `status_read` 与 `gate_read`，但这些扩展仍必须消费同一
-fact-chain，不得新增第二状态面。
+`status_read` 与 `gate_read` 必须消费同一 fact-chain，不得新增第二状态面。
 
 ## 5. Workspace Attach
 
@@ -126,7 +127,35 @@ orchestrator 私有 action。
 写回后，status control plane 只能重新派生或刷新；外部 orchestrator 不得直接写 status、
 gate、review、validation、host action 或 closeout authored fields。
 
-## 7. Truth Boundary
+## 7. Status / Gate Consumption
+
+外部 orchestrator 可以只读消费 `status control plane v2` 与现有 gate chain。
+
+它读取的状态必须与 Loom 本地入口同源：
+
+- `schema_version` 继续使用 `loom-governance-status/v2`
+- `result`、`current_gate`、`classifications`、`missing_inputs`、`head_binding`
+  与 `gate_chain` 来自同一个 status control plane
+- `provenance` 继续指向 Work Item、recovery entry、review / checkpoint / host mirror
+  等既有来源
+
+外部 orchestrator 视图只能是 consumer view。它可以裁剪字段以便消费，但不得定义
+新的 status schema、不得 authored `pass | block`、不得替换 gate chain。
+
+当 status/gate 读取无法消费时，回退只能指向 Loom checkpoint 或 gate 前置修复，例如：
+
+- `current_checkpoint`
+- `spec_gate`
+- `build_gate`
+- `review_gate`
+- `merge_gate`
+- `admission`
+- `binding_repair`
+
+不得回退到 scheduler 私有 action、retry queue、tracker state 或 orchestrator-owned
+decision。
+
+## 8. Truth Boundary
 
 `external_orchestrators` 不得承载：
 
@@ -146,7 +175,7 @@ gate、review、validation、host action 或 closeout authored fields。
 这些字段若出现在 external orchestrator locator payload 中，必须被视为 truth
 pollution，并阻断 required 声明。
 
-## 8. 非目标
+## 9. 非目标
 
 - 不提供默认 daemon
 - 不定义 tracker polling 产品

--- a/src/skills/shared/references/harness/status-surface-contract.md
+++ b/src/skills/shared/references/harness/status-surface-contract.md
@@ -286,6 +286,30 @@
 `provenance` 是读取说明，不是新的 authored 字段组。它可以在 JSON 输出中按字段内联，也可以作为并列索引输出，但必须能被机械入口追溯到具体字段。
 若一个字段组混合消费多个来源，provenance 必须能下钻到字段级，不能用组级 provenance 掩盖局部 stale / drift。
 
+### 3.12 `external_orchestrator`
+
+当外部 orchestrator 只读消费 status / gate 时，状态面可以暴露派生 consumer view：
+
+- `schema_version`: 继续使用 `loom-governance-status/v2`
+- `view`: 固定为 `external_orchestrator_consumer`
+- `result`
+- `current_gate`
+- `classifications`
+- `missing_inputs`
+- `head_binding`
+- `gate_chain`
+- `allowed_operations`
+- `source_policy`
+- `provenance`
+- `recovery_readiness`
+
+该字段组只能投影本状态面的 `governance_status` 与 provenance。它不得定义第二套 status
+schema，不得 authored gate verdict，不得成为 scheduler state 或 tracker state。
+
+`allowed_operations` 只能声明 `status_read` 与 `gate_read`。`source_policy` 必须说明 status
+来自 `status control plane v2`、gate 来自现有 governance gate chain、writeback 只能回到
+recovery entry，失败回退只能指向 Loom checkpoint 或 gate 前置修复。
+
 ## 4. 总结果语义
 
 统一状态控制面本身只允许输出：

--- a/src/skills/shared/scripts/governance_surface.py
+++ b/src/skills/shared/scripts/governance_surface.py
@@ -428,6 +428,8 @@ EXTERNAL_ORCHESTRATOR_OPERATIONS = {
     "work_item_read",
     "workspace_attach",
     "recovery_writeback",
+    "status_read",
+    "gate_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -2123,7 +2125,7 @@ def validate_external_orchestrator_entry(
         for operation_index, operation in enumerate(operations):
             if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
                 missing_inputs.append(
-                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`"
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`, `status_read`, `gate_read`"
                 )
     return missing_inputs, missing_optional
 

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -4666,6 +4666,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 classifications = governance_status.get("classifications")
                 if not isinstance(classifications, list):
                     failures.append(Failure("daily-execution-cli", "`loom_status` governance_status must include classifications"))
+            external_orchestrator = payload.get("external_orchestrator")
+            if not isinstance(external_orchestrator, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `external_orchestrator` consumer view"))
+            else:
+                if external_orchestrator.get("schema_version") != "loom-governance-status/v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse governance status schema v2"))
+                if external_orchestrator.get("view") != "external_orchestrator_consumer":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator view must be consumer-only"))
+                if external_orchestrator.get("result") not in {"pass", "block"}:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator result must be `pass` or `block`"))
+                if external_orchestrator.get("allowed_operations") != ["status_read", "gate_read"]:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must expose only read operations"))
+                if not isinstance(external_orchestrator.get("gate_chain"), list):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse gate_chain"))
+                source_policy = external_orchestrator.get("source_policy")
+                if not isinstance(source_policy, dict):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must include source_policy"))
+                elif source_policy.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator fallback must point to Loom checkpoint"))
+                elif source_policy.get("status_source") != "derived_from_status_control_plane_v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read status from status control plane v2"))
+                elif source_policy.get("gate_source") != "derived_from_governance_gate_chain":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read gates from the governance gate chain"))
+                external_provenance = external_orchestrator.get("provenance")
+                if not (
+                    isinstance(external_provenance, dict)
+                    or (isinstance(external_provenance, list) and external_provenance)
+                ):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must carry provenance"))
             closeout = payload.get("closeout")
             if not isinstance(closeout, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `closeout`"))
@@ -9272,6 +9301,24 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "source_binding": {"item_id": "INIT-0001"},
                 "consumed_as": "locator",
             },
+            "host/external-orchestrator-status.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "status_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "status_schema_version": "loom-governance-status/v2"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-gate.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "gate_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "gate_chain": "status_control_plane_v2"},
+                "consumed_as": "summary",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -9370,6 +9417,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "owner": "external-tool",
                 "requirement": "required",
                 "fallback_to": "build",
+            },
+            {
+                "id": "fake-external-orchestrator-status",
+                "summary": "Read status control plane v2 without defining a second status surface.",
+                "surfaces": ["merge_ready"],
+                "operations": ["status_read"],
+                "locator": "host/external-orchestrator-status.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "current_checkpoint",
+            },
+            {
+                "id": "fake-external-orchestrator-gate",
+                "summary": "Read the Loom gate chain without authoring a gate verdict.",
+                "surfaces": ["merge_ready"],
+                "operations": ["gate_read"],
+                "locator": "host/external-orchestrator-gate.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "review_gate",
             },
         ],
         "shadow_surfaces": {
@@ -9736,6 +9803,24 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
         "workspace-attach-present",
         "recovery-writeback-present",
         "direct-status-write-block",
+        "status-read-present",
+        "gate-read-present",
+        "scheduler-private-fallback-block",
+    }
+    allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"}
+    loom_fallbacks = {
+        "work_item",
+        "admission",
+        "binding_repair",
+        "current_checkpoint",
+        "spec_gate",
+        "build_gate",
+        "review_gate",
+        "merge_gate",
+        "merge_ready",
+        "build",
+        "review",
+        "closeout",
     }
     for index, fixture in enumerate(fixtures):
         if not isinstance(fixture, dict):
@@ -9746,6 +9831,7 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
         else:
             seen_names.add(name)
+        expect = fixture.get("expect")
         entry = fixture.get("entry")
         if not isinstance(entry, dict):
             failures.append(Failure(category, f"{name or index} entry must be an object"))
@@ -9761,23 +9847,35 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
             if not isinstance(surfaces, list) or not surfaces:
                 failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
             operations = entry.get("operations")
-            allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback"}
             if not isinstance(operations, list) or not operations:
                 failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
             elif any(operation not in allowed_operations for operation in operations):
                 failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
+            fallback_to = entry.get("fallback_to")
+            if (
+                isinstance(fallback_to, str)
+                and fallback_to not in loom_fallbacks
+                and (not isinstance(expect, dict) or expect.get("result") != "block")
+            ):
+                failures.append(Failure(category, f"{name or index} fallback_to must point to a Loom checkpoint or gate repair surface"))
         payload = fixture.get("payload")
-        expect = fixture.get("expect")
         if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
             failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
         if payload is not None:
             if not isinstance(payload, dict):
                 failures.append(Failure(category, f"{name or index} payload must be an object or null"))
             else:
-                if payload.get("operation") not in {"work_item_read", "workspace_attach", "recovery_writeback"}:
+                if payload.get("operation") not in allowed_operations:
                     failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
                 if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
                     failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                payload_fallback = payload.get("fallback_to")
+                if (
+                    isinstance(payload_fallback, str)
+                    and payload_fallback not in loom_fallbacks
+                    and (not isinstance(expect, dict) or expect.get("result") != "block")
+                ):
+                    failures.append(Failure(category, f"{name or index} payload fallback_to must point to a Loom checkpoint or gate repair surface"))
                 forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
                 if forbidden and expect.get("result") != "block":
                     failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
@@ -9785,6 +9883,27 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
                     failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
                 if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
                     failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+                if payload.get("operation") in {"status_read", "gate_read"}:
+                    if payload.get("source_layer") != "derived_surface":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must consume the derived status surface"))
+                    if payload.get("consumed_as") != "summary":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must be consumed as summary, not authored truth"))
+                    if payload.get("operation") == "status_read":
+                        status_fields = payload.get("status_fields")
+                        required_status_fields = {"result", "current_gate", "classifications", "missing_inputs", "head_binding", "gate_chain", "provenance"}
+                        if not isinstance(status_fields, list) or not required_status_fields.issubset(set(status_fields)):
+                            failures.append(Failure(category, f"{name or index} status_read fixture must reuse status control plane v2 fields"))
+                    if payload.get("operation") == "gate_read":
+                        gate_fields = payload.get("gate_fields")
+                        required_gate_fields = {"name", "result", "classification", "missing_inputs", "fallback_to"}
+                        if expect.get("result") != "block" and (not isinstance(gate_fields, list) or not required_gate_fields.issubset(set(gate_fields))):
+                            failures.append(Failure(category, f"{name or index} gate_read fixture must reuse the existing gate chain fields"))
+                if name == "scheduler-private-fallback-block" and expect.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure(category, "scheduler-private fallback fixture must fallback to `current_checkpoint`"))
+                if name == "scheduler-private-fallback-block":
+                    entry_fallback = entry.get("fallback_to") if isinstance(entry, dict) else None
+                    if entry_fallback in loom_fallbacks or payload.get("fallback_to") in loom_fallbacks:
+                        failures.append(Failure(category, "scheduler-private fallback fixture must prove a private fallback is blocked"))
 
     missing = sorted(required_names - seen_names)
     if missing:

--- a/src/skills/shared/scripts/loom_status.py
+++ b/src/skills/shared/scripts/loom_status.py
@@ -205,6 +205,50 @@ def governance_control_status(
     }
 
 
+def external_orchestrator_consumer_status(
+    *,
+    control_status: dict[str, object],
+    provenance: dict[str, object],
+    recovery_readiness: dict[str, object],
+) -> dict[str, object]:
+    gate_chain = control_status.get("gate_chain")
+    if not isinstance(gate_chain, list):
+        gate_chain = []
+    external_gates = []
+    for gate in gate_chain:
+        if not isinstance(gate, dict):
+            continue
+        external_gates.append(
+            {
+                "name": gate.get("name"),
+                "result": gate.get("result"),
+                "classification": gate.get("classification"),
+                "missing_inputs": gate.get("missing_inputs", []),
+                "fallback_to": gate.get("fallback_to"),
+            }
+        )
+
+    return {
+        "schema_version": control_status.get("schema_version", "loom-governance-status/v2"),
+        "view": "external_orchestrator_consumer",
+        "result": control_status.get("result", "block"),
+        "current_gate": control_status.get("current_gate"),
+        "classifications": control_status.get("classifications", []),
+        "missing_inputs": control_status.get("missing_inputs", []),
+        "head_binding": control_status.get("head_binding", {}),
+        "gate_chain": external_gates,
+        "allowed_operations": ["status_read", "gate_read"],
+        "source_policy": {
+            "status_source": "derived_from_status_control_plane_v2",
+            "gate_source": "derived_from_governance_gate_chain",
+            "writeback": "recovery_entry_only",
+            "fallback_to": "current_checkpoint",
+        },
+        "provenance": provenance,
+        "recovery_readiness": recovery_readiness,
+    }
+
+
 def closeout_status_payload(
     *,
     github_status: dict[str, object],
@@ -535,6 +579,14 @@ def main(argv: list[str]) -> int:
         if result == "pass"
         else "status surface is readable, but one or more governance gates are still blocking or stale."
     )
+    provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    external_orchestrator = external_orchestrator_consumer_status(
+        control_status=control_status,
+        provenance=provenance,
+        recovery_readiness=recovery_readiness,
+    )
+
     return emit(
         {
             "command": "status",
@@ -543,8 +595,8 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
-            "provenance": report_provenance(context["report"]),
-            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "provenance": provenance,
+            "recovery_readiness": recovery_readiness,
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
@@ -586,6 +638,7 @@ def main(argv: list[str]) -> int:
             "ci_check_presence": ci_check_presence,
             "host_enforcement": host_enforcement,
             "governance_status": control_status,
+            "external_orchestrator": external_orchestrator,
             "governance_surface": governance_surface,
             "github": github_status,
         }


### PR DESCRIPTION
## Summary

Closes #637, #638, #639, #640.

Batch 3 for #535 defines external orchestrator read-only consumption of Loom status and gates without creating a second status surface.

## Changes

- Extends `external_orchestrators[*].operations` with `status_read` and `gate_read`.
- Defines status/gate consumption in the external orchestrator interop contract and repo interop contract.
- Adds `external_orchestrator` consumer view to `loom_status`, reusing `loom-governance-status/v2`, provenance, and the existing gate chain.
- Adds fixtures for status read, gate read, and scheduler-private fallback blocking.
- Extends `loom_check` coverage and regenerates shared skill runtime/reference payloads.

## Validation

- `python3 -m py_compile tools/loom_check.py tools/loom_flow.py tools/loom_init.py tools/loom_status.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py`
- `python3 tools/skills_surface.py generate`
- `python3 tools/skills_surface.py check`
- `python3 tools/host_adapter_check.py`
- `python3 tools/version_surface_check.py`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `git diff --check`
- `python3 tools/loom_status.py --target examples/new-project --item INIT-0001` (verified `external_orchestrator` consumer view; command result remains `block` because the fixture project intentionally lacks spec/review gates)
- `python3 tools/loom_check.py` (`OK`, checked 35 surfaces)
- `npm --prefix packages/loom-installer run check:release`

## Non-goals preserved

- No daemon.
- No scheduler state machine.
- No tracker polling product.
- No external authored status or gate truth.
- No branch/PR/git-worktree/worker lifecycle ownership.
