### PR TITLE
feat: establish external orchestrator conformance

### DIFF
--- a/docs/evidence/external-orchestrator-release-threshold.md
+++ b/docs/evidence/external-orchestrator-release-threshold.md
@@ -1,0 +1,43 @@
+# External Orchestrator Release Threshold
+
+This file defines the v0.12.0 release threshold for external orchestrator interop.
+
+External orchestrator interop is an `orchestration-extension/external-orchestrator`
+profile. It is release-blocking only for its own extension scope; it does not turn
+Loom into a default daemon or scheduler product.
+
+## Required Evidence
+
+Before v0.12.0 can close, the release candidate must show:
+
+- `docs/methodology/harness/external-orchestrator-interop.md` defines Work Item read,
+  workspace attach, recovery-only writeback, status/gate consumption, and truth
+  boundaries.
+- `docs/adoption/repo-interop-contract.md` exposes locator-only
+  `external_orchestrators[*]` declarations with `status_read` and `gate_read`.
+- `loom_status` exposes a read-only external consumer view that reuses
+  `loom-governance-status/v2`, provenance, and the existing gate chain.
+- `python3 tools/loom_flow.py live-smoke external-orchestrator-interop --target examples/new-project`
+  emits `loom-external-orchestrator-conformance/v1`.
+- `docs/evidence/fixtures/external-orchestrator-conformance-fixtures.json` covers
+  happy path, truth pollution drift, scheduler-private fallback, and no-daemon /
+  no-host-lifecycle ownership.
+- `python3 tools/loom_check.py` validates the conformance fixtures and command
+  contract.
+
+## Release Interpretation
+
+The release can pass when:
+
+- required external orchestrator declarations fail closed on unreadable locators,
+  truth pollution, private fallback, or lifecycle ownership drift
+- optional/advisory locator gaps stay profile-local
+- status and gates remain derived from Loom control planes
+- writeback remains limited to recovery entry fields
+- no daemon, scheduler state machine, tracker polling product, branch/PR/worktree
+  ownership, worker lifecycle ownership, or second status surface is introduced
+
+External orchestrator conformance does not require a real external scheduler for
+v0.12.0. The fake external orchestrator fixtures are sufficient release evidence
+because the release freezes the interop contract and boundaries, not a scheduler
+implementation.

--- a/docs/evidence/fixtures/external-orchestrator-conformance-fixtures.json
+++ b/docs/evidence/fixtures/external-orchestrator-conformance-fixtures.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": "loom-external-orchestrator-conformance-fixtures/v1",
+  "fixtures": [
+    {
+      "name": "fake-external-orchestrator-happy",
+      "entry": {
+        "id": "fake-external-orchestrator",
+        "summary": "Read Work Item, status, gates, workspace attach, and recovery writeback evidence without owning scheduling.",
+        "surfaces": ["admission", "build", "merge_ready"],
+        "operations": ["work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"],
+        "locator": ".loom/external-orchestrator/happy.json",
+        "owner": "external-tool",
+        "requirement": "required",
+        "fallback_to": "current_checkpoint"
+      },
+      "payload": {
+        "schema_version": "loom-external-orchestrator-read/v1",
+        "operation": "status_read",
+        "entry_kind": "work_item",
+        "source_layer": "derived_surface",
+        "source_locator": ".loom/status/current.md",
+        "source_binding": {
+          "item_id": "INIT-0001",
+          "status_schema_version": "loom-governance-status/v2"
+        },
+        "consumed_as": "summary",
+        "host_lifecycle_ownership": "external",
+        "fallback_to": "current_checkpoint"
+      },
+      "expect": {
+        "result": "pass",
+        "schema_version": "loom-external-orchestrator-conformance/v1"
+      }
+    },
+    {
+      "name": "fake-external-orchestrator-truth-drift",
+      "entry": {
+        "id": "fake-external-orchestrator-truth-drift",
+        "summary": "Attempt to carry scheduler state and authored status truth.",
+        "surfaces": ["merge_ready"],
+        "operations": ["status_read", "gate_read"],
+        "locator": ".loom/external-orchestrator/truth-drift.json",
+        "owner": "external-tool",
+        "requirement": "required",
+        "fallback_to": "current_checkpoint"
+      },
+      "payload": {
+        "schema_version": "loom-external-orchestrator-read/v1",
+        "operation": "gate_read",
+        "entry_kind": "work_item",
+        "source_layer": "derived_surface",
+        "source_locator": ".loom/status/current.md",
+        "source_binding": {
+          "item_id": "INIT-0001"
+        },
+        "consumed_as": "truth",
+        "scheduler_state": "Running",
+        "status_truth": {
+          "result": "pass"
+        },
+        "gate_verdict": {
+          "merge_gate": "pass"
+        }
+      },
+      "expect": {
+        "result": "block",
+        "failure": "truth_pollution",
+        "fallback_to": "current_checkpoint"
+      }
+    },
+    {
+      "name": "fake-external-orchestrator-private-fallback",
+      "entry": {
+        "id": "fake-external-orchestrator-private-fallback",
+        "summary": "Attempt to fall back to an orchestrator-private retry queue.",
+        "surfaces": ["merge_ready"],
+        "operations": ["gate_read"],
+        "locator": ".loom/external-orchestrator/private-fallback.json",
+        "owner": "external-tool",
+        "requirement": "required",
+        "fallback_to": "scheduler_retry_queue"
+      },
+      "payload": {
+        "schema_version": "loom-external-orchestrator-read/v1",
+        "operation": "gate_read",
+        "entry_kind": "work_item",
+        "source_layer": "derived_surface",
+        "source_locator": ".loom/status/current.md",
+        "source_binding": {
+          "item_id": "INIT-0001"
+        },
+        "consumed_as": "summary",
+        "fallback_to": "scheduler_retry_queue"
+      },
+      "expect": {
+        "result": "block",
+        "failure": "gate_failure.binding_failure",
+        "fallback_to": "current_checkpoint"
+      }
+    },
+    {
+      "name": "fake-external-orchestrator-lifecycle-drift",
+      "entry": {
+        "id": "fake-external-orchestrator-lifecycle-drift",
+        "summary": "Attempt to claim host lifecycle ownership.",
+        "surfaces": ["build"],
+        "operations": ["workspace_attach"],
+        "locator": ".loom/external-orchestrator/lifecycle-drift.json",
+        "owner": "external-tool",
+        "requirement": "required",
+        "fallback_to": "build"
+      },
+      "payload": {
+        "schema_version": "loom-external-orchestrator-read/v1",
+        "operation": "workspace_attach",
+        "entry_kind": "work_item",
+        "source_layer": "derived_surface",
+        "source_locator": ".loom/status/current.md",
+        "source_binding": {
+          "item_id": "INIT-0001"
+        },
+        "consumed_as": "summary",
+        "host_lifecycle_ownership": "loom",
+        "daemon": true,
+        "worker_lifecycle": "owned"
+      },
+      "expect": {
+        "result": "block",
+        "failure": "truth_pollution",
+        "fallback_to": "build"
+      }
+    }
+  ]
+}

--- a/docs/evidence/live-smoke-profile.md
+++ b/docs/evidence/live-smoke-profile.md
@@ -16,6 +16,8 @@
 
 `python3 tools/loom_flow.py live-smoke hooks-extension --target <repo>`
 
+`python3 tools/loom_flow.py live-smoke external-orchestrator-interop --target <repo>`
+
 输出 schema 固定为 `loom-live-smoke/v1`。
 
 `host-adapter-drift` 输出 schema 固定为 `loom-host-adapter-live-drift/v1`。
@@ -23,6 +25,9 @@
 `dynamic-tool-availability` 输出 schema 固定为 `loom-dynamic-tool-live-availability/v1`。
 
 `hooks-extension` 输出 schema 固定为 `loom-hooks-extension-profile/v1`。
+
+`external-orchestrator-interop` 输出 schema 固定为
+`loom-external-orchestrator-conformance/v1`。
 
 ## Run Contract
 
@@ -169,3 +174,34 @@
   `not_applicable`
 - 命令 does not execute hooks，不生成 host-native hook files，不写 repo
   companion、host state、authored progress 或 status truth
+
+## External Orchestrator Interop Profile Contract
+
+`external-orchestrator-interop` 读取 adopted repo
+`.loom/companion/interop.json` 中声明的 `external_orchestrators[*]`，并把
+retained read evidence 包装成 `orchestration-extension/external-orchestrator`
+profile-local evidence。
+
+最小检查面：
+
+- repo interop contract 是否存在且可读
+- `external_orchestrators[*]` 是否声明合法的 `operations`、`locator`、
+  `requirement` 与 `fallback_to`
+- retained evidence 是否只表达 `work_item_read`、`workspace_attach`、
+  `recovery_writeback`、`status_read` 或 `gate_read`
+- status/gate consumption 是否只读消费 `status control plane v2` 与现有 gate chain
+- retained evidence 是否避免 scheduler state、daemon、tracker polling、host
+  lifecycle ownership、status truth、gate truth、review verdict、validation summary、
+  host action result 或 closeout basis
+
+结果纪律：
+
+- 未声明 external orchestrator 时返回 `pass`，`external_orchestrator.status`
+  为 `not_applicable`
+- optional / advisory locator gaps 只返回 profile-local `warn`
+- required locator 缺失、truth pollution、scheduler-private fallback 或 lifecycle
+  ownership 漂移返回 `block`
+- `core_profile.result` 必须保持 `pass`，`core_profile.external_orchestrator_enforcement`
+  固定为 `not_applicable`
+- 命令不启动 daemon，不调度 worker，不创建/删除 branch、PR、git worktree 或目录，
+  不写 recovery/status/gate/review/host state

--- a/docs/evidence/orchestration-conformance-profiles.md
+++ b/docs/evidence/orchestration-conformance-profiles.md
@@ -39,7 +39,8 @@ Core 缺口必须 fail closed，因为这些能力构成 Loom v0.7.0 的可恢�
 - host action / dynamic tool declaration-time locator contract
 - hook locator safety declarations, mapped hook envelopes, and unsafe
   host-adapter results
-- external orchestrator Work Item read locators and retained read evidence
+- external orchestrator Work Item/status/gate read locators, workspace attach,
+  recovery writeback, retained read evidence, and conformance evidence
 - host-backed tracker state 只能作为 structured event evidence 或 retained host result 被消费
 - required locator missing / unreadable / invalid boundary 的 fail-closed 行为
 - optional / advisory missing in-repo locator 只进入 profile-local `missing_optional`
@@ -80,14 +81,23 @@ daemon 或 scheduler 产品。
 - `Work Item` read locator
 - `workspace attach` 只读绑定语义
 - recovery writeback 是唯一 authored progress 写回路径
+- `status_read` / `gate_read` 只读消费 `status control plane v2` 与既有 gate chain
 - PR-only / tracker-only / release-only / merge-commit-only 入口 fail closed
 - external orchestrator locator payload 不承载 authored progress、status truth、gate truth 或 scheduler state
+- external orchestrator conformance evidence 使用
+  `loom-external-orchestrator-conformance/v1`
+- fake external orchestrator happy/drift fixtures 证明 retained read evidence 可读、
+  truth pollution 会阻断、scheduler-private fallback 回到 Loom checkpoint
 - required locator missing / unreadable / unsafe 时在 extension path 内 block
 - optional / advisory locator gaps 只进入 profile-local warning
 
 该 profile 只消费 [external-orchestrator-interop.md](../methodology/harness/external-orchestrator-interop.md)
 与 `repo interop` 的 locator-only 声明。它不得新增第二状态面，不得改变
 `orchestration-core` pass/fail。
+
+该 profile 的 live evidence 命令是
+`python3 tools/loom_flow.py live-smoke external-orchestrator-interop --target <repo>`，
+输出 schema 为 `loom-external-orchestrator-conformance/v1`。
 
 ## 4. `orchestration-live`
 

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -310,6 +310,8 @@ EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA = "loom-external-orchestrator-conformance-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
     "scheduler_state",
     "attempt_ownership",
@@ -1510,6 +1512,67 @@ def require_hook_profile_payload(
             failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
         if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
             failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
+
+
+def require_external_orchestrator_conformance_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "external-orchestrator-interop":
+        failures.append(Failure(category, f"{context} must report `operation: external-orchestrator-interop`"))
+    if payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within pass/warn/block"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include summary"))
+    if payload.get("fallback_to") not in {None, "live-smoke-config-repair", "live-smoke-retry-or-record-unavailable"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay profile-local"))
+    for field in ("runtime_state", "target", "profile_check", "core_profile", "external_orchestrator"):
+        if not isinstance(payload.get(field), dict):
+            failures.append(Failure(category, f"{context} must include `{field}` object"))
+    if not isinstance(payload.get("command_plan"), list) or not payload.get("command_plan"):
+        failures.append(Failure(category, f"{context} must include command_plan"))
+    if not isinstance(payload.get("reports"), list):
+        failures.append(Failure(category, f"{context} must include reports"))
+    conformance = payload.get("external_orchestrator")
+    if isinstance(conformance, dict):
+        if conformance.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, f"{context}.external_orchestrator must use conformance schema"))
+        if conformance.get("profile_id") != "orchestration-extension/external-orchestrator":
+            failures.append(Failure(category, f"{context}.external_orchestrator profile_id must be external-orchestrator"))
+        if conformance.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.external_orchestrator result must stay stable"))
+        if conformance.get("status") not in {
+            "not_applicable",
+            "present",
+            "runtime-blocked",
+            "target-unavailable",
+            "missing-target",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context}.external_orchestrator status is outside the stable vocabulary"))
+        for field in ("missing_inputs", "missing_optional", "checks"):
+            if not isinstance(conformance.get(field), list):
+                failures.append(Failure(category, f"{context}.external_orchestrator.{field} must be a list"))
+        non_goals = conformance.get("non_goals")
+        if not isinstance(non_goals, dict):
+            failures.append(Failure(category, f"{context}.external_orchestrator must include non_goals"))
+        else:
+            for key in ("daemon", "scheduler_state_machine", "tracker_polling_product", "second_status_surface", "host_lifecycle_ownership"):
+                if non_goals.get(key) is not False:
+                    failures.append(Failure(category, f"{context}.external_orchestrator non_goal `{key}` must remain false"))
+    core_profile = payload.get("core_profile")
+    if isinstance(core_profile, dict) and core_profile.get("result") != "pass":
+        failures.append(Failure(category, f"{context}.core_profile.result must remain pass"))
 
 
 def require_repo_interop_payload(
@@ -9912,6 +9975,177 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
     return failures
 
 
+def check_external_orchestrator_conformance_contract(root: Path) -> list[Failure]:
+    category = "external-orchestrator-conformance"
+    failures: list[Failure] = []
+    required_docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/external-orchestrator",
+            "loom-external-orchestrator-conformance/v1",
+            "fake external orchestrator happy/drift fixtures",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "external-orchestrator-interop",
+            "loom-external-orchestrator-conformance/v1",
+            "does not execute",
+        ],
+        "docs/evidence/external-orchestrator-release-threshold.md": [
+            "v0.12.0",
+            "loom-external-orchestrator-conformance/v1",
+            "no daemon",
+            "fake external orchestrator fixtures are sufficient",
+        ],
+    }
+    for relative, anchors in required_docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure(category, f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure(category, f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-conformance-fixtures.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"external orchestrator conformance fixtures are unreadable: {exc}"))
+        return failures
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA:
+        failures.append(Failure(category, f"conformance fixture schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA}`"))
+    fixtures = fixture_payload.get("fixtures")
+    required_names = {
+        "fake-external-orchestrator-happy",
+        "fake-external-orchestrator-truth-drift",
+        "fake-external-orchestrator-private-fallback",
+        "fake-external-orchestrator-lifecycle-drift",
+    }
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator conformance fixtures must include fixtures"))
+        return failures
+    seen_names: set[str] = set()
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if isinstance(name, str):
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+            continue
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"{name or index} payload must be an object"))
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/block"))
+        operations = entry.get("operations")
+        if not isinstance(operations, list) or not operations:
+            failures.append(Failure(category, f"{name or index} entry.operations must be non-empty"))
+        elif any(operation not in {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"} for operation in operations):
+            failures.append(Failure(category, f"{name or index} declares unsupported operation"))
+        if name == "fake-external-orchestrator-happy" and expect.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, "happy fixture must expect conformance schema v1"))
+        if name == "fake-external-orchestrator-truth-drift" and payload is not None:
+            forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+            if not forbidden or expect.get("failure") != "truth_pollution":
+                failures.append(Failure(category, "truth drift fixture must prove forbidden authored/scheduler fields block"))
+        if name == "fake-external-orchestrator-private-fallback":
+            if entry.get("fallback_to") != "scheduler_retry_queue" or expect.get("fallback_to") != "current_checkpoint":
+                failures.append(Failure(category, "private fallback fixture must block back to current_checkpoint"))
+        if name == "fake-external-orchestrator-lifecycle-drift" and payload is not None:
+            if payload.get("host_lifecycle_ownership") != "loom" or payload.get("daemon") is not True:
+                failures.append(Failure(category, "lifecycle drift fixture must prove no-daemon/no-host-lifecycle boundary"))
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator conformance fixtures missing required cases: " + ", ".join(missing)))
+
+    example_target = root / "examples/new-project"
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(example_target)],
+    )
+    if error:
+        failures.append(Failure(category, f"`external-orchestrator-interop` not_applicable sample failed: {error}"))
+    else:
+        require_external_orchestrator_conformance_payload(
+            failures,
+            category=category,
+            context="not-applicable external orchestrator conformance",
+            payload=absent_payload,
+        )
+        external_profile = absent_payload.get("external_orchestrator") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must pass"))
+        elif not isinstance(external_profile, dict) or external_profile.get("status") != "not_applicable":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must expose not_applicable status"))
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    with tempfile.TemporaryDirectory(prefix="loom-external-orchestrator-conformance-") as tmp:
+        base = Path(tmp)
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        happy_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-happy"), None)
+        if isinstance(happy_fixture, dict):
+            interop = load_json_file(present_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [happy_fixture["entry"]]
+                write_json_local(present_target / ".loom/companion/interop.json", interop)
+                write_json_local(present_target / happy_fixture["entry"]["locator"], happy_fixture["payload"])
+            present_payload, present_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(present_target)],
+            )
+            if present_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` happy sample failed: {present_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="happy external orchestrator conformance",
+                    payload=present_payload,
+                )
+                if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                    failures.append(Failure(category, "happy external orchestrator conformance must pass"))
+
+        drift_target = base / "drift"
+        shutil.copytree(example_target, drift_target)
+        drift_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-truth-drift"), None)
+        if isinstance(drift_fixture, dict):
+            interop = load_json_file(drift_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [drift_fixture["entry"]]
+                write_json_local(drift_target / ".loom/companion/interop.json", interop)
+                write_json_local(drift_target / drift_fixture["entry"]["locator"], drift_fixture["payload"])
+            drift_payload, drift_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(drift_target)],
+            )
+            if drift_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` drift sample failed: {drift_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="drift external orchestrator conformance",
+                    payload=drift_payload,
+                )
+                core_profile = drift_payload.get("core_profile") if isinstance(drift_payload, dict) else None
+                if not isinstance(drift_payload, dict) or drift_payload.get("result") != "block":
+                    failures.append(Failure(category, "truth drift external orchestrator conformance must block"))
+                elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                    failures.append(Failure(category, "external orchestrator conformance drift must not rewrite core profile"))
+
+    return failures
+
+
 def check_external_runtime_devendor_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     required_anchors = {
@@ -14373,6 +14607,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
     failures.extend(check_external_orchestrator_interop_fixture_contract(root))
+    failures.extend(check_external_orchestrator_conformance_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14401,7 +14636,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 35
+    categories_checked = 36
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    EXTERNAL_ORCHESTRATOR_OPERATIONS,
     empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
@@ -122,6 +123,7 @@ DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -162,6 +164,41 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "current_lane",
     "recovery_boundary",
     "closing_condition",
+}
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+    "daemon",
+    "scheduler_queue",
+    "branch_ownership",
+    "pr_ownership",
+    "worktree_ownership",
+    "worker_lifecycle",
+}
+EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS = {
+    "work_item",
+    "admission",
+    "binding_repair",
+    "current_checkpoint",
+    "spec_gate",
+    "build_gate",
+    "review_gate",
+    "merge_gate",
+    "build",
+    "review",
+    "merge_ready",
+    "closeout",
 }
 HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
@@ -553,7 +590,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
+    live_smoke.add_argument(
+        "operation",
+        choices=(
+            "run",
+            "replay",
+            "host-adapter-drift",
+            "dynamic-tool-availability",
+            "hook-envelope",
+            "hooks-extension",
+            "external-orchestrator-interop",
+        ),
+    )
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -899,6 +947,41 @@ def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
     ]
 
 
+def external_orchestrator_conformance_command_plan(
+    target_root: Path,
+    external_orchestrators: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading external orchestrator declarations.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'} external_orchestrators",
+            "description": "Read external orchestrator locator declarations without starting a scheduler or daemon.",
+        },
+        {
+            "id": "status-consumer-view",
+            "command": f"{shlex.quote(sys.executable)} tools/loom_status.py --target {shlex.quote(str(target_root))} --item INIT-0001",
+            "description": "Confirm status/gate consumption reuses Loom status control plane v2 and the existing gate chain.",
+        },
+    ]
+    for index, entry in enumerate(external_orchestrators or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"external-orchestrator-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read external orchestrator retained evidence without accepting scheduler-owned status or gate truth.",
+            }
+        )
+    return plan
+
+
 def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
     found: list[str] = []
     if isinstance(value, dict):
@@ -911,6 +994,21 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     elif isinstance(value, list):
         for index, nested in enumerate(value):
             found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def find_forbidden_external_orchestrator_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=f"{prefix}[{index}]"))
     return found
 
 
@@ -1875,6 +1973,313 @@ def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
             "profile_check": {"id": "hooks-extension", "result": result},
             "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
             "hooks_extension": hook_profile,
+        }
+    )
+    return payload
+
+
+def empty_external_orchestrator_conformance() -> dict[str, Any]:
+    return {
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "profile_id": "orchestration-extension/external-orchestrator",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "external orchestrator interop profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+        "non_goals": {
+            "daemon": False,
+            "scheduler_state_machine": False,
+            "tracker_polling_product": False,
+            "second_status_surface": False,
+            "host_lifecycle_ownership": False,
+        },
+    }
+
+
+def external_orchestrator_conformance_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+) -> dict[str, Any]:
+    prefix = f"external_orchestrators[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "requirement": "required",
+            "operations": [],
+            "locator": "",
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            "evidence": {"locator_status": "invalid-declaration"},
+        }
+
+    entry_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"external-orchestrator-{index}"
+    requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+    locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "admission"
+    operations = entry.get("operations") if isinstance(entry.get("operations"), list) else []
+    blocking: list[str] = []
+    optional: list[str] = []
+
+    if requirement not in {"required", "optional", "advisory"}:
+        blocking.append(f"{prefix}.requirement must be required, optional, or advisory")
+        requirement = "required"
+    if not operations:
+        blocking.append(f"{prefix}.operations must be a non-empty list")
+    unsupported = [str(operation) for operation in operations if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS]
+    if unsupported:
+        blocking.append(f"{prefix}.operations contains unsupported operations: {', '.join(unsupported)}")
+    if isinstance(fallback_to, str) and fallback_to not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+        blocking.append(f"{prefix}.fallback_to must point back to a Loom checkpoint or gate repair surface")
+
+    locator_path, locator_errors = resolve_repo_relative_path(target_root, locator, label=f"{prefix} locator")
+    if locator_errors:
+        blocking.extend(locator_errors)
+    elif locator_path is None or not locator_path.exists() or locator_path.is_dir():
+        message = f"{prefix} locator points to missing or unreadable retained evidence `{locator}`"
+        if requirement in {"optional", "advisory"}:
+            optional.append(message)
+        else:
+            blocking.append(message)
+
+    payload: object = None
+    if locator_path is not None and locator_path.exists() and locator_path.is_file():
+        try:
+            payload = load_json_file(locator_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            blocking.append(f"{prefix} retained evidence is not readable JSON: {exc}")
+    if payload is not None and not isinstance(payload, dict):
+        blocking.append(f"{prefix} retained evidence must be a JSON object")
+    if isinstance(payload, dict):
+        forbidden = find_forbidden_external_orchestrator_fields(payload)
+        if forbidden:
+            blocking.append(f"{prefix} retained evidence contains forbidden authored/scheduler fields: {', '.join(forbidden)}")
+        payload_operation = payload.get("operation")
+        if isinstance(payload_operation, str) and operations and payload_operation not in operations:
+            blocking.append(f"{prefix} retained evidence operation is not declared by the locator")
+        if payload.get("operation") in {"status_read", "gate_read"}:
+            if payload.get("source_layer") != "derived_surface":
+                blocking.append(f"{prefix} status/gate reads must consume the derived status surface")
+            if payload.get("consumed_as") != "summary":
+                blocking.append(f"{prefix} status/gate reads must be consumed as summary")
+        if payload.get("host_lifecycle_ownership") not in {None, "host", "external"}:
+            blocking.append(f"{prefix} retained evidence must not claim Loom owns host lifecycle")
+        payload_fallback = payload.get("fallback_to")
+        if isinstance(payload_fallback, str) and payload_fallback not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+            blocking.append(f"{prefix} retained evidence fallback_to must point back to Loom")
+
+    result = "block" if blocking else "warn" if optional else "pass"
+    if result == "warn" and requirement in {"required"}:
+        result = "block"
+    return {
+        "id": entry_id,
+        "requirement": requirement,
+        "operations": operations,
+        "locator": locator,
+        "result": result,
+        "classification": "truth_pollution" if blocking and isinstance(payload, dict) and find_forbidden_external_orchestrator_fields(payload) else "locator_or_contract",
+        "summary": (
+            "external orchestrator retained evidence is readable and respects Loom truth boundaries."
+            if result == "pass"
+            else "external orchestrator retained evidence has profile-local warnings."
+            if result == "warn"
+            else "external orchestrator retained evidence violates interop conformance boundaries."
+        ),
+        "missing_inputs": blocking if result == "block" else [],
+        "missing_optional": optional,
+        "fallback_to": fallback_to if result == "block" else None,
+        "evidence": {
+            "locator_status": "readable" if isinstance(payload, dict) else "missing_or_invalid",
+            "payload_schema_version": payload.get("schema_version") if isinstance(payload, dict) else None,
+            "payload_operation": payload.get("operation") if isinstance(payload, dict) else None,
+        },
+    }
+
+
+def external_orchestrator_conformance_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "external-orchestrator-interop",
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": external_orchestrator_conformance_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "external orchestrator conformance is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "external orchestrator conformance recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    interop_path = target_root / ".loom" / "companion" / "interop.json"
+    if not interop_path.exists():
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop does not declare external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    try:
+        interop_payload = load_json_file(interop_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update(
+            {
+                "enabled": True,
+                "result": "block",
+                "status": "invalid_declaration",
+                "summary": "repo interop contract is unreadable for external orchestrator conformance.",
+                "missing_inputs": [f"repo interop contract is unreadable: {exc}"],
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": conformance["summary"],
+                "missing_inputs": conformance["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+    external_orchestrators = interop_payload.get("external_orchestrators", []) if isinstance(interop_payload, dict) else []
+    if not isinstance(external_orchestrators, list) or not external_orchestrators:
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop is readable but declares no external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    checks = [
+        external_orchestrator_conformance_check(target_root, entry=entry, index=index)
+        for index, entry in enumerate(external_orchestrators)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "repo-interop.external_orchestrator",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    conformance = empty_external_orchestrator_conformance()
+    conformance.update(
+        {
+            "enabled": True,
+            "result": result,
+            "status": "present",
+            "summary": (
+                "external orchestrator conformance passed without introducing a daemon, scheduler state, or second status surface."
+                if result == "pass"
+                else "external orchestrator conformance produced profile-local warnings."
+                if result == "warn"
+                else "external orchestrator conformance found blocking interop drift."
+            ),
+            "missing_inputs": live_smoke_missing_inputs([message for check in checks for message in check.get("missing_inputs", [])]),
+            "missing_optional": [message for check in checks for message in check.get("missing_optional", [])],
+            "checks": checks,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": conformance["summary"],
+            "missing_inputs": conformance["missing_inputs"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "external-orchestrator-interop", "result": result},
+            "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+            "external_orchestrator": conformance,
+            "command_plan": external_orchestrator_conformance_command_plan(target_root, external_orchestrators=external_orchestrators),
         }
     )
     return payload
@@ -12754,6 +13159,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "external-orchestrator-interop":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "external-orchestrator-interop",
+                    "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+                    "result": "block",
+                    "summary": "external orchestrator conformance requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                    "external_orchestrator": {
+                        **empty_external_orchestrator_conformance(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(external_orchestrator_conformance_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -310,6 +310,8 @@ EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA = "loom-external-orchestrator-conformance-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
     "scheduler_state",
     "attempt_ownership",
@@ -1510,6 +1512,67 @@ def require_hook_profile_payload(
             failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
         if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
             failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
+
+
+def require_external_orchestrator_conformance_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "external-orchestrator-interop":
+        failures.append(Failure(category, f"{context} must report `operation: external-orchestrator-interop`"))
+    if payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within pass/warn/block"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include summary"))
+    if payload.get("fallback_to") not in {None, "live-smoke-config-repair", "live-smoke-retry-or-record-unavailable"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay profile-local"))
+    for field in ("runtime_state", "target", "profile_check", "core_profile", "external_orchestrator"):
+        if not isinstance(payload.get(field), dict):
+            failures.append(Failure(category, f"{context} must include `{field}` object"))
+    if not isinstance(payload.get("command_plan"), list) or not payload.get("command_plan"):
+        failures.append(Failure(category, f"{context} must include command_plan"))
+    if not isinstance(payload.get("reports"), list):
+        failures.append(Failure(category, f"{context} must include reports"))
+    conformance = payload.get("external_orchestrator")
+    if isinstance(conformance, dict):
+        if conformance.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, f"{context}.external_orchestrator must use conformance schema"))
+        if conformance.get("profile_id") != "orchestration-extension/external-orchestrator":
+            failures.append(Failure(category, f"{context}.external_orchestrator profile_id must be external-orchestrator"))
+        if conformance.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.external_orchestrator result must stay stable"))
+        if conformance.get("status") not in {
+            "not_applicable",
+            "present",
+            "runtime-blocked",
+            "target-unavailable",
+            "missing-target",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context}.external_orchestrator status is outside the stable vocabulary"))
+        for field in ("missing_inputs", "missing_optional", "checks"):
+            if not isinstance(conformance.get(field), list):
+                failures.append(Failure(category, f"{context}.external_orchestrator.{field} must be a list"))
+        non_goals = conformance.get("non_goals")
+        if not isinstance(non_goals, dict):
+            failures.append(Failure(category, f"{context}.external_orchestrator must include non_goals"))
+        else:
+            for key in ("daemon", "scheduler_state_machine", "tracker_polling_product", "second_status_surface", "host_lifecycle_ownership"):
+                if non_goals.get(key) is not False:
+                    failures.append(Failure(category, f"{context}.external_orchestrator non_goal `{key}` must remain false"))
+    core_profile = payload.get("core_profile")
+    if isinstance(core_profile, dict) and core_profile.get("result") != "pass":
+        failures.append(Failure(category, f"{context}.core_profile.result must remain pass"))
 
 
 def require_repo_interop_payload(
@@ -9912,6 +9975,177 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
     return failures
 
 
+def check_external_orchestrator_conformance_contract(root: Path) -> list[Failure]:
+    category = "external-orchestrator-conformance"
+    failures: list[Failure] = []
+    required_docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/external-orchestrator",
+            "loom-external-orchestrator-conformance/v1",
+            "fake external orchestrator happy/drift fixtures",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "external-orchestrator-interop",
+            "loom-external-orchestrator-conformance/v1",
+            "does not execute",
+        ],
+        "docs/evidence/external-orchestrator-release-threshold.md": [
+            "v0.12.0",
+            "loom-external-orchestrator-conformance/v1",
+            "no daemon",
+            "fake external orchestrator fixtures are sufficient",
+        ],
+    }
+    for relative, anchors in required_docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure(category, f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure(category, f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-conformance-fixtures.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"external orchestrator conformance fixtures are unreadable: {exc}"))
+        return failures
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA:
+        failures.append(Failure(category, f"conformance fixture schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA}`"))
+    fixtures = fixture_payload.get("fixtures")
+    required_names = {
+        "fake-external-orchestrator-happy",
+        "fake-external-orchestrator-truth-drift",
+        "fake-external-orchestrator-private-fallback",
+        "fake-external-orchestrator-lifecycle-drift",
+    }
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator conformance fixtures must include fixtures"))
+        return failures
+    seen_names: set[str] = set()
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if isinstance(name, str):
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+            continue
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"{name or index} payload must be an object"))
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/block"))
+        operations = entry.get("operations")
+        if not isinstance(operations, list) or not operations:
+            failures.append(Failure(category, f"{name or index} entry.operations must be non-empty"))
+        elif any(operation not in {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"} for operation in operations):
+            failures.append(Failure(category, f"{name or index} declares unsupported operation"))
+        if name == "fake-external-orchestrator-happy" and expect.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, "happy fixture must expect conformance schema v1"))
+        if name == "fake-external-orchestrator-truth-drift" and payload is not None:
+            forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+            if not forbidden or expect.get("failure") != "truth_pollution":
+                failures.append(Failure(category, "truth drift fixture must prove forbidden authored/scheduler fields block"))
+        if name == "fake-external-orchestrator-private-fallback":
+            if entry.get("fallback_to") != "scheduler_retry_queue" or expect.get("fallback_to") != "current_checkpoint":
+                failures.append(Failure(category, "private fallback fixture must block back to current_checkpoint"))
+        if name == "fake-external-orchestrator-lifecycle-drift" and payload is not None:
+            if payload.get("host_lifecycle_ownership") != "loom" or payload.get("daemon") is not True:
+                failures.append(Failure(category, "lifecycle drift fixture must prove no-daemon/no-host-lifecycle boundary"))
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator conformance fixtures missing required cases: " + ", ".join(missing)))
+
+    example_target = root / "examples/new-project"
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(example_target)],
+    )
+    if error:
+        failures.append(Failure(category, f"`external-orchestrator-interop` not_applicable sample failed: {error}"))
+    else:
+        require_external_orchestrator_conformance_payload(
+            failures,
+            category=category,
+            context="not-applicable external orchestrator conformance",
+            payload=absent_payload,
+        )
+        external_profile = absent_payload.get("external_orchestrator") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must pass"))
+        elif not isinstance(external_profile, dict) or external_profile.get("status") != "not_applicable":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must expose not_applicable status"))
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    with tempfile.TemporaryDirectory(prefix="loom-external-orchestrator-conformance-") as tmp:
+        base = Path(tmp)
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        happy_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-happy"), None)
+        if isinstance(happy_fixture, dict):
+            interop = load_json_file(present_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [happy_fixture["entry"]]
+                write_json_local(present_target / ".loom/companion/interop.json", interop)
+                write_json_local(present_target / happy_fixture["entry"]["locator"], happy_fixture["payload"])
+            present_payload, present_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(present_target)],
+            )
+            if present_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` happy sample failed: {present_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="happy external orchestrator conformance",
+                    payload=present_payload,
+                )
+                if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                    failures.append(Failure(category, "happy external orchestrator conformance must pass"))
+
+        drift_target = base / "drift"
+        shutil.copytree(example_target, drift_target)
+        drift_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-truth-drift"), None)
+        if isinstance(drift_fixture, dict):
+            interop = load_json_file(drift_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [drift_fixture["entry"]]
+                write_json_local(drift_target / ".loom/companion/interop.json", interop)
+                write_json_local(drift_target / drift_fixture["entry"]["locator"], drift_fixture["payload"])
+            drift_payload, drift_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(drift_target)],
+            )
+            if drift_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` drift sample failed: {drift_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="drift external orchestrator conformance",
+                    payload=drift_payload,
+                )
+                core_profile = drift_payload.get("core_profile") if isinstance(drift_payload, dict) else None
+                if not isinstance(drift_payload, dict) or drift_payload.get("result") != "block":
+                    failures.append(Failure(category, "truth drift external orchestrator conformance must block"))
+                elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                    failures.append(Failure(category, "external orchestrator conformance drift must not rewrite core profile"))
+
+    return failures
+
+
 def check_external_runtime_devendor_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     required_anchors = {
@@ -14373,6 +14607,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
     failures.extend(check_external_orchestrator_interop_fixture_contract(root))
+    failures.extend(check_external_orchestrator_conformance_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14401,7 +14636,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 35
+    categories_checked = 36
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    EXTERNAL_ORCHESTRATOR_OPERATIONS,
     empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
@@ -122,6 +123,7 @@ DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -162,6 +164,41 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "current_lane",
     "recovery_boundary",
     "closing_condition",
+}
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+    "daemon",
+    "scheduler_queue",
+    "branch_ownership",
+    "pr_ownership",
+    "worktree_ownership",
+    "worker_lifecycle",
+}
+EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS = {
+    "work_item",
+    "admission",
+    "binding_repair",
+    "current_checkpoint",
+    "spec_gate",
+    "build_gate",
+    "review_gate",
+    "merge_gate",
+    "build",
+    "review",
+    "merge_ready",
+    "closeout",
 }
 HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
@@ -553,7 +590,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
+    live_smoke.add_argument(
+        "operation",
+        choices=(
+            "run",
+            "replay",
+            "host-adapter-drift",
+            "dynamic-tool-availability",
+            "hook-envelope",
+            "hooks-extension",
+            "external-orchestrator-interop",
+        ),
+    )
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -899,6 +947,41 @@ def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
     ]
 
 
+def external_orchestrator_conformance_command_plan(
+    target_root: Path,
+    external_orchestrators: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading external orchestrator declarations.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'} external_orchestrators",
+            "description": "Read external orchestrator locator declarations without starting a scheduler or daemon.",
+        },
+        {
+            "id": "status-consumer-view",
+            "command": f"{shlex.quote(sys.executable)} tools/loom_status.py --target {shlex.quote(str(target_root))} --item INIT-0001",
+            "description": "Confirm status/gate consumption reuses Loom status control plane v2 and the existing gate chain.",
+        },
+    ]
+    for index, entry in enumerate(external_orchestrators or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"external-orchestrator-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read external orchestrator retained evidence without accepting scheduler-owned status or gate truth.",
+            }
+        )
+    return plan
+
+
 def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
     found: list[str] = []
     if isinstance(value, dict):
@@ -911,6 +994,21 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     elif isinstance(value, list):
         for index, nested in enumerate(value):
             found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def find_forbidden_external_orchestrator_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=f"{prefix}[{index}]"))
     return found
 
 
@@ -1875,6 +1973,313 @@ def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
             "profile_check": {"id": "hooks-extension", "result": result},
             "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
             "hooks_extension": hook_profile,
+        }
+    )
+    return payload
+
+
+def empty_external_orchestrator_conformance() -> dict[str, Any]:
+    return {
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "profile_id": "orchestration-extension/external-orchestrator",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "external orchestrator interop profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+        "non_goals": {
+            "daemon": False,
+            "scheduler_state_machine": False,
+            "tracker_polling_product": False,
+            "second_status_surface": False,
+            "host_lifecycle_ownership": False,
+        },
+    }
+
+
+def external_orchestrator_conformance_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+) -> dict[str, Any]:
+    prefix = f"external_orchestrators[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "requirement": "required",
+            "operations": [],
+            "locator": "",
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            "evidence": {"locator_status": "invalid-declaration"},
+        }
+
+    entry_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"external-orchestrator-{index}"
+    requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+    locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "admission"
+    operations = entry.get("operations") if isinstance(entry.get("operations"), list) else []
+    blocking: list[str] = []
+    optional: list[str] = []
+
+    if requirement not in {"required", "optional", "advisory"}:
+        blocking.append(f"{prefix}.requirement must be required, optional, or advisory")
+        requirement = "required"
+    if not operations:
+        blocking.append(f"{prefix}.operations must be a non-empty list")
+    unsupported = [str(operation) for operation in operations if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS]
+    if unsupported:
+        blocking.append(f"{prefix}.operations contains unsupported operations: {', '.join(unsupported)}")
+    if isinstance(fallback_to, str) and fallback_to not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+        blocking.append(f"{prefix}.fallback_to must point back to a Loom checkpoint or gate repair surface")
+
+    locator_path, locator_errors = resolve_repo_relative_path(target_root, locator, label=f"{prefix} locator")
+    if locator_errors:
+        blocking.extend(locator_errors)
+    elif locator_path is None or not locator_path.exists() or locator_path.is_dir():
+        message = f"{prefix} locator points to missing or unreadable retained evidence `{locator}`"
+        if requirement in {"optional", "advisory"}:
+            optional.append(message)
+        else:
+            blocking.append(message)
+
+    payload: object = None
+    if locator_path is not None and locator_path.exists() and locator_path.is_file():
+        try:
+            payload = load_json_file(locator_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            blocking.append(f"{prefix} retained evidence is not readable JSON: {exc}")
+    if payload is not None and not isinstance(payload, dict):
+        blocking.append(f"{prefix} retained evidence must be a JSON object")
+    if isinstance(payload, dict):
+        forbidden = find_forbidden_external_orchestrator_fields(payload)
+        if forbidden:
+            blocking.append(f"{prefix} retained evidence contains forbidden authored/scheduler fields: {', '.join(forbidden)}")
+        payload_operation = payload.get("operation")
+        if isinstance(payload_operation, str) and operations and payload_operation not in operations:
+            blocking.append(f"{prefix} retained evidence operation is not declared by the locator")
+        if payload.get("operation") in {"status_read", "gate_read"}:
+            if payload.get("source_layer") != "derived_surface":
+                blocking.append(f"{prefix} status/gate reads must consume the derived status surface")
+            if payload.get("consumed_as") != "summary":
+                blocking.append(f"{prefix} status/gate reads must be consumed as summary")
+        if payload.get("host_lifecycle_ownership") not in {None, "host", "external"}:
+            blocking.append(f"{prefix} retained evidence must not claim Loom owns host lifecycle")
+        payload_fallback = payload.get("fallback_to")
+        if isinstance(payload_fallback, str) and payload_fallback not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+            blocking.append(f"{prefix} retained evidence fallback_to must point back to Loom")
+
+    result = "block" if blocking else "warn" if optional else "pass"
+    if result == "warn" and requirement in {"required"}:
+        result = "block"
+    return {
+        "id": entry_id,
+        "requirement": requirement,
+        "operations": operations,
+        "locator": locator,
+        "result": result,
+        "classification": "truth_pollution" if blocking and isinstance(payload, dict) and find_forbidden_external_orchestrator_fields(payload) else "locator_or_contract",
+        "summary": (
+            "external orchestrator retained evidence is readable and respects Loom truth boundaries."
+            if result == "pass"
+            else "external orchestrator retained evidence has profile-local warnings."
+            if result == "warn"
+            else "external orchestrator retained evidence violates interop conformance boundaries."
+        ),
+        "missing_inputs": blocking if result == "block" else [],
+        "missing_optional": optional,
+        "fallback_to": fallback_to if result == "block" else None,
+        "evidence": {
+            "locator_status": "readable" if isinstance(payload, dict) else "missing_or_invalid",
+            "payload_schema_version": payload.get("schema_version") if isinstance(payload, dict) else None,
+            "payload_operation": payload.get("operation") if isinstance(payload, dict) else None,
+        },
+    }
+
+
+def external_orchestrator_conformance_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "external-orchestrator-interop",
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": external_orchestrator_conformance_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "external orchestrator conformance is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "external orchestrator conformance recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    interop_path = target_root / ".loom" / "companion" / "interop.json"
+    if not interop_path.exists():
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop does not declare external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    try:
+        interop_payload = load_json_file(interop_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update(
+            {
+                "enabled": True,
+                "result": "block",
+                "status": "invalid_declaration",
+                "summary": "repo interop contract is unreadable for external orchestrator conformance.",
+                "missing_inputs": [f"repo interop contract is unreadable: {exc}"],
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": conformance["summary"],
+                "missing_inputs": conformance["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+    external_orchestrators = interop_payload.get("external_orchestrators", []) if isinstance(interop_payload, dict) else []
+    if not isinstance(external_orchestrators, list) or not external_orchestrators:
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop is readable but declares no external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    checks = [
+        external_orchestrator_conformance_check(target_root, entry=entry, index=index)
+        for index, entry in enumerate(external_orchestrators)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "repo-interop.external_orchestrator",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    conformance = empty_external_orchestrator_conformance()
+    conformance.update(
+        {
+            "enabled": True,
+            "result": result,
+            "status": "present",
+            "summary": (
+                "external orchestrator conformance passed without introducing a daemon, scheduler state, or second status surface."
+                if result == "pass"
+                else "external orchestrator conformance produced profile-local warnings."
+                if result == "warn"
+                else "external orchestrator conformance found blocking interop drift."
+            ),
+            "missing_inputs": live_smoke_missing_inputs([message for check in checks for message in check.get("missing_inputs", [])]),
+            "missing_optional": [message for check in checks for message in check.get("missing_optional", [])],
+            "checks": checks,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": conformance["summary"],
+            "missing_inputs": conformance["missing_inputs"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "external-orchestrator-interop", "result": result},
+            "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+            "external_orchestrator": conformance,
+            "command_plan": external_orchestrator_conformance_command_plan(target_root, external_orchestrators=external_orchestrators),
         }
     )
     return payload
@@ -12754,6 +13159,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "external-orchestrator-interop":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "external-orchestrator-interop",
+                    "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+                    "result": "block",
+                    "summary": "external orchestrator conformance requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                    "external_orchestrator": {
+                        **empty_external_orchestrator_conformance(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(external_orchestrator_conformance_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -310,6 +310,8 @@ EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA = "loom-external-orchestrator-conformance-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
     "scheduler_state",
     "attempt_ownership",
@@ -1510,6 +1512,67 @@ def require_hook_profile_payload(
             failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
         if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
             failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
+
+
+def require_external_orchestrator_conformance_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "external-orchestrator-interop":
+        failures.append(Failure(category, f"{context} must report `operation: external-orchestrator-interop`"))
+    if payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within pass/warn/block"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include summary"))
+    if payload.get("fallback_to") not in {None, "live-smoke-config-repair", "live-smoke-retry-or-record-unavailable"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay profile-local"))
+    for field in ("runtime_state", "target", "profile_check", "core_profile", "external_orchestrator"):
+        if not isinstance(payload.get(field), dict):
+            failures.append(Failure(category, f"{context} must include `{field}` object"))
+    if not isinstance(payload.get("command_plan"), list) or not payload.get("command_plan"):
+        failures.append(Failure(category, f"{context} must include command_plan"))
+    if not isinstance(payload.get("reports"), list):
+        failures.append(Failure(category, f"{context} must include reports"))
+    conformance = payload.get("external_orchestrator")
+    if isinstance(conformance, dict):
+        if conformance.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, f"{context}.external_orchestrator must use conformance schema"))
+        if conformance.get("profile_id") != "orchestration-extension/external-orchestrator":
+            failures.append(Failure(category, f"{context}.external_orchestrator profile_id must be external-orchestrator"))
+        if conformance.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.external_orchestrator result must stay stable"))
+        if conformance.get("status") not in {
+            "not_applicable",
+            "present",
+            "runtime-blocked",
+            "target-unavailable",
+            "missing-target",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context}.external_orchestrator status is outside the stable vocabulary"))
+        for field in ("missing_inputs", "missing_optional", "checks"):
+            if not isinstance(conformance.get(field), list):
+                failures.append(Failure(category, f"{context}.external_orchestrator.{field} must be a list"))
+        non_goals = conformance.get("non_goals")
+        if not isinstance(non_goals, dict):
+            failures.append(Failure(category, f"{context}.external_orchestrator must include non_goals"))
+        else:
+            for key in ("daemon", "scheduler_state_machine", "tracker_polling_product", "second_status_surface", "host_lifecycle_ownership"):
+                if non_goals.get(key) is not False:
+                    failures.append(Failure(category, f"{context}.external_orchestrator non_goal `{key}` must remain false"))
+    core_profile = payload.get("core_profile")
+    if isinstance(core_profile, dict) and core_profile.get("result") != "pass":
+        failures.append(Failure(category, f"{context}.core_profile.result must remain pass"))
 
 
 def require_repo_interop_payload(
@@ -9912,6 +9975,177 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
     return failures
 
 
+def check_external_orchestrator_conformance_contract(root: Path) -> list[Failure]:
+    category = "external-orchestrator-conformance"
+    failures: list[Failure] = []
+    required_docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/external-orchestrator",
+            "loom-external-orchestrator-conformance/v1",
+            "fake external orchestrator happy/drift fixtures",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "external-orchestrator-interop",
+            "loom-external-orchestrator-conformance/v1",
+            "does not execute",
+        ],
+        "docs/evidence/external-orchestrator-release-threshold.md": [
+            "v0.12.0",
+            "loom-external-orchestrator-conformance/v1",
+            "no daemon",
+            "fake external orchestrator fixtures are sufficient",
+        ],
+    }
+    for relative, anchors in required_docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure(category, f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure(category, f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-conformance-fixtures.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"external orchestrator conformance fixtures are unreadable: {exc}"))
+        return failures
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA:
+        failures.append(Failure(category, f"conformance fixture schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA}`"))
+    fixtures = fixture_payload.get("fixtures")
+    required_names = {
+        "fake-external-orchestrator-happy",
+        "fake-external-orchestrator-truth-drift",
+        "fake-external-orchestrator-private-fallback",
+        "fake-external-orchestrator-lifecycle-drift",
+    }
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator conformance fixtures must include fixtures"))
+        return failures
+    seen_names: set[str] = set()
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if isinstance(name, str):
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+            continue
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"{name or index} payload must be an object"))
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/block"))
+        operations = entry.get("operations")
+        if not isinstance(operations, list) or not operations:
+            failures.append(Failure(category, f"{name or index} entry.operations must be non-empty"))
+        elif any(operation not in {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"} for operation in operations):
+            failures.append(Failure(category, f"{name or index} declares unsupported operation"))
+        if name == "fake-external-orchestrator-happy" and expect.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, "happy fixture must expect conformance schema v1"))
+        if name == "fake-external-orchestrator-truth-drift" and payload is not None:
+            forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+            if not forbidden or expect.get("failure") != "truth_pollution":
+                failures.append(Failure(category, "truth drift fixture must prove forbidden authored/scheduler fields block"))
+        if name == "fake-external-orchestrator-private-fallback":
+            if entry.get("fallback_to") != "scheduler_retry_queue" or expect.get("fallback_to") != "current_checkpoint":
+                failures.append(Failure(category, "private fallback fixture must block back to current_checkpoint"))
+        if name == "fake-external-orchestrator-lifecycle-drift" and payload is not None:
+            if payload.get("host_lifecycle_ownership") != "loom" or payload.get("daemon") is not True:
+                failures.append(Failure(category, "lifecycle drift fixture must prove no-daemon/no-host-lifecycle boundary"))
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator conformance fixtures missing required cases: " + ", ".join(missing)))
+
+    example_target = root / "examples/new-project"
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(example_target)],
+    )
+    if error:
+        failures.append(Failure(category, f"`external-orchestrator-interop` not_applicable sample failed: {error}"))
+    else:
+        require_external_orchestrator_conformance_payload(
+            failures,
+            category=category,
+            context="not-applicable external orchestrator conformance",
+            payload=absent_payload,
+        )
+        external_profile = absent_payload.get("external_orchestrator") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must pass"))
+        elif not isinstance(external_profile, dict) or external_profile.get("status") != "not_applicable":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must expose not_applicable status"))
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    with tempfile.TemporaryDirectory(prefix="loom-external-orchestrator-conformance-") as tmp:
+        base = Path(tmp)
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        happy_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-happy"), None)
+        if isinstance(happy_fixture, dict):
+            interop = load_json_file(present_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [happy_fixture["entry"]]
+                write_json_local(present_target / ".loom/companion/interop.json", interop)
+                write_json_local(present_target / happy_fixture["entry"]["locator"], happy_fixture["payload"])
+            present_payload, present_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(present_target)],
+            )
+            if present_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` happy sample failed: {present_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="happy external orchestrator conformance",
+                    payload=present_payload,
+                )
+                if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                    failures.append(Failure(category, "happy external orchestrator conformance must pass"))
+
+        drift_target = base / "drift"
+        shutil.copytree(example_target, drift_target)
+        drift_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-truth-drift"), None)
+        if isinstance(drift_fixture, dict):
+            interop = load_json_file(drift_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [drift_fixture["entry"]]
+                write_json_local(drift_target / ".loom/companion/interop.json", interop)
+                write_json_local(drift_target / drift_fixture["entry"]["locator"], drift_fixture["payload"])
+            drift_payload, drift_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(drift_target)],
+            )
+            if drift_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` drift sample failed: {drift_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="drift external orchestrator conformance",
+                    payload=drift_payload,
+                )
+                core_profile = drift_payload.get("core_profile") if isinstance(drift_payload, dict) else None
+                if not isinstance(drift_payload, dict) or drift_payload.get("result") != "block":
+                    failures.append(Failure(category, "truth drift external orchestrator conformance must block"))
+                elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                    failures.append(Failure(category, "external orchestrator conformance drift must not rewrite core profile"))
+
+    return failures
+
+
 def check_external_runtime_devendor_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     required_anchors = {
@@ -14373,6 +14607,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
     failures.extend(check_external_orchestrator_interop_fixture_contract(root))
+    failures.extend(check_external_orchestrator_conformance_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14401,7 +14636,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 35
+    categories_checked = 36
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    EXTERNAL_ORCHESTRATOR_OPERATIONS,
     empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
@@ -122,6 +123,7 @@ DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -162,6 +164,41 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "current_lane",
     "recovery_boundary",
     "closing_condition",
+}
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+    "daemon",
+    "scheduler_queue",
+    "branch_ownership",
+    "pr_ownership",
+    "worktree_ownership",
+    "worker_lifecycle",
+}
+EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS = {
+    "work_item",
+    "admission",
+    "binding_repair",
+    "current_checkpoint",
+    "spec_gate",
+    "build_gate",
+    "review_gate",
+    "merge_gate",
+    "build",
+    "review",
+    "merge_ready",
+    "closeout",
 }
 HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
@@ -553,7 +590,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
+    live_smoke.add_argument(
+        "operation",
+        choices=(
+            "run",
+            "replay",
+            "host-adapter-drift",
+            "dynamic-tool-availability",
+            "hook-envelope",
+            "hooks-extension",
+            "external-orchestrator-interop",
+        ),
+    )
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -899,6 +947,41 @@ def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
     ]
 
 
+def external_orchestrator_conformance_command_plan(
+    target_root: Path,
+    external_orchestrators: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading external orchestrator declarations.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'} external_orchestrators",
+            "description": "Read external orchestrator locator declarations without starting a scheduler or daemon.",
+        },
+        {
+            "id": "status-consumer-view",
+            "command": f"{shlex.quote(sys.executable)} tools/loom_status.py --target {shlex.quote(str(target_root))} --item INIT-0001",
+            "description": "Confirm status/gate consumption reuses Loom status control plane v2 and the existing gate chain.",
+        },
+    ]
+    for index, entry in enumerate(external_orchestrators or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"external-orchestrator-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read external orchestrator retained evidence without accepting scheduler-owned status or gate truth.",
+            }
+        )
+    return plan
+
+
 def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
     found: list[str] = []
     if isinstance(value, dict):
@@ -911,6 +994,21 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     elif isinstance(value, list):
         for index, nested in enumerate(value):
             found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def find_forbidden_external_orchestrator_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=f"{prefix}[{index}]"))
     return found
 
 
@@ -1875,6 +1973,313 @@ def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
             "profile_check": {"id": "hooks-extension", "result": result},
             "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
             "hooks_extension": hook_profile,
+        }
+    )
+    return payload
+
+
+def empty_external_orchestrator_conformance() -> dict[str, Any]:
+    return {
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "profile_id": "orchestration-extension/external-orchestrator",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "external orchestrator interop profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+        "non_goals": {
+            "daemon": False,
+            "scheduler_state_machine": False,
+            "tracker_polling_product": False,
+            "second_status_surface": False,
+            "host_lifecycle_ownership": False,
+        },
+    }
+
+
+def external_orchestrator_conformance_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+) -> dict[str, Any]:
+    prefix = f"external_orchestrators[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "requirement": "required",
+            "operations": [],
+            "locator": "",
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            "evidence": {"locator_status": "invalid-declaration"},
+        }
+
+    entry_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"external-orchestrator-{index}"
+    requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+    locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "admission"
+    operations = entry.get("operations") if isinstance(entry.get("operations"), list) else []
+    blocking: list[str] = []
+    optional: list[str] = []
+
+    if requirement not in {"required", "optional", "advisory"}:
+        blocking.append(f"{prefix}.requirement must be required, optional, or advisory")
+        requirement = "required"
+    if not operations:
+        blocking.append(f"{prefix}.operations must be a non-empty list")
+    unsupported = [str(operation) for operation in operations if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS]
+    if unsupported:
+        blocking.append(f"{prefix}.operations contains unsupported operations: {', '.join(unsupported)}")
+    if isinstance(fallback_to, str) and fallback_to not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+        blocking.append(f"{prefix}.fallback_to must point back to a Loom checkpoint or gate repair surface")
+
+    locator_path, locator_errors = resolve_repo_relative_path(target_root, locator, label=f"{prefix} locator")
+    if locator_errors:
+        blocking.extend(locator_errors)
+    elif locator_path is None or not locator_path.exists() or locator_path.is_dir():
+        message = f"{prefix} locator points to missing or unreadable retained evidence `{locator}`"
+        if requirement in {"optional", "advisory"}:
+            optional.append(message)
+        else:
+            blocking.append(message)
+
+    payload: object = None
+    if locator_path is not None and locator_path.exists() and locator_path.is_file():
+        try:
+            payload = load_json_file(locator_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            blocking.append(f"{prefix} retained evidence is not readable JSON: {exc}")
+    if payload is not None and not isinstance(payload, dict):
+        blocking.append(f"{prefix} retained evidence must be a JSON object")
+    if isinstance(payload, dict):
+        forbidden = find_forbidden_external_orchestrator_fields(payload)
+        if forbidden:
+            blocking.append(f"{prefix} retained evidence contains forbidden authored/scheduler fields: {', '.join(forbidden)}")
+        payload_operation = payload.get("operation")
+        if isinstance(payload_operation, str) and operations and payload_operation not in operations:
+            blocking.append(f"{prefix} retained evidence operation is not declared by the locator")
+        if payload.get("operation") in {"status_read", "gate_read"}:
+            if payload.get("source_layer") != "derived_surface":
+                blocking.append(f"{prefix} status/gate reads must consume the derived status surface")
+            if payload.get("consumed_as") != "summary":
+                blocking.append(f"{prefix} status/gate reads must be consumed as summary")
+        if payload.get("host_lifecycle_ownership") not in {None, "host", "external"}:
+            blocking.append(f"{prefix} retained evidence must not claim Loom owns host lifecycle")
+        payload_fallback = payload.get("fallback_to")
+        if isinstance(payload_fallback, str) and payload_fallback not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+            blocking.append(f"{prefix} retained evidence fallback_to must point back to Loom")
+
+    result = "block" if blocking else "warn" if optional else "pass"
+    if result == "warn" and requirement in {"required"}:
+        result = "block"
+    return {
+        "id": entry_id,
+        "requirement": requirement,
+        "operations": operations,
+        "locator": locator,
+        "result": result,
+        "classification": "truth_pollution" if blocking and isinstance(payload, dict) and find_forbidden_external_orchestrator_fields(payload) else "locator_or_contract",
+        "summary": (
+            "external orchestrator retained evidence is readable and respects Loom truth boundaries."
+            if result == "pass"
+            else "external orchestrator retained evidence has profile-local warnings."
+            if result == "warn"
+            else "external orchestrator retained evidence violates interop conformance boundaries."
+        ),
+        "missing_inputs": blocking if result == "block" else [],
+        "missing_optional": optional,
+        "fallback_to": fallback_to if result == "block" else None,
+        "evidence": {
+            "locator_status": "readable" if isinstance(payload, dict) else "missing_or_invalid",
+            "payload_schema_version": payload.get("schema_version") if isinstance(payload, dict) else None,
+            "payload_operation": payload.get("operation") if isinstance(payload, dict) else None,
+        },
+    }
+
+
+def external_orchestrator_conformance_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "external-orchestrator-interop",
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": external_orchestrator_conformance_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "external orchestrator conformance is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "external orchestrator conformance recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    interop_path = target_root / ".loom" / "companion" / "interop.json"
+    if not interop_path.exists():
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop does not declare external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    try:
+        interop_payload = load_json_file(interop_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update(
+            {
+                "enabled": True,
+                "result": "block",
+                "status": "invalid_declaration",
+                "summary": "repo interop contract is unreadable for external orchestrator conformance.",
+                "missing_inputs": [f"repo interop contract is unreadable: {exc}"],
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": conformance["summary"],
+                "missing_inputs": conformance["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+    external_orchestrators = interop_payload.get("external_orchestrators", []) if isinstance(interop_payload, dict) else []
+    if not isinstance(external_orchestrators, list) or not external_orchestrators:
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop is readable but declares no external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    checks = [
+        external_orchestrator_conformance_check(target_root, entry=entry, index=index)
+        for index, entry in enumerate(external_orchestrators)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "repo-interop.external_orchestrator",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    conformance = empty_external_orchestrator_conformance()
+    conformance.update(
+        {
+            "enabled": True,
+            "result": result,
+            "status": "present",
+            "summary": (
+                "external orchestrator conformance passed without introducing a daemon, scheduler state, or second status surface."
+                if result == "pass"
+                else "external orchestrator conformance produced profile-local warnings."
+                if result == "warn"
+                else "external orchestrator conformance found blocking interop drift."
+            ),
+            "missing_inputs": live_smoke_missing_inputs([message for check in checks for message in check.get("missing_inputs", [])]),
+            "missing_optional": [message for check in checks for message in check.get("missing_optional", [])],
+            "checks": checks,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": conformance["summary"],
+            "missing_inputs": conformance["missing_inputs"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "external-orchestrator-interop", "result": result},
+            "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+            "external_orchestrator": conformance,
+            "command_plan": external_orchestrator_conformance_command_plan(target_root, external_orchestrators=external_orchestrators),
         }
     )
     return payload
@@ -12754,6 +13159,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "external-orchestrator-interop":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "external-orchestrator-interop",
+                    "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+                    "result": "block",
+                    "summary": "external orchestrator conformance requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                    "external_orchestrator": {
+                        **empty_external_orchestrator_conformance(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(external_orchestrator_conformance_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -310,6 +310,8 @@ EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA = "loom-external-orchestrator-conformance-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
     "scheduler_state",
     "attempt_ownership",
@@ -1510,6 +1512,67 @@ def require_hook_profile_payload(
             failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
         if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
             failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
+
+
+def require_external_orchestrator_conformance_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "external-orchestrator-interop":
+        failures.append(Failure(category, f"{context} must report `operation: external-orchestrator-interop`"))
+    if payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within pass/warn/block"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include summary"))
+    if payload.get("fallback_to") not in {None, "live-smoke-config-repair", "live-smoke-retry-or-record-unavailable"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay profile-local"))
+    for field in ("runtime_state", "target", "profile_check", "core_profile", "external_orchestrator"):
+        if not isinstance(payload.get(field), dict):
+            failures.append(Failure(category, f"{context} must include `{field}` object"))
+    if not isinstance(payload.get("command_plan"), list) or not payload.get("command_plan"):
+        failures.append(Failure(category, f"{context} must include command_plan"))
+    if not isinstance(payload.get("reports"), list):
+        failures.append(Failure(category, f"{context} must include reports"))
+    conformance = payload.get("external_orchestrator")
+    if isinstance(conformance, dict):
+        if conformance.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, f"{context}.external_orchestrator must use conformance schema"))
+        if conformance.get("profile_id") != "orchestration-extension/external-orchestrator":
+            failures.append(Failure(category, f"{context}.external_orchestrator profile_id must be external-orchestrator"))
+        if conformance.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.external_orchestrator result must stay stable"))
+        if conformance.get("status") not in {
+            "not_applicable",
+            "present",
+            "runtime-blocked",
+            "target-unavailable",
+            "missing-target",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context}.external_orchestrator status is outside the stable vocabulary"))
+        for field in ("missing_inputs", "missing_optional", "checks"):
+            if not isinstance(conformance.get(field), list):
+                failures.append(Failure(category, f"{context}.external_orchestrator.{field} must be a list"))
+        non_goals = conformance.get("non_goals")
+        if not isinstance(non_goals, dict):
+            failures.append(Failure(category, f"{context}.external_orchestrator must include non_goals"))
+        else:
+            for key in ("daemon", "scheduler_state_machine", "tracker_polling_product", "second_status_surface", "host_lifecycle_ownership"):
+                if non_goals.get(key) is not False:
+                    failures.append(Failure(category, f"{context}.external_orchestrator non_goal `{key}` must remain false"))
+    core_profile = payload.get("core_profile")
+    if isinstance(core_profile, dict) and core_profile.get("result") != "pass":
+        failures.append(Failure(category, f"{context}.core_profile.result must remain pass"))
 
 
 def require_repo_interop_payload(
@@ -9912,6 +9975,177 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
     return failures
 
 
+def check_external_orchestrator_conformance_contract(root: Path) -> list[Failure]:
+    category = "external-orchestrator-conformance"
+    failures: list[Failure] = []
+    required_docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/external-orchestrator",
+            "loom-external-orchestrator-conformance/v1",
+            "fake external orchestrator happy/drift fixtures",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "external-orchestrator-interop",
+            "loom-external-orchestrator-conformance/v1",
+            "does not execute",
+        ],
+        "docs/evidence/external-orchestrator-release-threshold.md": [
+            "v0.12.0",
+            "loom-external-orchestrator-conformance/v1",
+            "no daemon",
+            "fake external orchestrator fixtures are sufficient",
+        ],
+    }
+    for relative, anchors in required_docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure(category, f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure(category, f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-conformance-fixtures.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"external orchestrator conformance fixtures are unreadable: {exc}"))
+        return failures
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA:
+        failures.append(Failure(category, f"conformance fixture schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA}`"))
+    fixtures = fixture_payload.get("fixtures")
+    required_names = {
+        "fake-external-orchestrator-happy",
+        "fake-external-orchestrator-truth-drift",
+        "fake-external-orchestrator-private-fallback",
+        "fake-external-orchestrator-lifecycle-drift",
+    }
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator conformance fixtures must include fixtures"))
+        return failures
+    seen_names: set[str] = set()
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if isinstance(name, str):
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+            continue
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"{name or index} payload must be an object"))
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/block"))
+        operations = entry.get("operations")
+        if not isinstance(operations, list) or not operations:
+            failures.append(Failure(category, f"{name or index} entry.operations must be non-empty"))
+        elif any(operation not in {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"} for operation in operations):
+            failures.append(Failure(category, f"{name or index} declares unsupported operation"))
+        if name == "fake-external-orchestrator-happy" and expect.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, "happy fixture must expect conformance schema v1"))
+        if name == "fake-external-orchestrator-truth-drift" and payload is not None:
+            forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+            if not forbidden or expect.get("failure") != "truth_pollution":
+                failures.append(Failure(category, "truth drift fixture must prove forbidden authored/scheduler fields block"))
+        if name == "fake-external-orchestrator-private-fallback":
+            if entry.get("fallback_to") != "scheduler_retry_queue" or expect.get("fallback_to") != "current_checkpoint":
+                failures.append(Failure(category, "private fallback fixture must block back to current_checkpoint"))
+        if name == "fake-external-orchestrator-lifecycle-drift" and payload is not None:
+            if payload.get("host_lifecycle_ownership") != "loom" or payload.get("daemon") is not True:
+                failures.append(Failure(category, "lifecycle drift fixture must prove no-daemon/no-host-lifecycle boundary"))
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator conformance fixtures missing required cases: " + ", ".join(missing)))
+
+    example_target = root / "examples/new-project"
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(example_target)],
+    )
+    if error:
+        failures.append(Failure(category, f"`external-orchestrator-interop` not_applicable sample failed: {error}"))
+    else:
+        require_external_orchestrator_conformance_payload(
+            failures,
+            category=category,
+            context="not-applicable external orchestrator conformance",
+            payload=absent_payload,
+        )
+        external_profile = absent_payload.get("external_orchestrator") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must pass"))
+        elif not isinstance(external_profile, dict) or external_profile.get("status") != "not_applicable":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must expose not_applicable status"))
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    with tempfile.TemporaryDirectory(prefix="loom-external-orchestrator-conformance-") as tmp:
+        base = Path(tmp)
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        happy_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-happy"), None)
+        if isinstance(happy_fixture, dict):
+            interop = load_json_file(present_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [happy_fixture["entry"]]
+                write_json_local(present_target / ".loom/companion/interop.json", interop)
+                write_json_local(present_target / happy_fixture["entry"]["locator"], happy_fixture["payload"])
+            present_payload, present_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(present_target)],
+            )
+            if present_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` happy sample failed: {present_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="happy external orchestrator conformance",
+                    payload=present_payload,
+                )
+                if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                    failures.append(Failure(category, "happy external orchestrator conformance must pass"))
+
+        drift_target = base / "drift"
+        shutil.copytree(example_target, drift_target)
+        drift_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-truth-drift"), None)
+        if isinstance(drift_fixture, dict):
+            interop = load_json_file(drift_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [drift_fixture["entry"]]
+                write_json_local(drift_target / ".loom/companion/interop.json", interop)
+                write_json_local(drift_target / drift_fixture["entry"]["locator"], drift_fixture["payload"])
+            drift_payload, drift_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(drift_target)],
+            )
+            if drift_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` drift sample failed: {drift_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="drift external orchestrator conformance",
+                    payload=drift_payload,
+                )
+                core_profile = drift_payload.get("core_profile") if isinstance(drift_payload, dict) else None
+                if not isinstance(drift_payload, dict) or drift_payload.get("result") != "block":
+                    failures.append(Failure(category, "truth drift external orchestrator conformance must block"))
+                elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                    failures.append(Failure(category, "external orchestrator conformance drift must not rewrite core profile"))
+
+    return failures
+
+
 def check_external_runtime_devendor_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     required_anchors = {
@@ -14373,6 +14607,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
     failures.extend(check_external_orchestrator_interop_fixture_contract(root))
+    failures.extend(check_external_orchestrator_conformance_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14401,7 +14636,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 35
+    categories_checked = 36
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    EXTERNAL_ORCHESTRATOR_OPERATIONS,
     empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
@@ -122,6 +123,7 @@ DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -162,6 +164,41 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "current_lane",
     "recovery_boundary",
     "closing_condition",
+}
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+    "daemon",
+    "scheduler_queue",
+    "branch_ownership",
+    "pr_ownership",
+    "worktree_ownership",
+    "worker_lifecycle",
+}
+EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS = {
+    "work_item",
+    "admission",
+    "binding_repair",
+    "current_checkpoint",
+    "spec_gate",
+    "build_gate",
+    "review_gate",
+    "merge_gate",
+    "build",
+    "review",
+    "merge_ready",
+    "closeout",
 }
 HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
@@ -553,7 +590,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
+    live_smoke.add_argument(
+        "operation",
+        choices=(
+            "run",
+            "replay",
+            "host-adapter-drift",
+            "dynamic-tool-availability",
+            "hook-envelope",
+            "hooks-extension",
+            "external-orchestrator-interop",
+        ),
+    )
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -899,6 +947,41 @@ def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
     ]
 
 
+def external_orchestrator_conformance_command_plan(
+    target_root: Path,
+    external_orchestrators: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading external orchestrator declarations.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'} external_orchestrators",
+            "description": "Read external orchestrator locator declarations without starting a scheduler or daemon.",
+        },
+        {
+            "id": "status-consumer-view",
+            "command": f"{shlex.quote(sys.executable)} tools/loom_status.py --target {shlex.quote(str(target_root))} --item INIT-0001",
+            "description": "Confirm status/gate consumption reuses Loom status control plane v2 and the existing gate chain.",
+        },
+    ]
+    for index, entry in enumerate(external_orchestrators or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"external-orchestrator-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read external orchestrator retained evidence without accepting scheduler-owned status or gate truth.",
+            }
+        )
+    return plan
+
+
 def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
     found: list[str] = []
     if isinstance(value, dict):
@@ -911,6 +994,21 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     elif isinstance(value, list):
         for index, nested in enumerate(value):
             found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def find_forbidden_external_orchestrator_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=f"{prefix}[{index}]"))
     return found
 
 
@@ -1875,6 +1973,313 @@ def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
             "profile_check": {"id": "hooks-extension", "result": result},
             "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
             "hooks_extension": hook_profile,
+        }
+    )
+    return payload
+
+
+def empty_external_orchestrator_conformance() -> dict[str, Any]:
+    return {
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "profile_id": "orchestration-extension/external-orchestrator",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "external orchestrator interop profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+        "non_goals": {
+            "daemon": False,
+            "scheduler_state_machine": False,
+            "tracker_polling_product": False,
+            "second_status_surface": False,
+            "host_lifecycle_ownership": False,
+        },
+    }
+
+
+def external_orchestrator_conformance_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+) -> dict[str, Any]:
+    prefix = f"external_orchestrators[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "requirement": "required",
+            "operations": [],
+            "locator": "",
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            "evidence": {"locator_status": "invalid-declaration"},
+        }
+
+    entry_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"external-orchestrator-{index}"
+    requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+    locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "admission"
+    operations = entry.get("operations") if isinstance(entry.get("operations"), list) else []
+    blocking: list[str] = []
+    optional: list[str] = []
+
+    if requirement not in {"required", "optional", "advisory"}:
+        blocking.append(f"{prefix}.requirement must be required, optional, or advisory")
+        requirement = "required"
+    if not operations:
+        blocking.append(f"{prefix}.operations must be a non-empty list")
+    unsupported = [str(operation) for operation in operations if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS]
+    if unsupported:
+        blocking.append(f"{prefix}.operations contains unsupported operations: {', '.join(unsupported)}")
+    if isinstance(fallback_to, str) and fallback_to not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+        blocking.append(f"{prefix}.fallback_to must point back to a Loom checkpoint or gate repair surface")
+
+    locator_path, locator_errors = resolve_repo_relative_path(target_root, locator, label=f"{prefix} locator")
+    if locator_errors:
+        blocking.extend(locator_errors)
+    elif locator_path is None or not locator_path.exists() or locator_path.is_dir():
+        message = f"{prefix} locator points to missing or unreadable retained evidence `{locator}`"
+        if requirement in {"optional", "advisory"}:
+            optional.append(message)
+        else:
+            blocking.append(message)
+
+    payload: object = None
+    if locator_path is not None and locator_path.exists() and locator_path.is_file():
+        try:
+            payload = load_json_file(locator_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            blocking.append(f"{prefix} retained evidence is not readable JSON: {exc}")
+    if payload is not None and not isinstance(payload, dict):
+        blocking.append(f"{prefix} retained evidence must be a JSON object")
+    if isinstance(payload, dict):
+        forbidden = find_forbidden_external_orchestrator_fields(payload)
+        if forbidden:
+            blocking.append(f"{prefix} retained evidence contains forbidden authored/scheduler fields: {', '.join(forbidden)}")
+        payload_operation = payload.get("operation")
+        if isinstance(payload_operation, str) and operations and payload_operation not in operations:
+            blocking.append(f"{prefix} retained evidence operation is not declared by the locator")
+        if payload.get("operation") in {"status_read", "gate_read"}:
+            if payload.get("source_layer") != "derived_surface":
+                blocking.append(f"{prefix} status/gate reads must consume the derived status surface")
+            if payload.get("consumed_as") != "summary":
+                blocking.append(f"{prefix} status/gate reads must be consumed as summary")
+        if payload.get("host_lifecycle_ownership") not in {None, "host", "external"}:
+            blocking.append(f"{prefix} retained evidence must not claim Loom owns host lifecycle")
+        payload_fallback = payload.get("fallback_to")
+        if isinstance(payload_fallback, str) and payload_fallback not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+            blocking.append(f"{prefix} retained evidence fallback_to must point back to Loom")
+
+    result = "block" if blocking else "warn" if optional else "pass"
+    if result == "warn" and requirement in {"required"}:
+        result = "block"
+    return {
+        "id": entry_id,
+        "requirement": requirement,
+        "operations": operations,
+        "locator": locator,
+        "result": result,
+        "classification": "truth_pollution" if blocking and isinstance(payload, dict) and find_forbidden_external_orchestrator_fields(payload) else "locator_or_contract",
+        "summary": (
+            "external orchestrator retained evidence is readable and respects Loom truth boundaries."
+            if result == "pass"
+            else "external orchestrator retained evidence has profile-local warnings."
+            if result == "warn"
+            else "external orchestrator retained evidence violates interop conformance boundaries."
+        ),
+        "missing_inputs": blocking if result == "block" else [],
+        "missing_optional": optional,
+        "fallback_to": fallback_to if result == "block" else None,
+        "evidence": {
+            "locator_status": "readable" if isinstance(payload, dict) else "missing_or_invalid",
+            "payload_schema_version": payload.get("schema_version") if isinstance(payload, dict) else None,
+            "payload_operation": payload.get("operation") if isinstance(payload, dict) else None,
+        },
+    }
+
+
+def external_orchestrator_conformance_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "external-orchestrator-interop",
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": external_orchestrator_conformance_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "external orchestrator conformance is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "external orchestrator conformance recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    interop_path = target_root / ".loom" / "companion" / "interop.json"
+    if not interop_path.exists():
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop does not declare external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    try:
+        interop_payload = load_json_file(interop_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update(
+            {
+                "enabled": True,
+                "result": "block",
+                "status": "invalid_declaration",
+                "summary": "repo interop contract is unreadable for external orchestrator conformance.",
+                "missing_inputs": [f"repo interop contract is unreadable: {exc}"],
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": conformance["summary"],
+                "missing_inputs": conformance["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+    external_orchestrators = interop_payload.get("external_orchestrators", []) if isinstance(interop_payload, dict) else []
+    if not isinstance(external_orchestrators, list) or not external_orchestrators:
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop is readable but declares no external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    checks = [
+        external_orchestrator_conformance_check(target_root, entry=entry, index=index)
+        for index, entry in enumerate(external_orchestrators)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "repo-interop.external_orchestrator",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    conformance = empty_external_orchestrator_conformance()
+    conformance.update(
+        {
+            "enabled": True,
+            "result": result,
+            "status": "present",
+            "summary": (
+                "external orchestrator conformance passed without introducing a daemon, scheduler state, or second status surface."
+                if result == "pass"
+                else "external orchestrator conformance produced profile-local warnings."
+                if result == "warn"
+                else "external orchestrator conformance found blocking interop drift."
+            ),
+            "missing_inputs": live_smoke_missing_inputs([message for check in checks for message in check.get("missing_inputs", [])]),
+            "missing_optional": [message for check in checks for message in check.get("missing_optional", [])],
+            "checks": checks,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": conformance["summary"],
+            "missing_inputs": conformance["missing_inputs"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "external-orchestrator-interop", "result": result},
+            "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+            "external_orchestrator": conformance,
+            "command_plan": external_orchestrator_conformance_command_plan(target_root, external_orchestrators=external_orchestrators),
         }
     )
     return payload
@@ -12754,6 +13159,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "external-orchestrator-interop":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "external-orchestrator-interop",
+                    "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+                    "result": "block",
+                    "summary": "external orchestrator conformance requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                    "external_orchestrator": {
+                        **empty_external_orchestrator_conformance(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(external_orchestrator_conformance_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -310,6 +310,8 @@ EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA = "loom-external-orchestrator-conformance-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
     "scheduler_state",
     "attempt_ownership",
@@ -1510,6 +1512,67 @@ def require_hook_profile_payload(
             failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
         if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
             failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
+
+
+def require_external_orchestrator_conformance_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "external-orchestrator-interop":
+        failures.append(Failure(category, f"{context} must report `operation: external-orchestrator-interop`"))
+    if payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within pass/warn/block"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include summary"))
+    if payload.get("fallback_to") not in {None, "live-smoke-config-repair", "live-smoke-retry-or-record-unavailable"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay profile-local"))
+    for field in ("runtime_state", "target", "profile_check", "core_profile", "external_orchestrator"):
+        if not isinstance(payload.get(field), dict):
+            failures.append(Failure(category, f"{context} must include `{field}` object"))
+    if not isinstance(payload.get("command_plan"), list) or not payload.get("command_plan"):
+        failures.append(Failure(category, f"{context} must include command_plan"))
+    if not isinstance(payload.get("reports"), list):
+        failures.append(Failure(category, f"{context} must include reports"))
+    conformance = payload.get("external_orchestrator")
+    if isinstance(conformance, dict):
+        if conformance.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, f"{context}.external_orchestrator must use conformance schema"))
+        if conformance.get("profile_id") != "orchestration-extension/external-orchestrator":
+            failures.append(Failure(category, f"{context}.external_orchestrator profile_id must be external-orchestrator"))
+        if conformance.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.external_orchestrator result must stay stable"))
+        if conformance.get("status") not in {
+            "not_applicable",
+            "present",
+            "runtime-blocked",
+            "target-unavailable",
+            "missing-target",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context}.external_orchestrator status is outside the stable vocabulary"))
+        for field in ("missing_inputs", "missing_optional", "checks"):
+            if not isinstance(conformance.get(field), list):
+                failures.append(Failure(category, f"{context}.external_orchestrator.{field} must be a list"))
+        non_goals = conformance.get("non_goals")
+        if not isinstance(non_goals, dict):
+            failures.append(Failure(category, f"{context}.external_orchestrator must include non_goals"))
+        else:
+            for key in ("daemon", "scheduler_state_machine", "tracker_polling_product", "second_status_surface", "host_lifecycle_ownership"):
+                if non_goals.get(key) is not False:
+                    failures.append(Failure(category, f"{context}.external_orchestrator non_goal `{key}` must remain false"))
+    core_profile = payload.get("core_profile")
+    if isinstance(core_profile, dict) and core_profile.get("result") != "pass":
+        failures.append(Failure(category, f"{context}.core_profile.result must remain pass"))
 
 
 def require_repo_interop_payload(
@@ -9912,6 +9975,177 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
     return failures
 
 
+def check_external_orchestrator_conformance_contract(root: Path) -> list[Failure]:
+    category = "external-orchestrator-conformance"
+    failures: list[Failure] = []
+    required_docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/external-orchestrator",
+            "loom-external-orchestrator-conformance/v1",
+            "fake external orchestrator happy/drift fixtures",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "external-orchestrator-interop",
+            "loom-external-orchestrator-conformance/v1",
+            "does not execute",
+        ],
+        "docs/evidence/external-orchestrator-release-threshold.md": [
+            "v0.12.0",
+            "loom-external-orchestrator-conformance/v1",
+            "no daemon",
+            "fake external orchestrator fixtures are sufficient",
+        ],
+    }
+    for relative, anchors in required_docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure(category, f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure(category, f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-conformance-fixtures.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"external orchestrator conformance fixtures are unreadable: {exc}"))
+        return failures
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA:
+        failures.append(Failure(category, f"conformance fixture schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA}`"))
+    fixtures = fixture_payload.get("fixtures")
+    required_names = {
+        "fake-external-orchestrator-happy",
+        "fake-external-orchestrator-truth-drift",
+        "fake-external-orchestrator-private-fallback",
+        "fake-external-orchestrator-lifecycle-drift",
+    }
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator conformance fixtures must include fixtures"))
+        return failures
+    seen_names: set[str] = set()
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if isinstance(name, str):
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+            continue
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"{name or index} payload must be an object"))
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/block"))
+        operations = entry.get("operations")
+        if not isinstance(operations, list) or not operations:
+            failures.append(Failure(category, f"{name or index} entry.operations must be non-empty"))
+        elif any(operation not in {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"} for operation in operations):
+            failures.append(Failure(category, f"{name or index} declares unsupported operation"))
+        if name == "fake-external-orchestrator-happy" and expect.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, "happy fixture must expect conformance schema v1"))
+        if name == "fake-external-orchestrator-truth-drift" and payload is not None:
+            forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+            if not forbidden or expect.get("failure") != "truth_pollution":
+                failures.append(Failure(category, "truth drift fixture must prove forbidden authored/scheduler fields block"))
+        if name == "fake-external-orchestrator-private-fallback":
+            if entry.get("fallback_to") != "scheduler_retry_queue" or expect.get("fallback_to") != "current_checkpoint":
+                failures.append(Failure(category, "private fallback fixture must block back to current_checkpoint"))
+        if name == "fake-external-orchestrator-lifecycle-drift" and payload is not None:
+            if payload.get("host_lifecycle_ownership") != "loom" or payload.get("daemon") is not True:
+                failures.append(Failure(category, "lifecycle drift fixture must prove no-daemon/no-host-lifecycle boundary"))
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator conformance fixtures missing required cases: " + ", ".join(missing)))
+
+    example_target = root / "examples/new-project"
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(example_target)],
+    )
+    if error:
+        failures.append(Failure(category, f"`external-orchestrator-interop` not_applicable sample failed: {error}"))
+    else:
+        require_external_orchestrator_conformance_payload(
+            failures,
+            category=category,
+            context="not-applicable external orchestrator conformance",
+            payload=absent_payload,
+        )
+        external_profile = absent_payload.get("external_orchestrator") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must pass"))
+        elif not isinstance(external_profile, dict) or external_profile.get("status") != "not_applicable":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must expose not_applicable status"))
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    with tempfile.TemporaryDirectory(prefix="loom-external-orchestrator-conformance-") as tmp:
+        base = Path(tmp)
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        happy_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-happy"), None)
+        if isinstance(happy_fixture, dict):
+            interop = load_json_file(present_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [happy_fixture["entry"]]
+                write_json_local(present_target / ".loom/companion/interop.json", interop)
+                write_json_local(present_target / happy_fixture["entry"]["locator"], happy_fixture["payload"])
+            present_payload, present_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(present_target)],
+            )
+            if present_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` happy sample failed: {present_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="happy external orchestrator conformance",
+                    payload=present_payload,
+                )
+                if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                    failures.append(Failure(category, "happy external orchestrator conformance must pass"))
+
+        drift_target = base / "drift"
+        shutil.copytree(example_target, drift_target)
+        drift_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-truth-drift"), None)
+        if isinstance(drift_fixture, dict):
+            interop = load_json_file(drift_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [drift_fixture["entry"]]
+                write_json_local(drift_target / ".loom/companion/interop.json", interop)
+                write_json_local(drift_target / drift_fixture["entry"]["locator"], drift_fixture["payload"])
+            drift_payload, drift_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(drift_target)],
+            )
+            if drift_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` drift sample failed: {drift_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="drift external orchestrator conformance",
+                    payload=drift_payload,
+                )
+                core_profile = drift_payload.get("core_profile") if isinstance(drift_payload, dict) else None
+                if not isinstance(drift_payload, dict) or drift_payload.get("result") != "block":
+                    failures.append(Failure(category, "truth drift external orchestrator conformance must block"))
+                elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                    failures.append(Failure(category, "external orchestrator conformance drift must not rewrite core profile"))
+
+    return failures
+
+
 def check_external_runtime_devendor_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     required_anchors = {
@@ -14373,6 +14607,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
     failures.extend(check_external_orchestrator_interop_fixture_contract(root))
+    failures.extend(check_external_orchestrator_conformance_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14401,7 +14636,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 35
+    categories_checked = 36
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    EXTERNAL_ORCHESTRATOR_OPERATIONS,
     empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
@@ -122,6 +123,7 @@ DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -162,6 +164,41 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "current_lane",
     "recovery_boundary",
     "closing_condition",
+}
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+    "daemon",
+    "scheduler_queue",
+    "branch_ownership",
+    "pr_ownership",
+    "worktree_ownership",
+    "worker_lifecycle",
+}
+EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS = {
+    "work_item",
+    "admission",
+    "binding_repair",
+    "current_checkpoint",
+    "spec_gate",
+    "build_gate",
+    "review_gate",
+    "merge_gate",
+    "build",
+    "review",
+    "merge_ready",
+    "closeout",
 }
 HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
@@ -553,7 +590,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
+    live_smoke.add_argument(
+        "operation",
+        choices=(
+            "run",
+            "replay",
+            "host-adapter-drift",
+            "dynamic-tool-availability",
+            "hook-envelope",
+            "hooks-extension",
+            "external-orchestrator-interop",
+        ),
+    )
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -899,6 +947,41 @@ def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
     ]
 
 
+def external_orchestrator_conformance_command_plan(
+    target_root: Path,
+    external_orchestrators: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading external orchestrator declarations.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'} external_orchestrators",
+            "description": "Read external orchestrator locator declarations without starting a scheduler or daemon.",
+        },
+        {
+            "id": "status-consumer-view",
+            "command": f"{shlex.quote(sys.executable)} tools/loom_status.py --target {shlex.quote(str(target_root))} --item INIT-0001",
+            "description": "Confirm status/gate consumption reuses Loom status control plane v2 and the existing gate chain.",
+        },
+    ]
+    for index, entry in enumerate(external_orchestrators or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"external-orchestrator-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read external orchestrator retained evidence without accepting scheduler-owned status or gate truth.",
+            }
+        )
+    return plan
+
+
 def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
     found: list[str] = []
     if isinstance(value, dict):
@@ -911,6 +994,21 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     elif isinstance(value, list):
         for index, nested in enumerate(value):
             found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def find_forbidden_external_orchestrator_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=f"{prefix}[{index}]"))
     return found
 
 
@@ -1875,6 +1973,313 @@ def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
             "profile_check": {"id": "hooks-extension", "result": result},
             "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
             "hooks_extension": hook_profile,
+        }
+    )
+    return payload
+
+
+def empty_external_orchestrator_conformance() -> dict[str, Any]:
+    return {
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "profile_id": "orchestration-extension/external-orchestrator",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "external orchestrator interop profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+        "non_goals": {
+            "daemon": False,
+            "scheduler_state_machine": False,
+            "tracker_polling_product": False,
+            "second_status_surface": False,
+            "host_lifecycle_ownership": False,
+        },
+    }
+
+
+def external_orchestrator_conformance_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+) -> dict[str, Any]:
+    prefix = f"external_orchestrators[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "requirement": "required",
+            "operations": [],
+            "locator": "",
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            "evidence": {"locator_status": "invalid-declaration"},
+        }
+
+    entry_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"external-orchestrator-{index}"
+    requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+    locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "admission"
+    operations = entry.get("operations") if isinstance(entry.get("operations"), list) else []
+    blocking: list[str] = []
+    optional: list[str] = []
+
+    if requirement not in {"required", "optional", "advisory"}:
+        blocking.append(f"{prefix}.requirement must be required, optional, or advisory")
+        requirement = "required"
+    if not operations:
+        blocking.append(f"{prefix}.operations must be a non-empty list")
+    unsupported = [str(operation) for operation in operations if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS]
+    if unsupported:
+        blocking.append(f"{prefix}.operations contains unsupported operations: {', '.join(unsupported)}")
+    if isinstance(fallback_to, str) and fallback_to not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+        blocking.append(f"{prefix}.fallback_to must point back to a Loom checkpoint or gate repair surface")
+
+    locator_path, locator_errors = resolve_repo_relative_path(target_root, locator, label=f"{prefix} locator")
+    if locator_errors:
+        blocking.extend(locator_errors)
+    elif locator_path is None or not locator_path.exists() or locator_path.is_dir():
+        message = f"{prefix} locator points to missing or unreadable retained evidence `{locator}`"
+        if requirement in {"optional", "advisory"}:
+            optional.append(message)
+        else:
+            blocking.append(message)
+
+    payload: object = None
+    if locator_path is not None and locator_path.exists() and locator_path.is_file():
+        try:
+            payload = load_json_file(locator_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            blocking.append(f"{prefix} retained evidence is not readable JSON: {exc}")
+    if payload is not None and not isinstance(payload, dict):
+        blocking.append(f"{prefix} retained evidence must be a JSON object")
+    if isinstance(payload, dict):
+        forbidden = find_forbidden_external_orchestrator_fields(payload)
+        if forbidden:
+            blocking.append(f"{prefix} retained evidence contains forbidden authored/scheduler fields: {', '.join(forbidden)}")
+        payload_operation = payload.get("operation")
+        if isinstance(payload_operation, str) and operations and payload_operation not in operations:
+            blocking.append(f"{prefix} retained evidence operation is not declared by the locator")
+        if payload.get("operation") in {"status_read", "gate_read"}:
+            if payload.get("source_layer") != "derived_surface":
+                blocking.append(f"{prefix} status/gate reads must consume the derived status surface")
+            if payload.get("consumed_as") != "summary":
+                blocking.append(f"{prefix} status/gate reads must be consumed as summary")
+        if payload.get("host_lifecycle_ownership") not in {None, "host", "external"}:
+            blocking.append(f"{prefix} retained evidence must not claim Loom owns host lifecycle")
+        payload_fallback = payload.get("fallback_to")
+        if isinstance(payload_fallback, str) and payload_fallback not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+            blocking.append(f"{prefix} retained evidence fallback_to must point back to Loom")
+
+    result = "block" if blocking else "warn" if optional else "pass"
+    if result == "warn" and requirement in {"required"}:
+        result = "block"
+    return {
+        "id": entry_id,
+        "requirement": requirement,
+        "operations": operations,
+        "locator": locator,
+        "result": result,
+        "classification": "truth_pollution" if blocking and isinstance(payload, dict) and find_forbidden_external_orchestrator_fields(payload) else "locator_or_contract",
+        "summary": (
+            "external orchestrator retained evidence is readable and respects Loom truth boundaries."
+            if result == "pass"
+            else "external orchestrator retained evidence has profile-local warnings."
+            if result == "warn"
+            else "external orchestrator retained evidence violates interop conformance boundaries."
+        ),
+        "missing_inputs": blocking if result == "block" else [],
+        "missing_optional": optional,
+        "fallback_to": fallback_to if result == "block" else None,
+        "evidence": {
+            "locator_status": "readable" if isinstance(payload, dict) else "missing_or_invalid",
+            "payload_schema_version": payload.get("schema_version") if isinstance(payload, dict) else None,
+            "payload_operation": payload.get("operation") if isinstance(payload, dict) else None,
+        },
+    }
+
+
+def external_orchestrator_conformance_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "external-orchestrator-interop",
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": external_orchestrator_conformance_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "external orchestrator conformance is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "external orchestrator conformance recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    interop_path = target_root / ".loom" / "companion" / "interop.json"
+    if not interop_path.exists():
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop does not declare external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    try:
+        interop_payload = load_json_file(interop_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update(
+            {
+                "enabled": True,
+                "result": "block",
+                "status": "invalid_declaration",
+                "summary": "repo interop contract is unreadable for external orchestrator conformance.",
+                "missing_inputs": [f"repo interop contract is unreadable: {exc}"],
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": conformance["summary"],
+                "missing_inputs": conformance["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+    external_orchestrators = interop_payload.get("external_orchestrators", []) if isinstance(interop_payload, dict) else []
+    if not isinstance(external_orchestrators, list) or not external_orchestrators:
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop is readable but declares no external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    checks = [
+        external_orchestrator_conformance_check(target_root, entry=entry, index=index)
+        for index, entry in enumerate(external_orchestrators)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "repo-interop.external_orchestrator",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    conformance = empty_external_orchestrator_conformance()
+    conformance.update(
+        {
+            "enabled": True,
+            "result": result,
+            "status": "present",
+            "summary": (
+                "external orchestrator conformance passed without introducing a daemon, scheduler state, or second status surface."
+                if result == "pass"
+                else "external orchestrator conformance produced profile-local warnings."
+                if result == "warn"
+                else "external orchestrator conformance found blocking interop drift."
+            ),
+            "missing_inputs": live_smoke_missing_inputs([message for check in checks for message in check.get("missing_inputs", [])]),
+            "missing_optional": [message for check in checks for message in check.get("missing_optional", [])],
+            "checks": checks,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": conformance["summary"],
+            "missing_inputs": conformance["missing_inputs"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "external-orchestrator-interop", "result": result},
+            "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+            "external_orchestrator": conformance,
+            "command_plan": external_orchestrator_conformance_command_plan(target_root, external_orchestrators=external_orchestrators),
         }
     )
     return payload
@@ -12754,6 +13159,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "external-orchestrator-interop":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "external-orchestrator-interop",
+                    "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+                    "result": "block",
+                    "summary": "external orchestrator conformance requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                    "external_orchestrator": {
+                        **empty_external_orchestrator_conformance(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(external_orchestrator_conformance_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -310,6 +310,8 @@ EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA = "loom-external-orchestrator-conformance-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
     "scheduler_state",
     "attempt_ownership",
@@ -1510,6 +1512,67 @@ def require_hook_profile_payload(
             failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
         if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
             failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
+
+
+def require_external_orchestrator_conformance_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "external-orchestrator-interop":
+        failures.append(Failure(category, f"{context} must report `operation: external-orchestrator-interop`"))
+    if payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within pass/warn/block"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include summary"))
+    if payload.get("fallback_to") not in {None, "live-smoke-config-repair", "live-smoke-retry-or-record-unavailable"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay profile-local"))
+    for field in ("runtime_state", "target", "profile_check", "core_profile", "external_orchestrator"):
+        if not isinstance(payload.get(field), dict):
+            failures.append(Failure(category, f"{context} must include `{field}` object"))
+    if not isinstance(payload.get("command_plan"), list) or not payload.get("command_plan"):
+        failures.append(Failure(category, f"{context} must include command_plan"))
+    if not isinstance(payload.get("reports"), list):
+        failures.append(Failure(category, f"{context} must include reports"))
+    conformance = payload.get("external_orchestrator")
+    if isinstance(conformance, dict):
+        if conformance.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, f"{context}.external_orchestrator must use conformance schema"))
+        if conformance.get("profile_id") != "orchestration-extension/external-orchestrator":
+            failures.append(Failure(category, f"{context}.external_orchestrator profile_id must be external-orchestrator"))
+        if conformance.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.external_orchestrator result must stay stable"))
+        if conformance.get("status") not in {
+            "not_applicable",
+            "present",
+            "runtime-blocked",
+            "target-unavailable",
+            "missing-target",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context}.external_orchestrator status is outside the stable vocabulary"))
+        for field in ("missing_inputs", "missing_optional", "checks"):
+            if not isinstance(conformance.get(field), list):
+                failures.append(Failure(category, f"{context}.external_orchestrator.{field} must be a list"))
+        non_goals = conformance.get("non_goals")
+        if not isinstance(non_goals, dict):
+            failures.append(Failure(category, f"{context}.external_orchestrator must include non_goals"))
+        else:
+            for key in ("daemon", "scheduler_state_machine", "tracker_polling_product", "second_status_surface", "host_lifecycle_ownership"):
+                if non_goals.get(key) is not False:
+                    failures.append(Failure(category, f"{context}.external_orchestrator non_goal `{key}` must remain false"))
+    core_profile = payload.get("core_profile")
+    if isinstance(core_profile, dict) and core_profile.get("result") != "pass":
+        failures.append(Failure(category, f"{context}.core_profile.result must remain pass"))
 
 
 def require_repo_interop_payload(
@@ -9912,6 +9975,177 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
     return failures
 
 
+def check_external_orchestrator_conformance_contract(root: Path) -> list[Failure]:
+    category = "external-orchestrator-conformance"
+    failures: list[Failure] = []
+    required_docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/external-orchestrator",
+            "loom-external-orchestrator-conformance/v1",
+            "fake external orchestrator happy/drift fixtures",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "external-orchestrator-interop",
+            "loom-external-orchestrator-conformance/v1",
+            "does not execute",
+        ],
+        "docs/evidence/external-orchestrator-release-threshold.md": [
+            "v0.12.0",
+            "loom-external-orchestrator-conformance/v1",
+            "no daemon",
+            "fake external orchestrator fixtures are sufficient",
+        ],
+    }
+    for relative, anchors in required_docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure(category, f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure(category, f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-conformance-fixtures.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"external orchestrator conformance fixtures are unreadable: {exc}"))
+        return failures
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA:
+        failures.append(Failure(category, f"conformance fixture schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA}`"))
+    fixtures = fixture_payload.get("fixtures")
+    required_names = {
+        "fake-external-orchestrator-happy",
+        "fake-external-orchestrator-truth-drift",
+        "fake-external-orchestrator-private-fallback",
+        "fake-external-orchestrator-lifecycle-drift",
+    }
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator conformance fixtures must include fixtures"))
+        return failures
+    seen_names: set[str] = set()
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if isinstance(name, str):
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+            continue
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"{name or index} payload must be an object"))
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/block"))
+        operations = entry.get("operations")
+        if not isinstance(operations, list) or not operations:
+            failures.append(Failure(category, f"{name or index} entry.operations must be non-empty"))
+        elif any(operation not in {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"} for operation in operations):
+            failures.append(Failure(category, f"{name or index} declares unsupported operation"))
+        if name == "fake-external-orchestrator-happy" and expect.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, "happy fixture must expect conformance schema v1"))
+        if name == "fake-external-orchestrator-truth-drift" and payload is not None:
+            forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+            if not forbidden or expect.get("failure") != "truth_pollution":
+                failures.append(Failure(category, "truth drift fixture must prove forbidden authored/scheduler fields block"))
+        if name == "fake-external-orchestrator-private-fallback":
+            if entry.get("fallback_to") != "scheduler_retry_queue" or expect.get("fallback_to") != "current_checkpoint":
+                failures.append(Failure(category, "private fallback fixture must block back to current_checkpoint"))
+        if name == "fake-external-orchestrator-lifecycle-drift" and payload is not None:
+            if payload.get("host_lifecycle_ownership") != "loom" or payload.get("daemon") is not True:
+                failures.append(Failure(category, "lifecycle drift fixture must prove no-daemon/no-host-lifecycle boundary"))
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator conformance fixtures missing required cases: " + ", ".join(missing)))
+
+    example_target = root / "examples/new-project"
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(example_target)],
+    )
+    if error:
+        failures.append(Failure(category, f"`external-orchestrator-interop` not_applicable sample failed: {error}"))
+    else:
+        require_external_orchestrator_conformance_payload(
+            failures,
+            category=category,
+            context="not-applicable external orchestrator conformance",
+            payload=absent_payload,
+        )
+        external_profile = absent_payload.get("external_orchestrator") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must pass"))
+        elif not isinstance(external_profile, dict) or external_profile.get("status") != "not_applicable":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must expose not_applicable status"))
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    with tempfile.TemporaryDirectory(prefix="loom-external-orchestrator-conformance-") as tmp:
+        base = Path(tmp)
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        happy_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-happy"), None)
+        if isinstance(happy_fixture, dict):
+            interop = load_json_file(present_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [happy_fixture["entry"]]
+                write_json_local(present_target / ".loom/companion/interop.json", interop)
+                write_json_local(present_target / happy_fixture["entry"]["locator"], happy_fixture["payload"])
+            present_payload, present_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(present_target)],
+            )
+            if present_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` happy sample failed: {present_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="happy external orchestrator conformance",
+                    payload=present_payload,
+                )
+                if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                    failures.append(Failure(category, "happy external orchestrator conformance must pass"))
+
+        drift_target = base / "drift"
+        shutil.copytree(example_target, drift_target)
+        drift_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-truth-drift"), None)
+        if isinstance(drift_fixture, dict):
+            interop = load_json_file(drift_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [drift_fixture["entry"]]
+                write_json_local(drift_target / ".loom/companion/interop.json", interop)
+                write_json_local(drift_target / drift_fixture["entry"]["locator"], drift_fixture["payload"])
+            drift_payload, drift_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(drift_target)],
+            )
+            if drift_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` drift sample failed: {drift_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="drift external orchestrator conformance",
+                    payload=drift_payload,
+                )
+                core_profile = drift_payload.get("core_profile") if isinstance(drift_payload, dict) else None
+                if not isinstance(drift_payload, dict) or drift_payload.get("result") != "block":
+                    failures.append(Failure(category, "truth drift external orchestrator conformance must block"))
+                elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                    failures.append(Failure(category, "external orchestrator conformance drift must not rewrite core profile"))
+
+    return failures
+
+
 def check_external_runtime_devendor_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     required_anchors = {
@@ -14373,6 +14607,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
     failures.extend(check_external_orchestrator_interop_fixture_contract(root))
+    failures.extend(check_external_orchestrator_conformance_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14401,7 +14636,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 35
+    categories_checked = 36
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    EXTERNAL_ORCHESTRATOR_OPERATIONS,
     empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
@@ -122,6 +123,7 @@ DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -162,6 +164,41 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "current_lane",
     "recovery_boundary",
     "closing_condition",
+}
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+    "daemon",
+    "scheduler_queue",
+    "branch_ownership",
+    "pr_ownership",
+    "worktree_ownership",
+    "worker_lifecycle",
+}
+EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS = {
+    "work_item",
+    "admission",
+    "binding_repair",
+    "current_checkpoint",
+    "spec_gate",
+    "build_gate",
+    "review_gate",
+    "merge_gate",
+    "build",
+    "review",
+    "merge_ready",
+    "closeout",
 }
 HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
@@ -553,7 +590,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
+    live_smoke.add_argument(
+        "operation",
+        choices=(
+            "run",
+            "replay",
+            "host-adapter-drift",
+            "dynamic-tool-availability",
+            "hook-envelope",
+            "hooks-extension",
+            "external-orchestrator-interop",
+        ),
+    )
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -899,6 +947,41 @@ def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
     ]
 
 
+def external_orchestrator_conformance_command_plan(
+    target_root: Path,
+    external_orchestrators: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading external orchestrator declarations.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'} external_orchestrators",
+            "description": "Read external orchestrator locator declarations without starting a scheduler or daemon.",
+        },
+        {
+            "id": "status-consumer-view",
+            "command": f"{shlex.quote(sys.executable)} tools/loom_status.py --target {shlex.quote(str(target_root))} --item INIT-0001",
+            "description": "Confirm status/gate consumption reuses Loom status control plane v2 and the existing gate chain.",
+        },
+    ]
+    for index, entry in enumerate(external_orchestrators or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"external-orchestrator-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read external orchestrator retained evidence without accepting scheduler-owned status or gate truth.",
+            }
+        )
+    return plan
+
+
 def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
     found: list[str] = []
     if isinstance(value, dict):
@@ -911,6 +994,21 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     elif isinstance(value, list):
         for index, nested in enumerate(value):
             found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def find_forbidden_external_orchestrator_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=f"{prefix}[{index}]"))
     return found
 
 
@@ -1875,6 +1973,313 @@ def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
             "profile_check": {"id": "hooks-extension", "result": result},
             "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
             "hooks_extension": hook_profile,
+        }
+    )
+    return payload
+
+
+def empty_external_orchestrator_conformance() -> dict[str, Any]:
+    return {
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "profile_id": "orchestration-extension/external-orchestrator",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "external orchestrator interop profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+        "non_goals": {
+            "daemon": False,
+            "scheduler_state_machine": False,
+            "tracker_polling_product": False,
+            "second_status_surface": False,
+            "host_lifecycle_ownership": False,
+        },
+    }
+
+
+def external_orchestrator_conformance_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+) -> dict[str, Any]:
+    prefix = f"external_orchestrators[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "requirement": "required",
+            "operations": [],
+            "locator": "",
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            "evidence": {"locator_status": "invalid-declaration"},
+        }
+
+    entry_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"external-orchestrator-{index}"
+    requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+    locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "admission"
+    operations = entry.get("operations") if isinstance(entry.get("operations"), list) else []
+    blocking: list[str] = []
+    optional: list[str] = []
+
+    if requirement not in {"required", "optional", "advisory"}:
+        blocking.append(f"{prefix}.requirement must be required, optional, or advisory")
+        requirement = "required"
+    if not operations:
+        blocking.append(f"{prefix}.operations must be a non-empty list")
+    unsupported = [str(operation) for operation in operations if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS]
+    if unsupported:
+        blocking.append(f"{prefix}.operations contains unsupported operations: {', '.join(unsupported)}")
+    if isinstance(fallback_to, str) and fallback_to not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+        blocking.append(f"{prefix}.fallback_to must point back to a Loom checkpoint or gate repair surface")
+
+    locator_path, locator_errors = resolve_repo_relative_path(target_root, locator, label=f"{prefix} locator")
+    if locator_errors:
+        blocking.extend(locator_errors)
+    elif locator_path is None or not locator_path.exists() or locator_path.is_dir():
+        message = f"{prefix} locator points to missing or unreadable retained evidence `{locator}`"
+        if requirement in {"optional", "advisory"}:
+            optional.append(message)
+        else:
+            blocking.append(message)
+
+    payload: object = None
+    if locator_path is not None and locator_path.exists() and locator_path.is_file():
+        try:
+            payload = load_json_file(locator_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            blocking.append(f"{prefix} retained evidence is not readable JSON: {exc}")
+    if payload is not None and not isinstance(payload, dict):
+        blocking.append(f"{prefix} retained evidence must be a JSON object")
+    if isinstance(payload, dict):
+        forbidden = find_forbidden_external_orchestrator_fields(payload)
+        if forbidden:
+            blocking.append(f"{prefix} retained evidence contains forbidden authored/scheduler fields: {', '.join(forbidden)}")
+        payload_operation = payload.get("operation")
+        if isinstance(payload_operation, str) and operations and payload_operation not in operations:
+            blocking.append(f"{prefix} retained evidence operation is not declared by the locator")
+        if payload.get("operation") in {"status_read", "gate_read"}:
+            if payload.get("source_layer") != "derived_surface":
+                blocking.append(f"{prefix} status/gate reads must consume the derived status surface")
+            if payload.get("consumed_as") != "summary":
+                blocking.append(f"{prefix} status/gate reads must be consumed as summary")
+        if payload.get("host_lifecycle_ownership") not in {None, "host", "external"}:
+            blocking.append(f"{prefix} retained evidence must not claim Loom owns host lifecycle")
+        payload_fallback = payload.get("fallback_to")
+        if isinstance(payload_fallback, str) and payload_fallback not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+            blocking.append(f"{prefix} retained evidence fallback_to must point back to Loom")
+
+    result = "block" if blocking else "warn" if optional else "pass"
+    if result == "warn" and requirement in {"required"}:
+        result = "block"
+    return {
+        "id": entry_id,
+        "requirement": requirement,
+        "operations": operations,
+        "locator": locator,
+        "result": result,
+        "classification": "truth_pollution" if blocking and isinstance(payload, dict) and find_forbidden_external_orchestrator_fields(payload) else "locator_or_contract",
+        "summary": (
+            "external orchestrator retained evidence is readable and respects Loom truth boundaries."
+            if result == "pass"
+            else "external orchestrator retained evidence has profile-local warnings."
+            if result == "warn"
+            else "external orchestrator retained evidence violates interop conformance boundaries."
+        ),
+        "missing_inputs": blocking if result == "block" else [],
+        "missing_optional": optional,
+        "fallback_to": fallback_to if result == "block" else None,
+        "evidence": {
+            "locator_status": "readable" if isinstance(payload, dict) else "missing_or_invalid",
+            "payload_schema_version": payload.get("schema_version") if isinstance(payload, dict) else None,
+            "payload_operation": payload.get("operation") if isinstance(payload, dict) else None,
+        },
+    }
+
+
+def external_orchestrator_conformance_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "external-orchestrator-interop",
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": external_orchestrator_conformance_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "external orchestrator conformance is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "external orchestrator conformance recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    interop_path = target_root / ".loom" / "companion" / "interop.json"
+    if not interop_path.exists():
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop does not declare external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    try:
+        interop_payload = load_json_file(interop_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update(
+            {
+                "enabled": True,
+                "result": "block",
+                "status": "invalid_declaration",
+                "summary": "repo interop contract is unreadable for external orchestrator conformance.",
+                "missing_inputs": [f"repo interop contract is unreadable: {exc}"],
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": conformance["summary"],
+                "missing_inputs": conformance["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+    external_orchestrators = interop_payload.get("external_orchestrators", []) if isinstance(interop_payload, dict) else []
+    if not isinstance(external_orchestrators, list) or not external_orchestrators:
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop is readable but declares no external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    checks = [
+        external_orchestrator_conformance_check(target_root, entry=entry, index=index)
+        for index, entry in enumerate(external_orchestrators)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "repo-interop.external_orchestrator",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    conformance = empty_external_orchestrator_conformance()
+    conformance.update(
+        {
+            "enabled": True,
+            "result": result,
+            "status": "present",
+            "summary": (
+                "external orchestrator conformance passed without introducing a daemon, scheduler state, or second status surface."
+                if result == "pass"
+                else "external orchestrator conformance produced profile-local warnings."
+                if result == "warn"
+                else "external orchestrator conformance found blocking interop drift."
+            ),
+            "missing_inputs": live_smoke_missing_inputs([message for check in checks for message in check.get("missing_inputs", [])]),
+            "missing_optional": [message for check in checks for message in check.get("missing_optional", [])],
+            "checks": checks,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": conformance["summary"],
+            "missing_inputs": conformance["missing_inputs"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "external-orchestrator-interop", "result": result},
+            "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+            "external_orchestrator": conformance,
+            "command_plan": external_orchestrator_conformance_command_plan(target_root, external_orchestrators=external_orchestrators),
         }
     )
     return payload
@@ -12754,6 +13159,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "external-orchestrator-interop":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "external-orchestrator-interop",
+                    "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+                    "result": "block",
+                    "summary": "external orchestrator conformance requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                    "external_orchestrator": {
+                        **empty_external_orchestrator_conformance(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(external_orchestrator_conformance_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -310,6 +310,8 @@ EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA = "loom-external-orchestrator-conformance-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
     "scheduler_state",
     "attempt_ownership",
@@ -1510,6 +1512,67 @@ def require_hook_profile_payload(
             failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
         if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
             failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
+
+
+def require_external_orchestrator_conformance_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "external-orchestrator-interop":
+        failures.append(Failure(category, f"{context} must report `operation: external-orchestrator-interop`"))
+    if payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within pass/warn/block"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include summary"))
+    if payload.get("fallback_to") not in {None, "live-smoke-config-repair", "live-smoke-retry-or-record-unavailable"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay profile-local"))
+    for field in ("runtime_state", "target", "profile_check", "core_profile", "external_orchestrator"):
+        if not isinstance(payload.get(field), dict):
+            failures.append(Failure(category, f"{context} must include `{field}` object"))
+    if not isinstance(payload.get("command_plan"), list) or not payload.get("command_plan"):
+        failures.append(Failure(category, f"{context} must include command_plan"))
+    if not isinstance(payload.get("reports"), list):
+        failures.append(Failure(category, f"{context} must include reports"))
+    conformance = payload.get("external_orchestrator")
+    if isinstance(conformance, dict):
+        if conformance.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, f"{context}.external_orchestrator must use conformance schema"))
+        if conformance.get("profile_id") != "orchestration-extension/external-orchestrator":
+            failures.append(Failure(category, f"{context}.external_orchestrator profile_id must be external-orchestrator"))
+        if conformance.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.external_orchestrator result must stay stable"))
+        if conformance.get("status") not in {
+            "not_applicable",
+            "present",
+            "runtime-blocked",
+            "target-unavailable",
+            "missing-target",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context}.external_orchestrator status is outside the stable vocabulary"))
+        for field in ("missing_inputs", "missing_optional", "checks"):
+            if not isinstance(conformance.get(field), list):
+                failures.append(Failure(category, f"{context}.external_orchestrator.{field} must be a list"))
+        non_goals = conformance.get("non_goals")
+        if not isinstance(non_goals, dict):
+            failures.append(Failure(category, f"{context}.external_orchestrator must include non_goals"))
+        else:
+            for key in ("daemon", "scheduler_state_machine", "tracker_polling_product", "second_status_surface", "host_lifecycle_ownership"):
+                if non_goals.get(key) is not False:
+                    failures.append(Failure(category, f"{context}.external_orchestrator non_goal `{key}` must remain false"))
+    core_profile = payload.get("core_profile")
+    if isinstance(core_profile, dict) and core_profile.get("result") != "pass":
+        failures.append(Failure(category, f"{context}.core_profile.result must remain pass"))
 
 
 def require_repo_interop_payload(
@@ -9912,6 +9975,177 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
     return failures
 
 
+def check_external_orchestrator_conformance_contract(root: Path) -> list[Failure]:
+    category = "external-orchestrator-conformance"
+    failures: list[Failure] = []
+    required_docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/external-orchestrator",
+            "loom-external-orchestrator-conformance/v1",
+            "fake external orchestrator happy/drift fixtures",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "external-orchestrator-interop",
+            "loom-external-orchestrator-conformance/v1",
+            "does not execute",
+        ],
+        "docs/evidence/external-orchestrator-release-threshold.md": [
+            "v0.12.0",
+            "loom-external-orchestrator-conformance/v1",
+            "no daemon",
+            "fake external orchestrator fixtures are sufficient",
+        ],
+    }
+    for relative, anchors in required_docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure(category, f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure(category, f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-conformance-fixtures.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"external orchestrator conformance fixtures are unreadable: {exc}"))
+        return failures
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA:
+        failures.append(Failure(category, f"conformance fixture schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA}`"))
+    fixtures = fixture_payload.get("fixtures")
+    required_names = {
+        "fake-external-orchestrator-happy",
+        "fake-external-orchestrator-truth-drift",
+        "fake-external-orchestrator-private-fallback",
+        "fake-external-orchestrator-lifecycle-drift",
+    }
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator conformance fixtures must include fixtures"))
+        return failures
+    seen_names: set[str] = set()
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if isinstance(name, str):
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+            continue
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"{name or index} payload must be an object"))
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/block"))
+        operations = entry.get("operations")
+        if not isinstance(operations, list) or not operations:
+            failures.append(Failure(category, f"{name or index} entry.operations must be non-empty"))
+        elif any(operation not in {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"} for operation in operations):
+            failures.append(Failure(category, f"{name or index} declares unsupported operation"))
+        if name == "fake-external-orchestrator-happy" and expect.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, "happy fixture must expect conformance schema v1"))
+        if name == "fake-external-orchestrator-truth-drift" and payload is not None:
+            forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+            if not forbidden or expect.get("failure") != "truth_pollution":
+                failures.append(Failure(category, "truth drift fixture must prove forbidden authored/scheduler fields block"))
+        if name == "fake-external-orchestrator-private-fallback":
+            if entry.get("fallback_to") != "scheduler_retry_queue" or expect.get("fallback_to") != "current_checkpoint":
+                failures.append(Failure(category, "private fallback fixture must block back to current_checkpoint"))
+        if name == "fake-external-orchestrator-lifecycle-drift" and payload is not None:
+            if payload.get("host_lifecycle_ownership") != "loom" or payload.get("daemon") is not True:
+                failures.append(Failure(category, "lifecycle drift fixture must prove no-daemon/no-host-lifecycle boundary"))
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator conformance fixtures missing required cases: " + ", ".join(missing)))
+
+    example_target = root / "examples/new-project"
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(example_target)],
+    )
+    if error:
+        failures.append(Failure(category, f"`external-orchestrator-interop` not_applicable sample failed: {error}"))
+    else:
+        require_external_orchestrator_conformance_payload(
+            failures,
+            category=category,
+            context="not-applicable external orchestrator conformance",
+            payload=absent_payload,
+        )
+        external_profile = absent_payload.get("external_orchestrator") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must pass"))
+        elif not isinstance(external_profile, dict) or external_profile.get("status") != "not_applicable":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must expose not_applicable status"))
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    with tempfile.TemporaryDirectory(prefix="loom-external-orchestrator-conformance-") as tmp:
+        base = Path(tmp)
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        happy_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-happy"), None)
+        if isinstance(happy_fixture, dict):
+            interop = load_json_file(present_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [happy_fixture["entry"]]
+                write_json_local(present_target / ".loom/companion/interop.json", interop)
+                write_json_local(present_target / happy_fixture["entry"]["locator"], happy_fixture["payload"])
+            present_payload, present_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(present_target)],
+            )
+            if present_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` happy sample failed: {present_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="happy external orchestrator conformance",
+                    payload=present_payload,
+                )
+                if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                    failures.append(Failure(category, "happy external orchestrator conformance must pass"))
+
+        drift_target = base / "drift"
+        shutil.copytree(example_target, drift_target)
+        drift_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-truth-drift"), None)
+        if isinstance(drift_fixture, dict):
+            interop = load_json_file(drift_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [drift_fixture["entry"]]
+                write_json_local(drift_target / ".loom/companion/interop.json", interop)
+                write_json_local(drift_target / drift_fixture["entry"]["locator"], drift_fixture["payload"])
+            drift_payload, drift_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(drift_target)],
+            )
+            if drift_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` drift sample failed: {drift_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="drift external orchestrator conformance",
+                    payload=drift_payload,
+                )
+                core_profile = drift_payload.get("core_profile") if isinstance(drift_payload, dict) else None
+                if not isinstance(drift_payload, dict) or drift_payload.get("result") != "block":
+                    failures.append(Failure(category, "truth drift external orchestrator conformance must block"))
+                elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                    failures.append(Failure(category, "external orchestrator conformance drift must not rewrite core profile"))
+
+    return failures
+
+
 def check_external_runtime_devendor_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     required_anchors = {
@@ -14373,6 +14607,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
     failures.extend(check_external_orchestrator_interop_fixture_contract(root))
+    failures.extend(check_external_orchestrator_conformance_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14401,7 +14636,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 35
+    categories_checked = 36
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    EXTERNAL_ORCHESTRATOR_OPERATIONS,
     empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
@@ -122,6 +123,7 @@ DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -162,6 +164,41 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "current_lane",
     "recovery_boundary",
     "closing_condition",
+}
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+    "daemon",
+    "scheduler_queue",
+    "branch_ownership",
+    "pr_ownership",
+    "worktree_ownership",
+    "worker_lifecycle",
+}
+EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS = {
+    "work_item",
+    "admission",
+    "binding_repair",
+    "current_checkpoint",
+    "spec_gate",
+    "build_gate",
+    "review_gate",
+    "merge_gate",
+    "build",
+    "review",
+    "merge_ready",
+    "closeout",
 }
 HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
@@ -553,7 +590,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
+    live_smoke.add_argument(
+        "operation",
+        choices=(
+            "run",
+            "replay",
+            "host-adapter-drift",
+            "dynamic-tool-availability",
+            "hook-envelope",
+            "hooks-extension",
+            "external-orchestrator-interop",
+        ),
+    )
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -899,6 +947,41 @@ def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
     ]
 
 
+def external_orchestrator_conformance_command_plan(
+    target_root: Path,
+    external_orchestrators: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading external orchestrator declarations.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'} external_orchestrators",
+            "description": "Read external orchestrator locator declarations without starting a scheduler or daemon.",
+        },
+        {
+            "id": "status-consumer-view",
+            "command": f"{shlex.quote(sys.executable)} tools/loom_status.py --target {shlex.quote(str(target_root))} --item INIT-0001",
+            "description": "Confirm status/gate consumption reuses Loom status control plane v2 and the existing gate chain.",
+        },
+    ]
+    for index, entry in enumerate(external_orchestrators or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"external-orchestrator-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read external orchestrator retained evidence without accepting scheduler-owned status or gate truth.",
+            }
+        )
+    return plan
+
+
 def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
     found: list[str] = []
     if isinstance(value, dict):
@@ -911,6 +994,21 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     elif isinstance(value, list):
         for index, nested in enumerate(value):
             found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def find_forbidden_external_orchestrator_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=f"{prefix}[{index}]"))
     return found
 
 
@@ -1875,6 +1973,313 @@ def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
             "profile_check": {"id": "hooks-extension", "result": result},
             "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
             "hooks_extension": hook_profile,
+        }
+    )
+    return payload
+
+
+def empty_external_orchestrator_conformance() -> dict[str, Any]:
+    return {
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "profile_id": "orchestration-extension/external-orchestrator",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "external orchestrator interop profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+        "non_goals": {
+            "daemon": False,
+            "scheduler_state_machine": False,
+            "tracker_polling_product": False,
+            "second_status_surface": False,
+            "host_lifecycle_ownership": False,
+        },
+    }
+
+
+def external_orchestrator_conformance_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+) -> dict[str, Any]:
+    prefix = f"external_orchestrators[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "requirement": "required",
+            "operations": [],
+            "locator": "",
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            "evidence": {"locator_status": "invalid-declaration"},
+        }
+
+    entry_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"external-orchestrator-{index}"
+    requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+    locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "admission"
+    operations = entry.get("operations") if isinstance(entry.get("operations"), list) else []
+    blocking: list[str] = []
+    optional: list[str] = []
+
+    if requirement not in {"required", "optional", "advisory"}:
+        blocking.append(f"{prefix}.requirement must be required, optional, or advisory")
+        requirement = "required"
+    if not operations:
+        blocking.append(f"{prefix}.operations must be a non-empty list")
+    unsupported = [str(operation) for operation in operations if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS]
+    if unsupported:
+        blocking.append(f"{prefix}.operations contains unsupported operations: {', '.join(unsupported)}")
+    if isinstance(fallback_to, str) and fallback_to not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+        blocking.append(f"{prefix}.fallback_to must point back to a Loom checkpoint or gate repair surface")
+
+    locator_path, locator_errors = resolve_repo_relative_path(target_root, locator, label=f"{prefix} locator")
+    if locator_errors:
+        blocking.extend(locator_errors)
+    elif locator_path is None or not locator_path.exists() or locator_path.is_dir():
+        message = f"{prefix} locator points to missing or unreadable retained evidence `{locator}`"
+        if requirement in {"optional", "advisory"}:
+            optional.append(message)
+        else:
+            blocking.append(message)
+
+    payload: object = None
+    if locator_path is not None and locator_path.exists() and locator_path.is_file():
+        try:
+            payload = load_json_file(locator_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            blocking.append(f"{prefix} retained evidence is not readable JSON: {exc}")
+    if payload is not None and not isinstance(payload, dict):
+        blocking.append(f"{prefix} retained evidence must be a JSON object")
+    if isinstance(payload, dict):
+        forbidden = find_forbidden_external_orchestrator_fields(payload)
+        if forbidden:
+            blocking.append(f"{prefix} retained evidence contains forbidden authored/scheduler fields: {', '.join(forbidden)}")
+        payload_operation = payload.get("operation")
+        if isinstance(payload_operation, str) and operations and payload_operation not in operations:
+            blocking.append(f"{prefix} retained evidence operation is not declared by the locator")
+        if payload.get("operation") in {"status_read", "gate_read"}:
+            if payload.get("source_layer") != "derived_surface":
+                blocking.append(f"{prefix} status/gate reads must consume the derived status surface")
+            if payload.get("consumed_as") != "summary":
+                blocking.append(f"{prefix} status/gate reads must be consumed as summary")
+        if payload.get("host_lifecycle_ownership") not in {None, "host", "external"}:
+            blocking.append(f"{prefix} retained evidence must not claim Loom owns host lifecycle")
+        payload_fallback = payload.get("fallback_to")
+        if isinstance(payload_fallback, str) and payload_fallback not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+            blocking.append(f"{prefix} retained evidence fallback_to must point back to Loom")
+
+    result = "block" if blocking else "warn" if optional else "pass"
+    if result == "warn" and requirement in {"required"}:
+        result = "block"
+    return {
+        "id": entry_id,
+        "requirement": requirement,
+        "operations": operations,
+        "locator": locator,
+        "result": result,
+        "classification": "truth_pollution" if blocking and isinstance(payload, dict) and find_forbidden_external_orchestrator_fields(payload) else "locator_or_contract",
+        "summary": (
+            "external orchestrator retained evidence is readable and respects Loom truth boundaries."
+            if result == "pass"
+            else "external orchestrator retained evidence has profile-local warnings."
+            if result == "warn"
+            else "external orchestrator retained evidence violates interop conformance boundaries."
+        ),
+        "missing_inputs": blocking if result == "block" else [],
+        "missing_optional": optional,
+        "fallback_to": fallback_to if result == "block" else None,
+        "evidence": {
+            "locator_status": "readable" if isinstance(payload, dict) else "missing_or_invalid",
+            "payload_schema_version": payload.get("schema_version") if isinstance(payload, dict) else None,
+            "payload_operation": payload.get("operation") if isinstance(payload, dict) else None,
+        },
+    }
+
+
+def external_orchestrator_conformance_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "external-orchestrator-interop",
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": external_orchestrator_conformance_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "external orchestrator conformance is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "external orchestrator conformance recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    interop_path = target_root / ".loom" / "companion" / "interop.json"
+    if not interop_path.exists():
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop does not declare external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    try:
+        interop_payload = load_json_file(interop_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update(
+            {
+                "enabled": True,
+                "result": "block",
+                "status": "invalid_declaration",
+                "summary": "repo interop contract is unreadable for external orchestrator conformance.",
+                "missing_inputs": [f"repo interop contract is unreadable: {exc}"],
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": conformance["summary"],
+                "missing_inputs": conformance["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+    external_orchestrators = interop_payload.get("external_orchestrators", []) if isinstance(interop_payload, dict) else []
+    if not isinstance(external_orchestrators, list) or not external_orchestrators:
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop is readable but declares no external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    checks = [
+        external_orchestrator_conformance_check(target_root, entry=entry, index=index)
+        for index, entry in enumerate(external_orchestrators)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "repo-interop.external_orchestrator",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    conformance = empty_external_orchestrator_conformance()
+    conformance.update(
+        {
+            "enabled": True,
+            "result": result,
+            "status": "present",
+            "summary": (
+                "external orchestrator conformance passed without introducing a daemon, scheduler state, or second status surface."
+                if result == "pass"
+                else "external orchestrator conformance produced profile-local warnings."
+                if result == "warn"
+                else "external orchestrator conformance found blocking interop drift."
+            ),
+            "missing_inputs": live_smoke_missing_inputs([message for check in checks for message in check.get("missing_inputs", [])]),
+            "missing_optional": [message for check in checks for message in check.get("missing_optional", [])],
+            "checks": checks,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": conformance["summary"],
+            "missing_inputs": conformance["missing_inputs"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "external-orchestrator-interop", "result": result},
+            "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+            "external_orchestrator": conformance,
+            "command_plan": external_orchestrator_conformance_command_plan(target_root, external_orchestrators=external_orchestrators),
         }
     )
     return payload
@@ -12754,6 +13159,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "external-orchestrator-interop":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "external-orchestrator-interop",
+                    "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+                    "result": "block",
+                    "summary": "external orchestrator conformance requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                    "external_orchestrator": {
+                        **empty_external_orchestrator_conformance(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(external_orchestrator_conformance_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -310,6 +310,8 @@ EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA = "loom-external-orchestrator-conformance-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
     "scheduler_state",
     "attempt_ownership",
@@ -1510,6 +1512,67 @@ def require_hook_profile_payload(
             failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
         if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
             failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
+
+
+def require_external_orchestrator_conformance_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "external-orchestrator-interop":
+        failures.append(Failure(category, f"{context} must report `operation: external-orchestrator-interop`"))
+    if payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within pass/warn/block"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include summary"))
+    if payload.get("fallback_to") not in {None, "live-smoke-config-repair", "live-smoke-retry-or-record-unavailable"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay profile-local"))
+    for field in ("runtime_state", "target", "profile_check", "core_profile", "external_orchestrator"):
+        if not isinstance(payload.get(field), dict):
+            failures.append(Failure(category, f"{context} must include `{field}` object"))
+    if not isinstance(payload.get("command_plan"), list) or not payload.get("command_plan"):
+        failures.append(Failure(category, f"{context} must include command_plan"))
+    if not isinstance(payload.get("reports"), list):
+        failures.append(Failure(category, f"{context} must include reports"))
+    conformance = payload.get("external_orchestrator")
+    if isinstance(conformance, dict):
+        if conformance.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, f"{context}.external_orchestrator must use conformance schema"))
+        if conformance.get("profile_id") != "orchestration-extension/external-orchestrator":
+            failures.append(Failure(category, f"{context}.external_orchestrator profile_id must be external-orchestrator"))
+        if conformance.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.external_orchestrator result must stay stable"))
+        if conformance.get("status") not in {
+            "not_applicable",
+            "present",
+            "runtime-blocked",
+            "target-unavailable",
+            "missing-target",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context}.external_orchestrator status is outside the stable vocabulary"))
+        for field in ("missing_inputs", "missing_optional", "checks"):
+            if not isinstance(conformance.get(field), list):
+                failures.append(Failure(category, f"{context}.external_orchestrator.{field} must be a list"))
+        non_goals = conformance.get("non_goals")
+        if not isinstance(non_goals, dict):
+            failures.append(Failure(category, f"{context}.external_orchestrator must include non_goals"))
+        else:
+            for key in ("daemon", "scheduler_state_machine", "tracker_polling_product", "second_status_surface", "host_lifecycle_ownership"):
+                if non_goals.get(key) is not False:
+                    failures.append(Failure(category, f"{context}.external_orchestrator non_goal `{key}` must remain false"))
+    core_profile = payload.get("core_profile")
+    if isinstance(core_profile, dict) and core_profile.get("result") != "pass":
+        failures.append(Failure(category, f"{context}.core_profile.result must remain pass"))
 
 
 def require_repo_interop_payload(
@@ -9912,6 +9975,177 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
     return failures
 
 
+def check_external_orchestrator_conformance_contract(root: Path) -> list[Failure]:
+    category = "external-orchestrator-conformance"
+    failures: list[Failure] = []
+    required_docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/external-orchestrator",
+            "loom-external-orchestrator-conformance/v1",
+            "fake external orchestrator happy/drift fixtures",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "external-orchestrator-interop",
+            "loom-external-orchestrator-conformance/v1",
+            "does not execute",
+        ],
+        "docs/evidence/external-orchestrator-release-threshold.md": [
+            "v0.12.0",
+            "loom-external-orchestrator-conformance/v1",
+            "no daemon",
+            "fake external orchestrator fixtures are sufficient",
+        ],
+    }
+    for relative, anchors in required_docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure(category, f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure(category, f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-conformance-fixtures.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"external orchestrator conformance fixtures are unreadable: {exc}"))
+        return failures
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA:
+        failures.append(Failure(category, f"conformance fixture schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA}`"))
+    fixtures = fixture_payload.get("fixtures")
+    required_names = {
+        "fake-external-orchestrator-happy",
+        "fake-external-orchestrator-truth-drift",
+        "fake-external-orchestrator-private-fallback",
+        "fake-external-orchestrator-lifecycle-drift",
+    }
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator conformance fixtures must include fixtures"))
+        return failures
+    seen_names: set[str] = set()
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if isinstance(name, str):
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+            continue
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"{name or index} payload must be an object"))
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/block"))
+        operations = entry.get("operations")
+        if not isinstance(operations, list) or not operations:
+            failures.append(Failure(category, f"{name or index} entry.operations must be non-empty"))
+        elif any(operation not in {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"} for operation in operations):
+            failures.append(Failure(category, f"{name or index} declares unsupported operation"))
+        if name == "fake-external-orchestrator-happy" and expect.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, "happy fixture must expect conformance schema v1"))
+        if name == "fake-external-orchestrator-truth-drift" and payload is not None:
+            forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+            if not forbidden or expect.get("failure") != "truth_pollution":
+                failures.append(Failure(category, "truth drift fixture must prove forbidden authored/scheduler fields block"))
+        if name == "fake-external-orchestrator-private-fallback":
+            if entry.get("fallback_to") != "scheduler_retry_queue" or expect.get("fallback_to") != "current_checkpoint":
+                failures.append(Failure(category, "private fallback fixture must block back to current_checkpoint"))
+        if name == "fake-external-orchestrator-lifecycle-drift" and payload is not None:
+            if payload.get("host_lifecycle_ownership") != "loom" or payload.get("daemon") is not True:
+                failures.append(Failure(category, "lifecycle drift fixture must prove no-daemon/no-host-lifecycle boundary"))
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator conformance fixtures missing required cases: " + ", ".join(missing)))
+
+    example_target = root / "examples/new-project"
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(example_target)],
+    )
+    if error:
+        failures.append(Failure(category, f"`external-orchestrator-interop` not_applicable sample failed: {error}"))
+    else:
+        require_external_orchestrator_conformance_payload(
+            failures,
+            category=category,
+            context="not-applicable external orchestrator conformance",
+            payload=absent_payload,
+        )
+        external_profile = absent_payload.get("external_orchestrator") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must pass"))
+        elif not isinstance(external_profile, dict) or external_profile.get("status") != "not_applicable":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must expose not_applicable status"))
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    with tempfile.TemporaryDirectory(prefix="loom-external-orchestrator-conformance-") as tmp:
+        base = Path(tmp)
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        happy_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-happy"), None)
+        if isinstance(happy_fixture, dict):
+            interop = load_json_file(present_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [happy_fixture["entry"]]
+                write_json_local(present_target / ".loom/companion/interop.json", interop)
+                write_json_local(present_target / happy_fixture["entry"]["locator"], happy_fixture["payload"])
+            present_payload, present_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(present_target)],
+            )
+            if present_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` happy sample failed: {present_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="happy external orchestrator conformance",
+                    payload=present_payload,
+                )
+                if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                    failures.append(Failure(category, "happy external orchestrator conformance must pass"))
+
+        drift_target = base / "drift"
+        shutil.copytree(example_target, drift_target)
+        drift_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-truth-drift"), None)
+        if isinstance(drift_fixture, dict):
+            interop = load_json_file(drift_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [drift_fixture["entry"]]
+                write_json_local(drift_target / ".loom/companion/interop.json", interop)
+                write_json_local(drift_target / drift_fixture["entry"]["locator"], drift_fixture["payload"])
+            drift_payload, drift_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(drift_target)],
+            )
+            if drift_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` drift sample failed: {drift_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="drift external orchestrator conformance",
+                    payload=drift_payload,
+                )
+                core_profile = drift_payload.get("core_profile") if isinstance(drift_payload, dict) else None
+                if not isinstance(drift_payload, dict) or drift_payload.get("result") != "block":
+                    failures.append(Failure(category, "truth drift external orchestrator conformance must block"))
+                elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                    failures.append(Failure(category, "external orchestrator conformance drift must not rewrite core profile"))
+
+    return failures
+
+
 def check_external_runtime_devendor_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     required_anchors = {
@@ -14373,6 +14607,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
     failures.extend(check_external_orchestrator_interop_fixture_contract(root))
+    failures.extend(check_external_orchestrator_conformance_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14401,7 +14636,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 35
+    categories_checked = 36
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    EXTERNAL_ORCHESTRATOR_OPERATIONS,
     empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
@@ -122,6 +123,7 @@ DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -162,6 +164,41 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "current_lane",
     "recovery_boundary",
     "closing_condition",
+}
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+    "daemon",
+    "scheduler_queue",
+    "branch_ownership",
+    "pr_ownership",
+    "worktree_ownership",
+    "worker_lifecycle",
+}
+EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS = {
+    "work_item",
+    "admission",
+    "binding_repair",
+    "current_checkpoint",
+    "spec_gate",
+    "build_gate",
+    "review_gate",
+    "merge_gate",
+    "build",
+    "review",
+    "merge_ready",
+    "closeout",
 }
 HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
@@ -553,7 +590,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
+    live_smoke.add_argument(
+        "operation",
+        choices=(
+            "run",
+            "replay",
+            "host-adapter-drift",
+            "dynamic-tool-availability",
+            "hook-envelope",
+            "hooks-extension",
+            "external-orchestrator-interop",
+        ),
+    )
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -899,6 +947,41 @@ def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
     ]
 
 
+def external_orchestrator_conformance_command_plan(
+    target_root: Path,
+    external_orchestrators: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading external orchestrator declarations.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'} external_orchestrators",
+            "description": "Read external orchestrator locator declarations without starting a scheduler or daemon.",
+        },
+        {
+            "id": "status-consumer-view",
+            "command": f"{shlex.quote(sys.executable)} tools/loom_status.py --target {shlex.quote(str(target_root))} --item INIT-0001",
+            "description": "Confirm status/gate consumption reuses Loom status control plane v2 and the existing gate chain.",
+        },
+    ]
+    for index, entry in enumerate(external_orchestrators or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"external-orchestrator-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read external orchestrator retained evidence without accepting scheduler-owned status or gate truth.",
+            }
+        )
+    return plan
+
+
 def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
     found: list[str] = []
     if isinstance(value, dict):
@@ -911,6 +994,21 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     elif isinstance(value, list):
         for index, nested in enumerate(value):
             found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def find_forbidden_external_orchestrator_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=f"{prefix}[{index}]"))
     return found
 
 
@@ -1875,6 +1973,313 @@ def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
             "profile_check": {"id": "hooks-extension", "result": result},
             "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
             "hooks_extension": hook_profile,
+        }
+    )
+    return payload
+
+
+def empty_external_orchestrator_conformance() -> dict[str, Any]:
+    return {
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "profile_id": "orchestration-extension/external-orchestrator",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "external orchestrator interop profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+        "non_goals": {
+            "daemon": False,
+            "scheduler_state_machine": False,
+            "tracker_polling_product": False,
+            "second_status_surface": False,
+            "host_lifecycle_ownership": False,
+        },
+    }
+
+
+def external_orchestrator_conformance_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+) -> dict[str, Any]:
+    prefix = f"external_orchestrators[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "requirement": "required",
+            "operations": [],
+            "locator": "",
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            "evidence": {"locator_status": "invalid-declaration"},
+        }
+
+    entry_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"external-orchestrator-{index}"
+    requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+    locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "admission"
+    operations = entry.get("operations") if isinstance(entry.get("operations"), list) else []
+    blocking: list[str] = []
+    optional: list[str] = []
+
+    if requirement not in {"required", "optional", "advisory"}:
+        blocking.append(f"{prefix}.requirement must be required, optional, or advisory")
+        requirement = "required"
+    if not operations:
+        blocking.append(f"{prefix}.operations must be a non-empty list")
+    unsupported = [str(operation) for operation in operations if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS]
+    if unsupported:
+        blocking.append(f"{prefix}.operations contains unsupported operations: {', '.join(unsupported)}")
+    if isinstance(fallback_to, str) and fallback_to not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+        blocking.append(f"{prefix}.fallback_to must point back to a Loom checkpoint or gate repair surface")
+
+    locator_path, locator_errors = resolve_repo_relative_path(target_root, locator, label=f"{prefix} locator")
+    if locator_errors:
+        blocking.extend(locator_errors)
+    elif locator_path is None or not locator_path.exists() or locator_path.is_dir():
+        message = f"{prefix} locator points to missing or unreadable retained evidence `{locator}`"
+        if requirement in {"optional", "advisory"}:
+            optional.append(message)
+        else:
+            blocking.append(message)
+
+    payload: object = None
+    if locator_path is not None and locator_path.exists() and locator_path.is_file():
+        try:
+            payload = load_json_file(locator_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            blocking.append(f"{prefix} retained evidence is not readable JSON: {exc}")
+    if payload is not None and not isinstance(payload, dict):
+        blocking.append(f"{prefix} retained evidence must be a JSON object")
+    if isinstance(payload, dict):
+        forbidden = find_forbidden_external_orchestrator_fields(payload)
+        if forbidden:
+            blocking.append(f"{prefix} retained evidence contains forbidden authored/scheduler fields: {', '.join(forbidden)}")
+        payload_operation = payload.get("operation")
+        if isinstance(payload_operation, str) and operations and payload_operation not in operations:
+            blocking.append(f"{prefix} retained evidence operation is not declared by the locator")
+        if payload.get("operation") in {"status_read", "gate_read"}:
+            if payload.get("source_layer") != "derived_surface":
+                blocking.append(f"{prefix} status/gate reads must consume the derived status surface")
+            if payload.get("consumed_as") != "summary":
+                blocking.append(f"{prefix} status/gate reads must be consumed as summary")
+        if payload.get("host_lifecycle_ownership") not in {None, "host", "external"}:
+            blocking.append(f"{prefix} retained evidence must not claim Loom owns host lifecycle")
+        payload_fallback = payload.get("fallback_to")
+        if isinstance(payload_fallback, str) and payload_fallback not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+            blocking.append(f"{prefix} retained evidence fallback_to must point back to Loom")
+
+    result = "block" if blocking else "warn" if optional else "pass"
+    if result == "warn" and requirement in {"required"}:
+        result = "block"
+    return {
+        "id": entry_id,
+        "requirement": requirement,
+        "operations": operations,
+        "locator": locator,
+        "result": result,
+        "classification": "truth_pollution" if blocking and isinstance(payload, dict) and find_forbidden_external_orchestrator_fields(payload) else "locator_or_contract",
+        "summary": (
+            "external orchestrator retained evidence is readable and respects Loom truth boundaries."
+            if result == "pass"
+            else "external orchestrator retained evidence has profile-local warnings."
+            if result == "warn"
+            else "external orchestrator retained evidence violates interop conformance boundaries."
+        ),
+        "missing_inputs": blocking if result == "block" else [],
+        "missing_optional": optional,
+        "fallback_to": fallback_to if result == "block" else None,
+        "evidence": {
+            "locator_status": "readable" if isinstance(payload, dict) else "missing_or_invalid",
+            "payload_schema_version": payload.get("schema_version") if isinstance(payload, dict) else None,
+            "payload_operation": payload.get("operation") if isinstance(payload, dict) else None,
+        },
+    }
+
+
+def external_orchestrator_conformance_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "external-orchestrator-interop",
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": external_orchestrator_conformance_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "external orchestrator conformance is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "external orchestrator conformance recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    interop_path = target_root / ".loom" / "companion" / "interop.json"
+    if not interop_path.exists():
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop does not declare external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    try:
+        interop_payload = load_json_file(interop_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update(
+            {
+                "enabled": True,
+                "result": "block",
+                "status": "invalid_declaration",
+                "summary": "repo interop contract is unreadable for external orchestrator conformance.",
+                "missing_inputs": [f"repo interop contract is unreadable: {exc}"],
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": conformance["summary"],
+                "missing_inputs": conformance["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+    external_orchestrators = interop_payload.get("external_orchestrators", []) if isinstance(interop_payload, dict) else []
+    if not isinstance(external_orchestrators, list) or not external_orchestrators:
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop is readable but declares no external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    checks = [
+        external_orchestrator_conformance_check(target_root, entry=entry, index=index)
+        for index, entry in enumerate(external_orchestrators)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "repo-interop.external_orchestrator",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    conformance = empty_external_orchestrator_conformance()
+    conformance.update(
+        {
+            "enabled": True,
+            "result": result,
+            "status": "present",
+            "summary": (
+                "external orchestrator conformance passed without introducing a daemon, scheduler state, or second status surface."
+                if result == "pass"
+                else "external orchestrator conformance produced profile-local warnings."
+                if result == "warn"
+                else "external orchestrator conformance found blocking interop drift."
+            ),
+            "missing_inputs": live_smoke_missing_inputs([message for check in checks for message in check.get("missing_inputs", [])]),
+            "missing_optional": [message for check in checks for message in check.get("missing_optional", [])],
+            "checks": checks,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": conformance["summary"],
+            "missing_inputs": conformance["missing_inputs"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "external-orchestrator-interop", "result": result},
+            "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+            "external_orchestrator": conformance,
+            "command_plan": external_orchestrator_conformance_command_plan(target_root, external_orchestrators=external_orchestrators),
         }
     )
     return payload
@@ -12754,6 +13159,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "external-orchestrator-interop":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "external-orchestrator-interop",
+                    "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+                    "result": "block",
+                    "summary": "external orchestrator conformance requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                    "external_orchestrator": {
+                        **empty_external_orchestrator_conformance(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(external_orchestrator_conformance_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -310,6 +310,8 @@ EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA = "loom-external-orchestrator-conformance-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
     "scheduler_state",
     "attempt_ownership",
@@ -1510,6 +1512,67 @@ def require_hook_profile_payload(
             failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
         if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
             failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
+
+
+def require_external_orchestrator_conformance_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "external-orchestrator-interop":
+        failures.append(Failure(category, f"{context} must report `operation: external-orchestrator-interop`"))
+    if payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within pass/warn/block"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include summary"))
+    if payload.get("fallback_to") not in {None, "live-smoke-config-repair", "live-smoke-retry-or-record-unavailable"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay profile-local"))
+    for field in ("runtime_state", "target", "profile_check", "core_profile", "external_orchestrator"):
+        if not isinstance(payload.get(field), dict):
+            failures.append(Failure(category, f"{context} must include `{field}` object"))
+    if not isinstance(payload.get("command_plan"), list) or not payload.get("command_plan"):
+        failures.append(Failure(category, f"{context} must include command_plan"))
+    if not isinstance(payload.get("reports"), list):
+        failures.append(Failure(category, f"{context} must include reports"))
+    conformance = payload.get("external_orchestrator")
+    if isinstance(conformance, dict):
+        if conformance.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, f"{context}.external_orchestrator must use conformance schema"))
+        if conformance.get("profile_id") != "orchestration-extension/external-orchestrator":
+            failures.append(Failure(category, f"{context}.external_orchestrator profile_id must be external-orchestrator"))
+        if conformance.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.external_orchestrator result must stay stable"))
+        if conformance.get("status") not in {
+            "not_applicable",
+            "present",
+            "runtime-blocked",
+            "target-unavailable",
+            "missing-target",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context}.external_orchestrator status is outside the stable vocabulary"))
+        for field in ("missing_inputs", "missing_optional", "checks"):
+            if not isinstance(conformance.get(field), list):
+                failures.append(Failure(category, f"{context}.external_orchestrator.{field} must be a list"))
+        non_goals = conformance.get("non_goals")
+        if not isinstance(non_goals, dict):
+            failures.append(Failure(category, f"{context}.external_orchestrator must include non_goals"))
+        else:
+            for key in ("daemon", "scheduler_state_machine", "tracker_polling_product", "second_status_surface", "host_lifecycle_ownership"):
+                if non_goals.get(key) is not False:
+                    failures.append(Failure(category, f"{context}.external_orchestrator non_goal `{key}` must remain false"))
+    core_profile = payload.get("core_profile")
+    if isinstance(core_profile, dict) and core_profile.get("result") != "pass":
+        failures.append(Failure(category, f"{context}.core_profile.result must remain pass"))
 
 
 def require_repo_interop_payload(
@@ -9912,6 +9975,177 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
     return failures
 
 
+def check_external_orchestrator_conformance_contract(root: Path) -> list[Failure]:
+    category = "external-orchestrator-conformance"
+    failures: list[Failure] = []
+    required_docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/external-orchestrator",
+            "loom-external-orchestrator-conformance/v1",
+            "fake external orchestrator happy/drift fixtures",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "external-orchestrator-interop",
+            "loom-external-orchestrator-conformance/v1",
+            "does not execute",
+        ],
+        "docs/evidence/external-orchestrator-release-threshold.md": [
+            "v0.12.0",
+            "loom-external-orchestrator-conformance/v1",
+            "no daemon",
+            "fake external orchestrator fixtures are sufficient",
+        ],
+    }
+    for relative, anchors in required_docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure(category, f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure(category, f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-conformance-fixtures.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"external orchestrator conformance fixtures are unreadable: {exc}"))
+        return failures
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA:
+        failures.append(Failure(category, f"conformance fixture schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA}`"))
+    fixtures = fixture_payload.get("fixtures")
+    required_names = {
+        "fake-external-orchestrator-happy",
+        "fake-external-orchestrator-truth-drift",
+        "fake-external-orchestrator-private-fallback",
+        "fake-external-orchestrator-lifecycle-drift",
+    }
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator conformance fixtures must include fixtures"))
+        return failures
+    seen_names: set[str] = set()
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if isinstance(name, str):
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+            continue
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"{name or index} payload must be an object"))
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/block"))
+        operations = entry.get("operations")
+        if not isinstance(operations, list) or not operations:
+            failures.append(Failure(category, f"{name or index} entry.operations must be non-empty"))
+        elif any(operation not in {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"} for operation in operations):
+            failures.append(Failure(category, f"{name or index} declares unsupported operation"))
+        if name == "fake-external-orchestrator-happy" and expect.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, "happy fixture must expect conformance schema v1"))
+        if name == "fake-external-orchestrator-truth-drift" and payload is not None:
+            forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+            if not forbidden or expect.get("failure") != "truth_pollution":
+                failures.append(Failure(category, "truth drift fixture must prove forbidden authored/scheduler fields block"))
+        if name == "fake-external-orchestrator-private-fallback":
+            if entry.get("fallback_to") != "scheduler_retry_queue" or expect.get("fallback_to") != "current_checkpoint":
+                failures.append(Failure(category, "private fallback fixture must block back to current_checkpoint"))
+        if name == "fake-external-orchestrator-lifecycle-drift" and payload is not None:
+            if payload.get("host_lifecycle_ownership") != "loom" or payload.get("daemon") is not True:
+                failures.append(Failure(category, "lifecycle drift fixture must prove no-daemon/no-host-lifecycle boundary"))
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator conformance fixtures missing required cases: " + ", ".join(missing)))
+
+    example_target = root / "examples/new-project"
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(example_target)],
+    )
+    if error:
+        failures.append(Failure(category, f"`external-orchestrator-interop` not_applicable sample failed: {error}"))
+    else:
+        require_external_orchestrator_conformance_payload(
+            failures,
+            category=category,
+            context="not-applicable external orchestrator conformance",
+            payload=absent_payload,
+        )
+        external_profile = absent_payload.get("external_orchestrator") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must pass"))
+        elif not isinstance(external_profile, dict) or external_profile.get("status") != "not_applicable":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must expose not_applicable status"))
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    with tempfile.TemporaryDirectory(prefix="loom-external-orchestrator-conformance-") as tmp:
+        base = Path(tmp)
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        happy_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-happy"), None)
+        if isinstance(happy_fixture, dict):
+            interop = load_json_file(present_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [happy_fixture["entry"]]
+                write_json_local(present_target / ".loom/companion/interop.json", interop)
+                write_json_local(present_target / happy_fixture["entry"]["locator"], happy_fixture["payload"])
+            present_payload, present_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(present_target)],
+            )
+            if present_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` happy sample failed: {present_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="happy external orchestrator conformance",
+                    payload=present_payload,
+                )
+                if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                    failures.append(Failure(category, "happy external orchestrator conformance must pass"))
+
+        drift_target = base / "drift"
+        shutil.copytree(example_target, drift_target)
+        drift_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-truth-drift"), None)
+        if isinstance(drift_fixture, dict):
+            interop = load_json_file(drift_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [drift_fixture["entry"]]
+                write_json_local(drift_target / ".loom/companion/interop.json", interop)
+                write_json_local(drift_target / drift_fixture["entry"]["locator"], drift_fixture["payload"])
+            drift_payload, drift_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(drift_target)],
+            )
+            if drift_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` drift sample failed: {drift_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="drift external orchestrator conformance",
+                    payload=drift_payload,
+                )
+                core_profile = drift_payload.get("core_profile") if isinstance(drift_payload, dict) else None
+                if not isinstance(drift_payload, dict) or drift_payload.get("result") != "block":
+                    failures.append(Failure(category, "truth drift external orchestrator conformance must block"))
+                elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                    failures.append(Failure(category, "external orchestrator conformance drift must not rewrite core profile"))
+
+    return failures
+
+
 def check_external_runtime_devendor_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     required_anchors = {
@@ -14373,6 +14607,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
     failures.extend(check_external_orchestrator_interop_fixture_contract(root))
+    failures.extend(check_external_orchestrator_conformance_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14401,7 +14636,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 35
+    categories_checked = 36
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    EXTERNAL_ORCHESTRATOR_OPERATIONS,
     empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
@@ -122,6 +123,7 @@ DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -162,6 +164,41 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "current_lane",
     "recovery_boundary",
     "closing_condition",
+}
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+    "daemon",
+    "scheduler_queue",
+    "branch_ownership",
+    "pr_ownership",
+    "worktree_ownership",
+    "worker_lifecycle",
+}
+EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS = {
+    "work_item",
+    "admission",
+    "binding_repair",
+    "current_checkpoint",
+    "spec_gate",
+    "build_gate",
+    "review_gate",
+    "merge_gate",
+    "build",
+    "review",
+    "merge_ready",
+    "closeout",
 }
 HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
@@ -553,7 +590,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
+    live_smoke.add_argument(
+        "operation",
+        choices=(
+            "run",
+            "replay",
+            "host-adapter-drift",
+            "dynamic-tool-availability",
+            "hook-envelope",
+            "hooks-extension",
+            "external-orchestrator-interop",
+        ),
+    )
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -899,6 +947,41 @@ def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
     ]
 
 
+def external_orchestrator_conformance_command_plan(
+    target_root: Path,
+    external_orchestrators: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading external orchestrator declarations.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'} external_orchestrators",
+            "description": "Read external orchestrator locator declarations without starting a scheduler or daemon.",
+        },
+        {
+            "id": "status-consumer-view",
+            "command": f"{shlex.quote(sys.executable)} tools/loom_status.py --target {shlex.quote(str(target_root))} --item INIT-0001",
+            "description": "Confirm status/gate consumption reuses Loom status control plane v2 and the existing gate chain.",
+        },
+    ]
+    for index, entry in enumerate(external_orchestrators or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"external-orchestrator-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read external orchestrator retained evidence without accepting scheduler-owned status or gate truth.",
+            }
+        )
+    return plan
+
+
 def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
     found: list[str] = []
     if isinstance(value, dict):
@@ -911,6 +994,21 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     elif isinstance(value, list):
         for index, nested in enumerate(value):
             found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def find_forbidden_external_orchestrator_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=f"{prefix}[{index}]"))
     return found
 
 
@@ -1875,6 +1973,313 @@ def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
             "profile_check": {"id": "hooks-extension", "result": result},
             "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
             "hooks_extension": hook_profile,
+        }
+    )
+    return payload
+
+
+def empty_external_orchestrator_conformance() -> dict[str, Any]:
+    return {
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "profile_id": "orchestration-extension/external-orchestrator",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "external orchestrator interop profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+        "non_goals": {
+            "daemon": False,
+            "scheduler_state_machine": False,
+            "tracker_polling_product": False,
+            "second_status_surface": False,
+            "host_lifecycle_ownership": False,
+        },
+    }
+
+
+def external_orchestrator_conformance_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+) -> dict[str, Any]:
+    prefix = f"external_orchestrators[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "requirement": "required",
+            "operations": [],
+            "locator": "",
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            "evidence": {"locator_status": "invalid-declaration"},
+        }
+
+    entry_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"external-orchestrator-{index}"
+    requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+    locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "admission"
+    operations = entry.get("operations") if isinstance(entry.get("operations"), list) else []
+    blocking: list[str] = []
+    optional: list[str] = []
+
+    if requirement not in {"required", "optional", "advisory"}:
+        blocking.append(f"{prefix}.requirement must be required, optional, or advisory")
+        requirement = "required"
+    if not operations:
+        blocking.append(f"{prefix}.operations must be a non-empty list")
+    unsupported = [str(operation) for operation in operations if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS]
+    if unsupported:
+        blocking.append(f"{prefix}.operations contains unsupported operations: {', '.join(unsupported)}")
+    if isinstance(fallback_to, str) and fallback_to not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+        blocking.append(f"{prefix}.fallback_to must point back to a Loom checkpoint or gate repair surface")
+
+    locator_path, locator_errors = resolve_repo_relative_path(target_root, locator, label=f"{prefix} locator")
+    if locator_errors:
+        blocking.extend(locator_errors)
+    elif locator_path is None or not locator_path.exists() or locator_path.is_dir():
+        message = f"{prefix} locator points to missing or unreadable retained evidence `{locator}`"
+        if requirement in {"optional", "advisory"}:
+            optional.append(message)
+        else:
+            blocking.append(message)
+
+    payload: object = None
+    if locator_path is not None and locator_path.exists() and locator_path.is_file():
+        try:
+            payload = load_json_file(locator_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            blocking.append(f"{prefix} retained evidence is not readable JSON: {exc}")
+    if payload is not None and not isinstance(payload, dict):
+        blocking.append(f"{prefix} retained evidence must be a JSON object")
+    if isinstance(payload, dict):
+        forbidden = find_forbidden_external_orchestrator_fields(payload)
+        if forbidden:
+            blocking.append(f"{prefix} retained evidence contains forbidden authored/scheduler fields: {', '.join(forbidden)}")
+        payload_operation = payload.get("operation")
+        if isinstance(payload_operation, str) and operations and payload_operation not in operations:
+            blocking.append(f"{prefix} retained evidence operation is not declared by the locator")
+        if payload.get("operation") in {"status_read", "gate_read"}:
+            if payload.get("source_layer") != "derived_surface":
+                blocking.append(f"{prefix} status/gate reads must consume the derived status surface")
+            if payload.get("consumed_as") != "summary":
+                blocking.append(f"{prefix} status/gate reads must be consumed as summary")
+        if payload.get("host_lifecycle_ownership") not in {None, "host", "external"}:
+            blocking.append(f"{prefix} retained evidence must not claim Loom owns host lifecycle")
+        payload_fallback = payload.get("fallback_to")
+        if isinstance(payload_fallback, str) and payload_fallback not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+            blocking.append(f"{prefix} retained evidence fallback_to must point back to Loom")
+
+    result = "block" if blocking else "warn" if optional else "pass"
+    if result == "warn" and requirement in {"required"}:
+        result = "block"
+    return {
+        "id": entry_id,
+        "requirement": requirement,
+        "operations": operations,
+        "locator": locator,
+        "result": result,
+        "classification": "truth_pollution" if blocking and isinstance(payload, dict) and find_forbidden_external_orchestrator_fields(payload) else "locator_or_contract",
+        "summary": (
+            "external orchestrator retained evidence is readable and respects Loom truth boundaries."
+            if result == "pass"
+            else "external orchestrator retained evidence has profile-local warnings."
+            if result == "warn"
+            else "external orchestrator retained evidence violates interop conformance boundaries."
+        ),
+        "missing_inputs": blocking if result == "block" else [],
+        "missing_optional": optional,
+        "fallback_to": fallback_to if result == "block" else None,
+        "evidence": {
+            "locator_status": "readable" if isinstance(payload, dict) else "missing_or_invalid",
+            "payload_schema_version": payload.get("schema_version") if isinstance(payload, dict) else None,
+            "payload_operation": payload.get("operation") if isinstance(payload, dict) else None,
+        },
+    }
+
+
+def external_orchestrator_conformance_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "external-orchestrator-interop",
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": external_orchestrator_conformance_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "external orchestrator conformance is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "external orchestrator conformance recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    interop_path = target_root / ".loom" / "companion" / "interop.json"
+    if not interop_path.exists():
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop does not declare external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    try:
+        interop_payload = load_json_file(interop_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update(
+            {
+                "enabled": True,
+                "result": "block",
+                "status": "invalid_declaration",
+                "summary": "repo interop contract is unreadable for external orchestrator conformance.",
+                "missing_inputs": [f"repo interop contract is unreadable: {exc}"],
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": conformance["summary"],
+                "missing_inputs": conformance["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+    external_orchestrators = interop_payload.get("external_orchestrators", []) if isinstance(interop_payload, dict) else []
+    if not isinstance(external_orchestrators, list) or not external_orchestrators:
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop is readable but declares no external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    checks = [
+        external_orchestrator_conformance_check(target_root, entry=entry, index=index)
+        for index, entry in enumerate(external_orchestrators)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "repo-interop.external_orchestrator",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    conformance = empty_external_orchestrator_conformance()
+    conformance.update(
+        {
+            "enabled": True,
+            "result": result,
+            "status": "present",
+            "summary": (
+                "external orchestrator conformance passed without introducing a daemon, scheduler state, or second status surface."
+                if result == "pass"
+                else "external orchestrator conformance produced profile-local warnings."
+                if result == "warn"
+                else "external orchestrator conformance found blocking interop drift."
+            ),
+            "missing_inputs": live_smoke_missing_inputs([message for check in checks for message in check.get("missing_inputs", [])]),
+            "missing_optional": [message for check in checks for message in check.get("missing_optional", [])],
+            "checks": checks,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": conformance["summary"],
+            "missing_inputs": conformance["missing_inputs"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "external-orchestrator-interop", "result": result},
+            "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+            "external_orchestrator": conformance,
+            "command_plan": external_orchestrator_conformance_command_plan(target_root, external_orchestrators=external_orchestrators),
         }
     )
     return payload
@@ -12754,6 +13159,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "external-orchestrator-interop":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "external-orchestrator-interop",
+                    "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+                    "result": "block",
+                    "summary": "external orchestrator conformance requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                    "external_orchestrator": {
+                        **empty_external_orchestrator_conformance(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(external_orchestrator_conformance_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -310,6 +310,8 @@ EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA = "loom-external-orchestrator-conformance-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
     "scheduler_state",
     "attempt_ownership",
@@ -1510,6 +1512,67 @@ def require_hook_profile_payload(
             failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
         if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
             failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
+
+
+def require_external_orchestrator_conformance_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "external-orchestrator-interop":
+        failures.append(Failure(category, f"{context} must report `operation: external-orchestrator-interop`"))
+    if payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within pass/warn/block"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include summary"))
+    if payload.get("fallback_to") not in {None, "live-smoke-config-repair", "live-smoke-retry-or-record-unavailable"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay profile-local"))
+    for field in ("runtime_state", "target", "profile_check", "core_profile", "external_orchestrator"):
+        if not isinstance(payload.get(field), dict):
+            failures.append(Failure(category, f"{context} must include `{field}` object"))
+    if not isinstance(payload.get("command_plan"), list) or not payload.get("command_plan"):
+        failures.append(Failure(category, f"{context} must include command_plan"))
+    if not isinstance(payload.get("reports"), list):
+        failures.append(Failure(category, f"{context} must include reports"))
+    conformance = payload.get("external_orchestrator")
+    if isinstance(conformance, dict):
+        if conformance.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, f"{context}.external_orchestrator must use conformance schema"))
+        if conformance.get("profile_id") != "orchestration-extension/external-orchestrator":
+            failures.append(Failure(category, f"{context}.external_orchestrator profile_id must be external-orchestrator"))
+        if conformance.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.external_orchestrator result must stay stable"))
+        if conformance.get("status") not in {
+            "not_applicable",
+            "present",
+            "runtime-blocked",
+            "target-unavailable",
+            "missing-target",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context}.external_orchestrator status is outside the stable vocabulary"))
+        for field in ("missing_inputs", "missing_optional", "checks"):
+            if not isinstance(conformance.get(field), list):
+                failures.append(Failure(category, f"{context}.external_orchestrator.{field} must be a list"))
+        non_goals = conformance.get("non_goals")
+        if not isinstance(non_goals, dict):
+            failures.append(Failure(category, f"{context}.external_orchestrator must include non_goals"))
+        else:
+            for key in ("daemon", "scheduler_state_machine", "tracker_polling_product", "second_status_surface", "host_lifecycle_ownership"):
+                if non_goals.get(key) is not False:
+                    failures.append(Failure(category, f"{context}.external_orchestrator non_goal `{key}` must remain false"))
+    core_profile = payload.get("core_profile")
+    if isinstance(core_profile, dict) and core_profile.get("result") != "pass":
+        failures.append(Failure(category, f"{context}.core_profile.result must remain pass"))
 
 
 def require_repo_interop_payload(
@@ -9912,6 +9975,177 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
     return failures
 
 
+def check_external_orchestrator_conformance_contract(root: Path) -> list[Failure]:
+    category = "external-orchestrator-conformance"
+    failures: list[Failure] = []
+    required_docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/external-orchestrator",
+            "loom-external-orchestrator-conformance/v1",
+            "fake external orchestrator happy/drift fixtures",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "external-orchestrator-interop",
+            "loom-external-orchestrator-conformance/v1",
+            "does not execute",
+        ],
+        "docs/evidence/external-orchestrator-release-threshold.md": [
+            "v0.12.0",
+            "loom-external-orchestrator-conformance/v1",
+            "no daemon",
+            "fake external orchestrator fixtures are sufficient",
+        ],
+    }
+    for relative, anchors in required_docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure(category, f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure(category, f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-conformance-fixtures.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"external orchestrator conformance fixtures are unreadable: {exc}"))
+        return failures
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA:
+        failures.append(Failure(category, f"conformance fixture schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA}`"))
+    fixtures = fixture_payload.get("fixtures")
+    required_names = {
+        "fake-external-orchestrator-happy",
+        "fake-external-orchestrator-truth-drift",
+        "fake-external-orchestrator-private-fallback",
+        "fake-external-orchestrator-lifecycle-drift",
+    }
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator conformance fixtures must include fixtures"))
+        return failures
+    seen_names: set[str] = set()
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if isinstance(name, str):
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+            continue
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"{name or index} payload must be an object"))
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/block"))
+        operations = entry.get("operations")
+        if not isinstance(operations, list) or not operations:
+            failures.append(Failure(category, f"{name or index} entry.operations must be non-empty"))
+        elif any(operation not in {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"} for operation in operations):
+            failures.append(Failure(category, f"{name or index} declares unsupported operation"))
+        if name == "fake-external-orchestrator-happy" and expect.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, "happy fixture must expect conformance schema v1"))
+        if name == "fake-external-orchestrator-truth-drift" and payload is not None:
+            forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+            if not forbidden or expect.get("failure") != "truth_pollution":
+                failures.append(Failure(category, "truth drift fixture must prove forbidden authored/scheduler fields block"))
+        if name == "fake-external-orchestrator-private-fallback":
+            if entry.get("fallback_to") != "scheduler_retry_queue" or expect.get("fallback_to") != "current_checkpoint":
+                failures.append(Failure(category, "private fallback fixture must block back to current_checkpoint"))
+        if name == "fake-external-orchestrator-lifecycle-drift" and payload is not None:
+            if payload.get("host_lifecycle_ownership") != "loom" or payload.get("daemon") is not True:
+                failures.append(Failure(category, "lifecycle drift fixture must prove no-daemon/no-host-lifecycle boundary"))
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator conformance fixtures missing required cases: " + ", ".join(missing)))
+
+    example_target = root / "examples/new-project"
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(example_target)],
+    )
+    if error:
+        failures.append(Failure(category, f"`external-orchestrator-interop` not_applicable sample failed: {error}"))
+    else:
+        require_external_orchestrator_conformance_payload(
+            failures,
+            category=category,
+            context="not-applicable external orchestrator conformance",
+            payload=absent_payload,
+        )
+        external_profile = absent_payload.get("external_orchestrator") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must pass"))
+        elif not isinstance(external_profile, dict) or external_profile.get("status") != "not_applicable":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must expose not_applicable status"))
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    with tempfile.TemporaryDirectory(prefix="loom-external-orchestrator-conformance-") as tmp:
+        base = Path(tmp)
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        happy_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-happy"), None)
+        if isinstance(happy_fixture, dict):
+            interop = load_json_file(present_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [happy_fixture["entry"]]
+                write_json_local(present_target / ".loom/companion/interop.json", interop)
+                write_json_local(present_target / happy_fixture["entry"]["locator"], happy_fixture["payload"])
+            present_payload, present_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(present_target)],
+            )
+            if present_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` happy sample failed: {present_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="happy external orchestrator conformance",
+                    payload=present_payload,
+                )
+                if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                    failures.append(Failure(category, "happy external orchestrator conformance must pass"))
+
+        drift_target = base / "drift"
+        shutil.copytree(example_target, drift_target)
+        drift_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-truth-drift"), None)
+        if isinstance(drift_fixture, dict):
+            interop = load_json_file(drift_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [drift_fixture["entry"]]
+                write_json_local(drift_target / ".loom/companion/interop.json", interop)
+                write_json_local(drift_target / drift_fixture["entry"]["locator"], drift_fixture["payload"])
+            drift_payload, drift_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(drift_target)],
+            )
+            if drift_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` drift sample failed: {drift_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="drift external orchestrator conformance",
+                    payload=drift_payload,
+                )
+                core_profile = drift_payload.get("core_profile") if isinstance(drift_payload, dict) else None
+                if not isinstance(drift_payload, dict) or drift_payload.get("result") != "block":
+                    failures.append(Failure(category, "truth drift external orchestrator conformance must block"))
+                elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                    failures.append(Failure(category, "external orchestrator conformance drift must not rewrite core profile"))
+
+    return failures
+
+
 def check_external_runtime_devendor_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     required_anchors = {
@@ -14373,6 +14607,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
     failures.extend(check_external_orchestrator_interop_fixture_contract(root))
+    failures.extend(check_external_orchestrator_conformance_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14401,7 +14636,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 35
+    categories_checked = 36
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    EXTERNAL_ORCHESTRATOR_OPERATIONS,
     empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
@@ -122,6 +123,7 @@ DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -162,6 +164,41 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "current_lane",
     "recovery_boundary",
     "closing_condition",
+}
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+    "daemon",
+    "scheduler_queue",
+    "branch_ownership",
+    "pr_ownership",
+    "worktree_ownership",
+    "worker_lifecycle",
+}
+EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS = {
+    "work_item",
+    "admission",
+    "binding_repair",
+    "current_checkpoint",
+    "spec_gate",
+    "build_gate",
+    "review_gate",
+    "merge_gate",
+    "build",
+    "review",
+    "merge_ready",
+    "closeout",
 }
 HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
@@ -553,7 +590,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
+    live_smoke.add_argument(
+        "operation",
+        choices=(
+            "run",
+            "replay",
+            "host-adapter-drift",
+            "dynamic-tool-availability",
+            "hook-envelope",
+            "hooks-extension",
+            "external-orchestrator-interop",
+        ),
+    )
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -899,6 +947,41 @@ def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
     ]
 
 
+def external_orchestrator_conformance_command_plan(
+    target_root: Path,
+    external_orchestrators: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading external orchestrator declarations.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'} external_orchestrators",
+            "description": "Read external orchestrator locator declarations without starting a scheduler or daemon.",
+        },
+        {
+            "id": "status-consumer-view",
+            "command": f"{shlex.quote(sys.executable)} tools/loom_status.py --target {shlex.quote(str(target_root))} --item INIT-0001",
+            "description": "Confirm status/gate consumption reuses Loom status control plane v2 and the existing gate chain.",
+        },
+    ]
+    for index, entry in enumerate(external_orchestrators or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"external-orchestrator-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read external orchestrator retained evidence without accepting scheduler-owned status or gate truth.",
+            }
+        )
+    return plan
+
+
 def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
     found: list[str] = []
     if isinstance(value, dict):
@@ -911,6 +994,21 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     elif isinstance(value, list):
         for index, nested in enumerate(value):
             found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def find_forbidden_external_orchestrator_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=f"{prefix}[{index}]"))
     return found
 
 
@@ -1875,6 +1973,313 @@ def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
             "profile_check": {"id": "hooks-extension", "result": result},
             "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
             "hooks_extension": hook_profile,
+        }
+    )
+    return payload
+
+
+def empty_external_orchestrator_conformance() -> dict[str, Any]:
+    return {
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "profile_id": "orchestration-extension/external-orchestrator",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "external orchestrator interop profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+        "non_goals": {
+            "daemon": False,
+            "scheduler_state_machine": False,
+            "tracker_polling_product": False,
+            "second_status_surface": False,
+            "host_lifecycle_ownership": False,
+        },
+    }
+
+
+def external_orchestrator_conformance_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+) -> dict[str, Any]:
+    prefix = f"external_orchestrators[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "requirement": "required",
+            "operations": [],
+            "locator": "",
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            "evidence": {"locator_status": "invalid-declaration"},
+        }
+
+    entry_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"external-orchestrator-{index}"
+    requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+    locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "admission"
+    operations = entry.get("operations") if isinstance(entry.get("operations"), list) else []
+    blocking: list[str] = []
+    optional: list[str] = []
+
+    if requirement not in {"required", "optional", "advisory"}:
+        blocking.append(f"{prefix}.requirement must be required, optional, or advisory")
+        requirement = "required"
+    if not operations:
+        blocking.append(f"{prefix}.operations must be a non-empty list")
+    unsupported = [str(operation) for operation in operations if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS]
+    if unsupported:
+        blocking.append(f"{prefix}.operations contains unsupported operations: {', '.join(unsupported)}")
+    if isinstance(fallback_to, str) and fallback_to not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+        blocking.append(f"{prefix}.fallback_to must point back to a Loom checkpoint or gate repair surface")
+
+    locator_path, locator_errors = resolve_repo_relative_path(target_root, locator, label=f"{prefix} locator")
+    if locator_errors:
+        blocking.extend(locator_errors)
+    elif locator_path is None or not locator_path.exists() or locator_path.is_dir():
+        message = f"{prefix} locator points to missing or unreadable retained evidence `{locator}`"
+        if requirement in {"optional", "advisory"}:
+            optional.append(message)
+        else:
+            blocking.append(message)
+
+    payload: object = None
+    if locator_path is not None and locator_path.exists() and locator_path.is_file():
+        try:
+            payload = load_json_file(locator_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            blocking.append(f"{prefix} retained evidence is not readable JSON: {exc}")
+    if payload is not None and not isinstance(payload, dict):
+        blocking.append(f"{prefix} retained evidence must be a JSON object")
+    if isinstance(payload, dict):
+        forbidden = find_forbidden_external_orchestrator_fields(payload)
+        if forbidden:
+            blocking.append(f"{prefix} retained evidence contains forbidden authored/scheduler fields: {', '.join(forbidden)}")
+        payload_operation = payload.get("operation")
+        if isinstance(payload_operation, str) and operations and payload_operation not in operations:
+            blocking.append(f"{prefix} retained evidence operation is not declared by the locator")
+        if payload.get("operation") in {"status_read", "gate_read"}:
+            if payload.get("source_layer") != "derived_surface":
+                blocking.append(f"{prefix} status/gate reads must consume the derived status surface")
+            if payload.get("consumed_as") != "summary":
+                blocking.append(f"{prefix} status/gate reads must be consumed as summary")
+        if payload.get("host_lifecycle_ownership") not in {None, "host", "external"}:
+            blocking.append(f"{prefix} retained evidence must not claim Loom owns host lifecycle")
+        payload_fallback = payload.get("fallback_to")
+        if isinstance(payload_fallback, str) and payload_fallback not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+            blocking.append(f"{prefix} retained evidence fallback_to must point back to Loom")
+
+    result = "block" if blocking else "warn" if optional else "pass"
+    if result == "warn" and requirement in {"required"}:
+        result = "block"
+    return {
+        "id": entry_id,
+        "requirement": requirement,
+        "operations": operations,
+        "locator": locator,
+        "result": result,
+        "classification": "truth_pollution" if blocking and isinstance(payload, dict) and find_forbidden_external_orchestrator_fields(payload) else "locator_or_contract",
+        "summary": (
+            "external orchestrator retained evidence is readable and respects Loom truth boundaries."
+            if result == "pass"
+            else "external orchestrator retained evidence has profile-local warnings."
+            if result == "warn"
+            else "external orchestrator retained evidence violates interop conformance boundaries."
+        ),
+        "missing_inputs": blocking if result == "block" else [],
+        "missing_optional": optional,
+        "fallback_to": fallback_to if result == "block" else None,
+        "evidence": {
+            "locator_status": "readable" if isinstance(payload, dict) else "missing_or_invalid",
+            "payload_schema_version": payload.get("schema_version") if isinstance(payload, dict) else None,
+            "payload_operation": payload.get("operation") if isinstance(payload, dict) else None,
+        },
+    }
+
+
+def external_orchestrator_conformance_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "external-orchestrator-interop",
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": external_orchestrator_conformance_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "external orchestrator conformance is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "external orchestrator conformance recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    interop_path = target_root / ".loom" / "companion" / "interop.json"
+    if not interop_path.exists():
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop does not declare external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    try:
+        interop_payload = load_json_file(interop_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update(
+            {
+                "enabled": True,
+                "result": "block",
+                "status": "invalid_declaration",
+                "summary": "repo interop contract is unreadable for external orchestrator conformance.",
+                "missing_inputs": [f"repo interop contract is unreadable: {exc}"],
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": conformance["summary"],
+                "missing_inputs": conformance["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+    external_orchestrators = interop_payload.get("external_orchestrators", []) if isinstance(interop_payload, dict) else []
+    if not isinstance(external_orchestrators, list) or not external_orchestrators:
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop is readable but declares no external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    checks = [
+        external_orchestrator_conformance_check(target_root, entry=entry, index=index)
+        for index, entry in enumerate(external_orchestrators)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "repo-interop.external_orchestrator",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    conformance = empty_external_orchestrator_conformance()
+    conformance.update(
+        {
+            "enabled": True,
+            "result": result,
+            "status": "present",
+            "summary": (
+                "external orchestrator conformance passed without introducing a daemon, scheduler state, or second status surface."
+                if result == "pass"
+                else "external orchestrator conformance produced profile-local warnings."
+                if result == "warn"
+                else "external orchestrator conformance found blocking interop drift."
+            ),
+            "missing_inputs": live_smoke_missing_inputs([message for check in checks for message in check.get("missing_inputs", [])]),
+            "missing_optional": [message for check in checks for message in check.get("missing_optional", [])],
+            "checks": checks,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": conformance["summary"],
+            "missing_inputs": conformance["missing_inputs"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "external-orchestrator-interop", "result": result},
+            "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+            "external_orchestrator": conformance,
+            "command_plan": external_orchestrator_conformance_command_plan(target_root, external_orchestrators=external_orchestrators),
         }
     )
     return payload
@@ -12754,6 +13159,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "external-orchestrator-interop":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "external-orchestrator-interop",
+                    "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+                    "result": "block",
+                    "summary": "external orchestrator conformance requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                    "external_orchestrator": {
+                        **empty_external_orchestrator_conformance(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(external_orchestrator_conformance_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
@@ -310,6 +310,8 @@ EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA = "loom-external-orchestrator-conformance-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
     "scheduler_state",
     "attempt_ownership",
@@ -1510,6 +1512,67 @@ def require_hook_profile_payload(
             failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
         if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
             failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
+
+
+def require_external_orchestrator_conformance_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "external-orchestrator-interop":
+        failures.append(Failure(category, f"{context} must report `operation: external-orchestrator-interop`"))
+    if payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within pass/warn/block"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include summary"))
+    if payload.get("fallback_to") not in {None, "live-smoke-config-repair", "live-smoke-retry-or-record-unavailable"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay profile-local"))
+    for field in ("runtime_state", "target", "profile_check", "core_profile", "external_orchestrator"):
+        if not isinstance(payload.get(field), dict):
+            failures.append(Failure(category, f"{context} must include `{field}` object"))
+    if not isinstance(payload.get("command_plan"), list) or not payload.get("command_plan"):
+        failures.append(Failure(category, f"{context} must include command_plan"))
+    if not isinstance(payload.get("reports"), list):
+        failures.append(Failure(category, f"{context} must include reports"))
+    conformance = payload.get("external_orchestrator")
+    if isinstance(conformance, dict):
+        if conformance.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, f"{context}.external_orchestrator must use conformance schema"))
+        if conformance.get("profile_id") != "orchestration-extension/external-orchestrator":
+            failures.append(Failure(category, f"{context}.external_orchestrator profile_id must be external-orchestrator"))
+        if conformance.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.external_orchestrator result must stay stable"))
+        if conformance.get("status") not in {
+            "not_applicable",
+            "present",
+            "runtime-blocked",
+            "target-unavailable",
+            "missing-target",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context}.external_orchestrator status is outside the stable vocabulary"))
+        for field in ("missing_inputs", "missing_optional", "checks"):
+            if not isinstance(conformance.get(field), list):
+                failures.append(Failure(category, f"{context}.external_orchestrator.{field} must be a list"))
+        non_goals = conformance.get("non_goals")
+        if not isinstance(non_goals, dict):
+            failures.append(Failure(category, f"{context}.external_orchestrator must include non_goals"))
+        else:
+            for key in ("daemon", "scheduler_state_machine", "tracker_polling_product", "second_status_surface", "host_lifecycle_ownership"):
+                if non_goals.get(key) is not False:
+                    failures.append(Failure(category, f"{context}.external_orchestrator non_goal `{key}` must remain false"))
+    core_profile = payload.get("core_profile")
+    if isinstance(core_profile, dict) and core_profile.get("result") != "pass":
+        failures.append(Failure(category, f"{context}.core_profile.result must remain pass"))
 
 
 def require_repo_interop_payload(
@@ -9912,6 +9975,177 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
     return failures
 
 
+def check_external_orchestrator_conformance_contract(root: Path) -> list[Failure]:
+    category = "external-orchestrator-conformance"
+    failures: list[Failure] = []
+    required_docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/external-orchestrator",
+            "loom-external-orchestrator-conformance/v1",
+            "fake external orchestrator happy/drift fixtures",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "external-orchestrator-interop",
+            "loom-external-orchestrator-conformance/v1",
+            "does not execute",
+        ],
+        "docs/evidence/external-orchestrator-release-threshold.md": [
+            "v0.12.0",
+            "loom-external-orchestrator-conformance/v1",
+            "no daemon",
+            "fake external orchestrator fixtures are sufficient",
+        ],
+    }
+    for relative, anchors in required_docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure(category, f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure(category, f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-conformance-fixtures.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"external orchestrator conformance fixtures are unreadable: {exc}"))
+        return failures
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA:
+        failures.append(Failure(category, f"conformance fixture schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA}`"))
+    fixtures = fixture_payload.get("fixtures")
+    required_names = {
+        "fake-external-orchestrator-happy",
+        "fake-external-orchestrator-truth-drift",
+        "fake-external-orchestrator-private-fallback",
+        "fake-external-orchestrator-lifecycle-drift",
+    }
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator conformance fixtures must include fixtures"))
+        return failures
+    seen_names: set[str] = set()
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if isinstance(name, str):
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+            continue
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"{name or index} payload must be an object"))
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/block"))
+        operations = entry.get("operations")
+        if not isinstance(operations, list) or not operations:
+            failures.append(Failure(category, f"{name or index} entry.operations must be non-empty"))
+        elif any(operation not in {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"} for operation in operations):
+            failures.append(Failure(category, f"{name or index} declares unsupported operation"))
+        if name == "fake-external-orchestrator-happy" and expect.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, "happy fixture must expect conformance schema v1"))
+        if name == "fake-external-orchestrator-truth-drift" and payload is not None:
+            forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+            if not forbidden or expect.get("failure") != "truth_pollution":
+                failures.append(Failure(category, "truth drift fixture must prove forbidden authored/scheduler fields block"))
+        if name == "fake-external-orchestrator-private-fallback":
+            if entry.get("fallback_to") != "scheduler_retry_queue" or expect.get("fallback_to") != "current_checkpoint":
+                failures.append(Failure(category, "private fallback fixture must block back to current_checkpoint"))
+        if name == "fake-external-orchestrator-lifecycle-drift" and payload is not None:
+            if payload.get("host_lifecycle_ownership") != "loom" or payload.get("daemon") is not True:
+                failures.append(Failure(category, "lifecycle drift fixture must prove no-daemon/no-host-lifecycle boundary"))
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator conformance fixtures missing required cases: " + ", ".join(missing)))
+
+    example_target = root / "examples/new-project"
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(example_target)],
+    )
+    if error:
+        failures.append(Failure(category, f"`external-orchestrator-interop` not_applicable sample failed: {error}"))
+    else:
+        require_external_orchestrator_conformance_payload(
+            failures,
+            category=category,
+            context="not-applicable external orchestrator conformance",
+            payload=absent_payload,
+        )
+        external_profile = absent_payload.get("external_orchestrator") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must pass"))
+        elif not isinstance(external_profile, dict) or external_profile.get("status") != "not_applicable":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must expose not_applicable status"))
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    with tempfile.TemporaryDirectory(prefix="loom-external-orchestrator-conformance-") as tmp:
+        base = Path(tmp)
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        happy_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-happy"), None)
+        if isinstance(happy_fixture, dict):
+            interop = load_json_file(present_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [happy_fixture["entry"]]
+                write_json_local(present_target / ".loom/companion/interop.json", interop)
+                write_json_local(present_target / happy_fixture["entry"]["locator"], happy_fixture["payload"])
+            present_payload, present_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(present_target)],
+            )
+            if present_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` happy sample failed: {present_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="happy external orchestrator conformance",
+                    payload=present_payload,
+                )
+                if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                    failures.append(Failure(category, "happy external orchestrator conformance must pass"))
+
+        drift_target = base / "drift"
+        shutil.copytree(example_target, drift_target)
+        drift_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-truth-drift"), None)
+        if isinstance(drift_fixture, dict):
+            interop = load_json_file(drift_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [drift_fixture["entry"]]
+                write_json_local(drift_target / ".loom/companion/interop.json", interop)
+                write_json_local(drift_target / drift_fixture["entry"]["locator"], drift_fixture["payload"])
+            drift_payload, drift_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(drift_target)],
+            )
+            if drift_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` drift sample failed: {drift_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="drift external orchestrator conformance",
+                    payload=drift_payload,
+                )
+                core_profile = drift_payload.get("core_profile") if isinstance(drift_payload, dict) else None
+                if not isinstance(drift_payload, dict) or drift_payload.get("result") != "block":
+                    failures.append(Failure(category, "truth drift external orchestrator conformance must block"))
+                elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                    failures.append(Failure(category, "external orchestrator conformance drift must not rewrite core profile"))
+
+    return failures
+
+
 def check_external_runtime_devendor_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     required_anchors = {
@@ -14373,6 +14607,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
     failures.extend(check_external_orchestrator_interop_fixture_contract(root))
+    failures.extend(check_external_orchestrator_conformance_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14401,7 +14636,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 35
+    categories_checked = 36
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    EXTERNAL_ORCHESTRATOR_OPERATIONS,
     empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
@@ -122,6 +123,7 @@ DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -162,6 +164,41 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "current_lane",
     "recovery_boundary",
     "closing_condition",
+}
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+    "daemon",
+    "scheduler_queue",
+    "branch_ownership",
+    "pr_ownership",
+    "worktree_ownership",
+    "worker_lifecycle",
+}
+EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS = {
+    "work_item",
+    "admission",
+    "binding_repair",
+    "current_checkpoint",
+    "spec_gate",
+    "build_gate",
+    "review_gate",
+    "merge_gate",
+    "build",
+    "review",
+    "merge_ready",
+    "closeout",
 }
 HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
@@ -553,7 +590,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
+    live_smoke.add_argument(
+        "operation",
+        choices=(
+            "run",
+            "replay",
+            "host-adapter-drift",
+            "dynamic-tool-availability",
+            "hook-envelope",
+            "hooks-extension",
+            "external-orchestrator-interop",
+        ),
+    )
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -899,6 +947,41 @@ def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
     ]
 
 
+def external_orchestrator_conformance_command_plan(
+    target_root: Path,
+    external_orchestrators: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading external orchestrator declarations.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'} external_orchestrators",
+            "description": "Read external orchestrator locator declarations without starting a scheduler or daemon.",
+        },
+        {
+            "id": "status-consumer-view",
+            "command": f"{shlex.quote(sys.executable)} tools/loom_status.py --target {shlex.quote(str(target_root))} --item INIT-0001",
+            "description": "Confirm status/gate consumption reuses Loom status control plane v2 and the existing gate chain.",
+        },
+    ]
+    for index, entry in enumerate(external_orchestrators or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"external-orchestrator-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read external orchestrator retained evidence without accepting scheduler-owned status or gate truth.",
+            }
+        )
+    return plan
+
+
 def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
     found: list[str] = []
     if isinstance(value, dict):
@@ -911,6 +994,21 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     elif isinstance(value, list):
         for index, nested in enumerate(value):
             found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def find_forbidden_external_orchestrator_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=f"{prefix}[{index}]"))
     return found
 
 
@@ -1875,6 +1973,313 @@ def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
             "profile_check": {"id": "hooks-extension", "result": result},
             "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
             "hooks_extension": hook_profile,
+        }
+    )
+    return payload
+
+
+def empty_external_orchestrator_conformance() -> dict[str, Any]:
+    return {
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "profile_id": "orchestration-extension/external-orchestrator",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "external orchestrator interop profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+        "non_goals": {
+            "daemon": False,
+            "scheduler_state_machine": False,
+            "tracker_polling_product": False,
+            "second_status_surface": False,
+            "host_lifecycle_ownership": False,
+        },
+    }
+
+
+def external_orchestrator_conformance_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+) -> dict[str, Any]:
+    prefix = f"external_orchestrators[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "requirement": "required",
+            "operations": [],
+            "locator": "",
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            "evidence": {"locator_status": "invalid-declaration"},
+        }
+
+    entry_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"external-orchestrator-{index}"
+    requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+    locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "admission"
+    operations = entry.get("operations") if isinstance(entry.get("operations"), list) else []
+    blocking: list[str] = []
+    optional: list[str] = []
+
+    if requirement not in {"required", "optional", "advisory"}:
+        blocking.append(f"{prefix}.requirement must be required, optional, or advisory")
+        requirement = "required"
+    if not operations:
+        blocking.append(f"{prefix}.operations must be a non-empty list")
+    unsupported = [str(operation) for operation in operations if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS]
+    if unsupported:
+        blocking.append(f"{prefix}.operations contains unsupported operations: {', '.join(unsupported)}")
+    if isinstance(fallback_to, str) and fallback_to not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+        blocking.append(f"{prefix}.fallback_to must point back to a Loom checkpoint or gate repair surface")
+
+    locator_path, locator_errors = resolve_repo_relative_path(target_root, locator, label=f"{prefix} locator")
+    if locator_errors:
+        blocking.extend(locator_errors)
+    elif locator_path is None or not locator_path.exists() or locator_path.is_dir():
+        message = f"{prefix} locator points to missing or unreadable retained evidence `{locator}`"
+        if requirement in {"optional", "advisory"}:
+            optional.append(message)
+        else:
+            blocking.append(message)
+
+    payload: object = None
+    if locator_path is not None and locator_path.exists() and locator_path.is_file():
+        try:
+            payload = load_json_file(locator_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            blocking.append(f"{prefix} retained evidence is not readable JSON: {exc}")
+    if payload is not None and not isinstance(payload, dict):
+        blocking.append(f"{prefix} retained evidence must be a JSON object")
+    if isinstance(payload, dict):
+        forbidden = find_forbidden_external_orchestrator_fields(payload)
+        if forbidden:
+            blocking.append(f"{prefix} retained evidence contains forbidden authored/scheduler fields: {', '.join(forbidden)}")
+        payload_operation = payload.get("operation")
+        if isinstance(payload_operation, str) and operations and payload_operation not in operations:
+            blocking.append(f"{prefix} retained evidence operation is not declared by the locator")
+        if payload.get("operation") in {"status_read", "gate_read"}:
+            if payload.get("source_layer") != "derived_surface":
+                blocking.append(f"{prefix} status/gate reads must consume the derived status surface")
+            if payload.get("consumed_as") != "summary":
+                blocking.append(f"{prefix} status/gate reads must be consumed as summary")
+        if payload.get("host_lifecycle_ownership") not in {None, "host", "external"}:
+            blocking.append(f"{prefix} retained evidence must not claim Loom owns host lifecycle")
+        payload_fallback = payload.get("fallback_to")
+        if isinstance(payload_fallback, str) and payload_fallback not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+            blocking.append(f"{prefix} retained evidence fallback_to must point back to Loom")
+
+    result = "block" if blocking else "warn" if optional else "pass"
+    if result == "warn" and requirement in {"required"}:
+        result = "block"
+    return {
+        "id": entry_id,
+        "requirement": requirement,
+        "operations": operations,
+        "locator": locator,
+        "result": result,
+        "classification": "truth_pollution" if blocking and isinstance(payload, dict) and find_forbidden_external_orchestrator_fields(payload) else "locator_or_contract",
+        "summary": (
+            "external orchestrator retained evidence is readable and respects Loom truth boundaries."
+            if result == "pass"
+            else "external orchestrator retained evidence has profile-local warnings."
+            if result == "warn"
+            else "external orchestrator retained evidence violates interop conformance boundaries."
+        ),
+        "missing_inputs": blocking if result == "block" else [],
+        "missing_optional": optional,
+        "fallback_to": fallback_to if result == "block" else None,
+        "evidence": {
+            "locator_status": "readable" if isinstance(payload, dict) else "missing_or_invalid",
+            "payload_schema_version": payload.get("schema_version") if isinstance(payload, dict) else None,
+            "payload_operation": payload.get("operation") if isinstance(payload, dict) else None,
+        },
+    }
+
+
+def external_orchestrator_conformance_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "external-orchestrator-interop",
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": external_orchestrator_conformance_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "external orchestrator conformance is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "external orchestrator conformance recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    interop_path = target_root / ".loom" / "companion" / "interop.json"
+    if not interop_path.exists():
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop does not declare external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    try:
+        interop_payload = load_json_file(interop_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update(
+            {
+                "enabled": True,
+                "result": "block",
+                "status": "invalid_declaration",
+                "summary": "repo interop contract is unreadable for external orchestrator conformance.",
+                "missing_inputs": [f"repo interop contract is unreadable: {exc}"],
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": conformance["summary"],
+                "missing_inputs": conformance["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+    external_orchestrators = interop_payload.get("external_orchestrators", []) if isinstance(interop_payload, dict) else []
+    if not isinstance(external_orchestrators, list) or not external_orchestrators:
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop is readable but declares no external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    checks = [
+        external_orchestrator_conformance_check(target_root, entry=entry, index=index)
+        for index, entry in enumerate(external_orchestrators)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "repo-interop.external_orchestrator",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    conformance = empty_external_orchestrator_conformance()
+    conformance.update(
+        {
+            "enabled": True,
+            "result": result,
+            "status": "present",
+            "summary": (
+                "external orchestrator conformance passed without introducing a daemon, scheduler state, or second status surface."
+                if result == "pass"
+                else "external orchestrator conformance produced profile-local warnings."
+                if result == "warn"
+                else "external orchestrator conformance found blocking interop drift."
+            ),
+            "missing_inputs": live_smoke_missing_inputs([message for check in checks for message in check.get("missing_inputs", [])]),
+            "missing_optional": [message for check in checks for message in check.get("missing_optional", [])],
+            "checks": checks,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": conformance["summary"],
+            "missing_inputs": conformance["missing_inputs"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "external-orchestrator-interop", "result": result},
+            "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+            "external_orchestrator": conformance,
+            "command_plan": external_orchestrator_conformance_command_plan(target_root, external_orchestrators=external_orchestrators),
         }
     )
     return payload
@@ -12754,6 +13159,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "external-orchestrator-interop":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "external-orchestrator-interop",
+                    "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+                    "result": "block",
+                    "summary": "external orchestrator conformance requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                    "external_orchestrator": {
+                        **empty_external_orchestrator_conformance(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(external_orchestrator_conformance_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -310,6 +310,8 @@ EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA = "loom-external-orchestrator-conformance-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
     "scheduler_state",
     "attempt_ownership",
@@ -1510,6 +1512,67 @@ def require_hook_profile_payload(
             failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
         if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
             failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
+
+
+def require_external_orchestrator_conformance_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "external-orchestrator-interop":
+        failures.append(Failure(category, f"{context} must report `operation: external-orchestrator-interop`"))
+    if payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within pass/warn/block"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include summary"))
+    if payload.get("fallback_to") not in {None, "live-smoke-config-repair", "live-smoke-retry-or-record-unavailable"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay profile-local"))
+    for field in ("runtime_state", "target", "profile_check", "core_profile", "external_orchestrator"):
+        if not isinstance(payload.get(field), dict):
+            failures.append(Failure(category, f"{context} must include `{field}` object"))
+    if not isinstance(payload.get("command_plan"), list) or not payload.get("command_plan"):
+        failures.append(Failure(category, f"{context} must include command_plan"))
+    if not isinstance(payload.get("reports"), list):
+        failures.append(Failure(category, f"{context} must include reports"))
+    conformance = payload.get("external_orchestrator")
+    if isinstance(conformance, dict):
+        if conformance.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, f"{context}.external_orchestrator must use conformance schema"))
+        if conformance.get("profile_id") != "orchestration-extension/external-orchestrator":
+            failures.append(Failure(category, f"{context}.external_orchestrator profile_id must be external-orchestrator"))
+        if conformance.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.external_orchestrator result must stay stable"))
+        if conformance.get("status") not in {
+            "not_applicable",
+            "present",
+            "runtime-blocked",
+            "target-unavailable",
+            "missing-target",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context}.external_orchestrator status is outside the stable vocabulary"))
+        for field in ("missing_inputs", "missing_optional", "checks"):
+            if not isinstance(conformance.get(field), list):
+                failures.append(Failure(category, f"{context}.external_orchestrator.{field} must be a list"))
+        non_goals = conformance.get("non_goals")
+        if not isinstance(non_goals, dict):
+            failures.append(Failure(category, f"{context}.external_orchestrator must include non_goals"))
+        else:
+            for key in ("daemon", "scheduler_state_machine", "tracker_polling_product", "second_status_surface", "host_lifecycle_ownership"):
+                if non_goals.get(key) is not False:
+                    failures.append(Failure(category, f"{context}.external_orchestrator non_goal `{key}` must remain false"))
+    core_profile = payload.get("core_profile")
+    if isinstance(core_profile, dict) and core_profile.get("result") != "pass":
+        failures.append(Failure(category, f"{context}.core_profile.result must remain pass"))
 
 
 def require_repo_interop_payload(
@@ -9912,6 +9975,177 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
     return failures
 
 
+def check_external_orchestrator_conformance_contract(root: Path) -> list[Failure]:
+    category = "external-orchestrator-conformance"
+    failures: list[Failure] = []
+    required_docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/external-orchestrator",
+            "loom-external-orchestrator-conformance/v1",
+            "fake external orchestrator happy/drift fixtures",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "external-orchestrator-interop",
+            "loom-external-orchestrator-conformance/v1",
+            "does not execute",
+        ],
+        "docs/evidence/external-orchestrator-release-threshold.md": [
+            "v0.12.0",
+            "loom-external-orchestrator-conformance/v1",
+            "no daemon",
+            "fake external orchestrator fixtures are sufficient",
+        ],
+    }
+    for relative, anchors in required_docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure(category, f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure(category, f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-conformance-fixtures.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"external orchestrator conformance fixtures are unreadable: {exc}"))
+        return failures
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA:
+        failures.append(Failure(category, f"conformance fixture schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA}`"))
+    fixtures = fixture_payload.get("fixtures")
+    required_names = {
+        "fake-external-orchestrator-happy",
+        "fake-external-orchestrator-truth-drift",
+        "fake-external-orchestrator-private-fallback",
+        "fake-external-orchestrator-lifecycle-drift",
+    }
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator conformance fixtures must include fixtures"))
+        return failures
+    seen_names: set[str] = set()
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if isinstance(name, str):
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+            continue
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"{name or index} payload must be an object"))
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/block"))
+        operations = entry.get("operations")
+        if not isinstance(operations, list) or not operations:
+            failures.append(Failure(category, f"{name or index} entry.operations must be non-empty"))
+        elif any(operation not in {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"} for operation in operations):
+            failures.append(Failure(category, f"{name or index} declares unsupported operation"))
+        if name == "fake-external-orchestrator-happy" and expect.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, "happy fixture must expect conformance schema v1"))
+        if name == "fake-external-orchestrator-truth-drift" and payload is not None:
+            forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+            if not forbidden or expect.get("failure") != "truth_pollution":
+                failures.append(Failure(category, "truth drift fixture must prove forbidden authored/scheduler fields block"))
+        if name == "fake-external-orchestrator-private-fallback":
+            if entry.get("fallback_to") != "scheduler_retry_queue" or expect.get("fallback_to") != "current_checkpoint":
+                failures.append(Failure(category, "private fallback fixture must block back to current_checkpoint"))
+        if name == "fake-external-orchestrator-lifecycle-drift" and payload is not None:
+            if payload.get("host_lifecycle_ownership") != "loom" or payload.get("daemon") is not True:
+                failures.append(Failure(category, "lifecycle drift fixture must prove no-daemon/no-host-lifecycle boundary"))
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator conformance fixtures missing required cases: " + ", ".join(missing)))
+
+    example_target = root / "examples/new-project"
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(example_target)],
+    )
+    if error:
+        failures.append(Failure(category, f"`external-orchestrator-interop` not_applicable sample failed: {error}"))
+    else:
+        require_external_orchestrator_conformance_payload(
+            failures,
+            category=category,
+            context="not-applicable external orchestrator conformance",
+            payload=absent_payload,
+        )
+        external_profile = absent_payload.get("external_orchestrator") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must pass"))
+        elif not isinstance(external_profile, dict) or external_profile.get("status") != "not_applicable":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must expose not_applicable status"))
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    with tempfile.TemporaryDirectory(prefix="loom-external-orchestrator-conformance-") as tmp:
+        base = Path(tmp)
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        happy_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-happy"), None)
+        if isinstance(happy_fixture, dict):
+            interop = load_json_file(present_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [happy_fixture["entry"]]
+                write_json_local(present_target / ".loom/companion/interop.json", interop)
+                write_json_local(present_target / happy_fixture["entry"]["locator"], happy_fixture["payload"])
+            present_payload, present_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(present_target)],
+            )
+            if present_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` happy sample failed: {present_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="happy external orchestrator conformance",
+                    payload=present_payload,
+                )
+                if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                    failures.append(Failure(category, "happy external orchestrator conformance must pass"))
+
+        drift_target = base / "drift"
+        shutil.copytree(example_target, drift_target)
+        drift_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-truth-drift"), None)
+        if isinstance(drift_fixture, dict):
+            interop = load_json_file(drift_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [drift_fixture["entry"]]
+                write_json_local(drift_target / ".loom/companion/interop.json", interop)
+                write_json_local(drift_target / drift_fixture["entry"]["locator"], drift_fixture["payload"])
+            drift_payload, drift_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(drift_target)],
+            )
+            if drift_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` drift sample failed: {drift_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="drift external orchestrator conformance",
+                    payload=drift_payload,
+                )
+                core_profile = drift_payload.get("core_profile") if isinstance(drift_payload, dict) else None
+                if not isinstance(drift_payload, dict) or drift_payload.get("result") != "block":
+                    failures.append(Failure(category, "truth drift external orchestrator conformance must block"))
+                elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                    failures.append(Failure(category, "external orchestrator conformance drift must not rewrite core profile"))
+
+    return failures
+
+
 def check_external_runtime_devendor_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     required_anchors = {
@@ -14373,6 +14607,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
     failures.extend(check_external_orchestrator_interop_fixture_contract(root))
+    failures.extend(check_external_orchestrator_conformance_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14401,7 +14636,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 35
+    categories_checked = 36
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    EXTERNAL_ORCHESTRATOR_OPERATIONS,
     empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
@@ -122,6 +123,7 @@ DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -162,6 +164,41 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "current_lane",
     "recovery_boundary",
     "closing_condition",
+}
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+    "daemon",
+    "scheduler_queue",
+    "branch_ownership",
+    "pr_ownership",
+    "worktree_ownership",
+    "worker_lifecycle",
+}
+EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS = {
+    "work_item",
+    "admission",
+    "binding_repair",
+    "current_checkpoint",
+    "spec_gate",
+    "build_gate",
+    "review_gate",
+    "merge_gate",
+    "build",
+    "review",
+    "merge_ready",
+    "closeout",
 }
 HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
@@ -553,7 +590,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
+    live_smoke.add_argument(
+        "operation",
+        choices=(
+            "run",
+            "replay",
+            "host-adapter-drift",
+            "dynamic-tool-availability",
+            "hook-envelope",
+            "hooks-extension",
+            "external-orchestrator-interop",
+        ),
+    )
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -899,6 +947,41 @@ def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
     ]
 
 
+def external_orchestrator_conformance_command_plan(
+    target_root: Path,
+    external_orchestrators: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading external orchestrator declarations.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'} external_orchestrators",
+            "description": "Read external orchestrator locator declarations without starting a scheduler or daemon.",
+        },
+        {
+            "id": "status-consumer-view",
+            "command": f"{shlex.quote(sys.executable)} tools/loom_status.py --target {shlex.quote(str(target_root))} --item INIT-0001",
+            "description": "Confirm status/gate consumption reuses Loom status control plane v2 and the existing gate chain.",
+        },
+    ]
+    for index, entry in enumerate(external_orchestrators or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"external-orchestrator-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read external orchestrator retained evidence without accepting scheduler-owned status or gate truth.",
+            }
+        )
+    return plan
+
+
 def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
     found: list[str] = []
     if isinstance(value, dict):
@@ -911,6 +994,21 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     elif isinstance(value, list):
         for index, nested in enumerate(value):
             found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def find_forbidden_external_orchestrator_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=f"{prefix}[{index}]"))
     return found
 
 
@@ -1875,6 +1973,313 @@ def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
             "profile_check": {"id": "hooks-extension", "result": result},
             "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
             "hooks_extension": hook_profile,
+        }
+    )
+    return payload
+
+
+def empty_external_orchestrator_conformance() -> dict[str, Any]:
+    return {
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "profile_id": "orchestration-extension/external-orchestrator",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "external orchestrator interop profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+        "non_goals": {
+            "daemon": False,
+            "scheduler_state_machine": False,
+            "tracker_polling_product": False,
+            "second_status_surface": False,
+            "host_lifecycle_ownership": False,
+        },
+    }
+
+
+def external_orchestrator_conformance_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+) -> dict[str, Any]:
+    prefix = f"external_orchestrators[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "requirement": "required",
+            "operations": [],
+            "locator": "",
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            "evidence": {"locator_status": "invalid-declaration"},
+        }
+
+    entry_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"external-orchestrator-{index}"
+    requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+    locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "admission"
+    operations = entry.get("operations") if isinstance(entry.get("operations"), list) else []
+    blocking: list[str] = []
+    optional: list[str] = []
+
+    if requirement not in {"required", "optional", "advisory"}:
+        blocking.append(f"{prefix}.requirement must be required, optional, or advisory")
+        requirement = "required"
+    if not operations:
+        blocking.append(f"{prefix}.operations must be a non-empty list")
+    unsupported = [str(operation) for operation in operations if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS]
+    if unsupported:
+        blocking.append(f"{prefix}.operations contains unsupported operations: {', '.join(unsupported)}")
+    if isinstance(fallback_to, str) and fallback_to not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+        blocking.append(f"{prefix}.fallback_to must point back to a Loom checkpoint or gate repair surface")
+
+    locator_path, locator_errors = resolve_repo_relative_path(target_root, locator, label=f"{prefix} locator")
+    if locator_errors:
+        blocking.extend(locator_errors)
+    elif locator_path is None or not locator_path.exists() or locator_path.is_dir():
+        message = f"{prefix} locator points to missing or unreadable retained evidence `{locator}`"
+        if requirement in {"optional", "advisory"}:
+            optional.append(message)
+        else:
+            blocking.append(message)
+
+    payload: object = None
+    if locator_path is not None and locator_path.exists() and locator_path.is_file():
+        try:
+            payload = load_json_file(locator_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            blocking.append(f"{prefix} retained evidence is not readable JSON: {exc}")
+    if payload is not None and not isinstance(payload, dict):
+        blocking.append(f"{prefix} retained evidence must be a JSON object")
+    if isinstance(payload, dict):
+        forbidden = find_forbidden_external_orchestrator_fields(payload)
+        if forbidden:
+            blocking.append(f"{prefix} retained evidence contains forbidden authored/scheduler fields: {', '.join(forbidden)}")
+        payload_operation = payload.get("operation")
+        if isinstance(payload_operation, str) and operations and payload_operation not in operations:
+            blocking.append(f"{prefix} retained evidence operation is not declared by the locator")
+        if payload.get("operation") in {"status_read", "gate_read"}:
+            if payload.get("source_layer") != "derived_surface":
+                blocking.append(f"{prefix} status/gate reads must consume the derived status surface")
+            if payload.get("consumed_as") != "summary":
+                blocking.append(f"{prefix} status/gate reads must be consumed as summary")
+        if payload.get("host_lifecycle_ownership") not in {None, "host", "external"}:
+            blocking.append(f"{prefix} retained evidence must not claim Loom owns host lifecycle")
+        payload_fallback = payload.get("fallback_to")
+        if isinstance(payload_fallback, str) and payload_fallback not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+            blocking.append(f"{prefix} retained evidence fallback_to must point back to Loom")
+
+    result = "block" if blocking else "warn" if optional else "pass"
+    if result == "warn" and requirement in {"required"}:
+        result = "block"
+    return {
+        "id": entry_id,
+        "requirement": requirement,
+        "operations": operations,
+        "locator": locator,
+        "result": result,
+        "classification": "truth_pollution" if blocking and isinstance(payload, dict) and find_forbidden_external_orchestrator_fields(payload) else "locator_or_contract",
+        "summary": (
+            "external orchestrator retained evidence is readable and respects Loom truth boundaries."
+            if result == "pass"
+            else "external orchestrator retained evidence has profile-local warnings."
+            if result == "warn"
+            else "external orchestrator retained evidence violates interop conformance boundaries."
+        ),
+        "missing_inputs": blocking if result == "block" else [],
+        "missing_optional": optional,
+        "fallback_to": fallback_to if result == "block" else None,
+        "evidence": {
+            "locator_status": "readable" if isinstance(payload, dict) else "missing_or_invalid",
+            "payload_schema_version": payload.get("schema_version") if isinstance(payload, dict) else None,
+            "payload_operation": payload.get("operation") if isinstance(payload, dict) else None,
+        },
+    }
+
+
+def external_orchestrator_conformance_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "external-orchestrator-interop",
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": external_orchestrator_conformance_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "external orchestrator conformance is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "external orchestrator conformance recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    interop_path = target_root / ".loom" / "companion" / "interop.json"
+    if not interop_path.exists():
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop does not declare external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    try:
+        interop_payload = load_json_file(interop_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update(
+            {
+                "enabled": True,
+                "result": "block",
+                "status": "invalid_declaration",
+                "summary": "repo interop contract is unreadable for external orchestrator conformance.",
+                "missing_inputs": [f"repo interop contract is unreadable: {exc}"],
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": conformance["summary"],
+                "missing_inputs": conformance["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+    external_orchestrators = interop_payload.get("external_orchestrators", []) if isinstance(interop_payload, dict) else []
+    if not isinstance(external_orchestrators, list) or not external_orchestrators:
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop is readable but declares no external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    checks = [
+        external_orchestrator_conformance_check(target_root, entry=entry, index=index)
+        for index, entry in enumerate(external_orchestrators)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "repo-interop.external_orchestrator",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    conformance = empty_external_orchestrator_conformance()
+    conformance.update(
+        {
+            "enabled": True,
+            "result": result,
+            "status": "present",
+            "summary": (
+                "external orchestrator conformance passed without introducing a daemon, scheduler state, or second status surface."
+                if result == "pass"
+                else "external orchestrator conformance produced profile-local warnings."
+                if result == "warn"
+                else "external orchestrator conformance found blocking interop drift."
+            ),
+            "missing_inputs": live_smoke_missing_inputs([message for check in checks for message in check.get("missing_inputs", [])]),
+            "missing_optional": [message for check in checks for message in check.get("missing_optional", [])],
+            "checks": checks,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": conformance["summary"],
+            "missing_inputs": conformance["missing_inputs"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "external-orchestrator-interop", "result": result},
+            "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+            "external_orchestrator": conformance,
+            "command_plan": external_orchestrator_conformance_command_plan(target_root, external_orchestrators=external_orchestrators),
         }
     )
     return payload
@@ -12754,6 +13159,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "external-orchestrator-interop":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "external-orchestrator-interop",
+                    "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+                    "result": "block",
+                    "summary": "external orchestrator conformance requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                    "external_orchestrator": {
+                        **empty_external_orchestrator_conformance(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(external_orchestrator_conformance_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -310,6 +310,8 @@ EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA = "loom-external-orchestrator-conformance-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
     "scheduler_state",
     "attempt_ownership",
@@ -1510,6 +1512,67 @@ def require_hook_profile_payload(
             failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
         if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
             failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
+
+
+def require_external_orchestrator_conformance_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "external-orchestrator-interop":
+        failures.append(Failure(category, f"{context} must report `operation: external-orchestrator-interop`"))
+    if payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within pass/warn/block"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include summary"))
+    if payload.get("fallback_to") not in {None, "live-smoke-config-repair", "live-smoke-retry-or-record-unavailable"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay profile-local"))
+    for field in ("runtime_state", "target", "profile_check", "core_profile", "external_orchestrator"):
+        if not isinstance(payload.get(field), dict):
+            failures.append(Failure(category, f"{context} must include `{field}` object"))
+    if not isinstance(payload.get("command_plan"), list) or not payload.get("command_plan"):
+        failures.append(Failure(category, f"{context} must include command_plan"))
+    if not isinstance(payload.get("reports"), list):
+        failures.append(Failure(category, f"{context} must include reports"))
+    conformance = payload.get("external_orchestrator")
+    if isinstance(conformance, dict):
+        if conformance.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, f"{context}.external_orchestrator must use conformance schema"))
+        if conformance.get("profile_id") != "orchestration-extension/external-orchestrator":
+            failures.append(Failure(category, f"{context}.external_orchestrator profile_id must be external-orchestrator"))
+        if conformance.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.external_orchestrator result must stay stable"))
+        if conformance.get("status") not in {
+            "not_applicable",
+            "present",
+            "runtime-blocked",
+            "target-unavailable",
+            "missing-target",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context}.external_orchestrator status is outside the stable vocabulary"))
+        for field in ("missing_inputs", "missing_optional", "checks"):
+            if not isinstance(conformance.get(field), list):
+                failures.append(Failure(category, f"{context}.external_orchestrator.{field} must be a list"))
+        non_goals = conformance.get("non_goals")
+        if not isinstance(non_goals, dict):
+            failures.append(Failure(category, f"{context}.external_orchestrator must include non_goals"))
+        else:
+            for key in ("daemon", "scheduler_state_machine", "tracker_polling_product", "second_status_surface", "host_lifecycle_ownership"):
+                if non_goals.get(key) is not False:
+                    failures.append(Failure(category, f"{context}.external_orchestrator non_goal `{key}` must remain false"))
+    core_profile = payload.get("core_profile")
+    if isinstance(core_profile, dict) and core_profile.get("result") != "pass":
+        failures.append(Failure(category, f"{context}.core_profile.result must remain pass"))
 
 
 def require_repo_interop_payload(
@@ -9912,6 +9975,177 @@ def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Fai
     return failures
 
 
+def check_external_orchestrator_conformance_contract(root: Path) -> list[Failure]:
+    category = "external-orchestrator-conformance"
+    failures: list[Failure] = []
+    required_docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/external-orchestrator",
+            "loom-external-orchestrator-conformance/v1",
+            "fake external orchestrator happy/drift fixtures",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "external-orchestrator-interop",
+            "loom-external-orchestrator-conformance/v1",
+            "does not execute",
+        ],
+        "docs/evidence/external-orchestrator-release-threshold.md": [
+            "v0.12.0",
+            "loom-external-orchestrator-conformance/v1",
+            "no daemon",
+            "fake external orchestrator fixtures are sufficient",
+        ],
+    }
+    for relative, anchors in required_docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure(category, f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure(category, f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-conformance-fixtures.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"external orchestrator conformance fixtures are unreadable: {exc}"))
+        return failures
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA:
+        failures.append(Failure(category, f"conformance fixture schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA}`"))
+    fixtures = fixture_payload.get("fixtures")
+    required_names = {
+        "fake-external-orchestrator-happy",
+        "fake-external-orchestrator-truth-drift",
+        "fake-external-orchestrator-private-fallback",
+        "fake-external-orchestrator-lifecycle-drift",
+    }
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator conformance fixtures must include fixtures"))
+        return failures
+    seen_names: set[str] = set()
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if isinstance(name, str):
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+            continue
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"{name or index} payload must be an object"))
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/block"))
+        operations = entry.get("operations")
+        if not isinstance(operations, list) or not operations:
+            failures.append(Failure(category, f"{name or index} entry.operations must be non-empty"))
+        elif any(operation not in {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"} for operation in operations):
+            failures.append(Failure(category, f"{name or index} declares unsupported operation"))
+        if name == "fake-external-orchestrator-happy" and expect.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, "happy fixture must expect conformance schema v1"))
+        if name == "fake-external-orchestrator-truth-drift" and payload is not None:
+            forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+            if not forbidden or expect.get("failure") != "truth_pollution":
+                failures.append(Failure(category, "truth drift fixture must prove forbidden authored/scheduler fields block"))
+        if name == "fake-external-orchestrator-private-fallback":
+            if entry.get("fallback_to") != "scheduler_retry_queue" or expect.get("fallback_to") != "current_checkpoint":
+                failures.append(Failure(category, "private fallback fixture must block back to current_checkpoint"))
+        if name == "fake-external-orchestrator-lifecycle-drift" and payload is not None:
+            if payload.get("host_lifecycle_ownership") != "loom" or payload.get("daemon") is not True:
+                failures.append(Failure(category, "lifecycle drift fixture must prove no-daemon/no-host-lifecycle boundary"))
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator conformance fixtures missing required cases: " + ", ".join(missing)))
+
+    example_target = root / "examples/new-project"
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(example_target)],
+    )
+    if error:
+        failures.append(Failure(category, f"`external-orchestrator-interop` not_applicable sample failed: {error}"))
+    else:
+        require_external_orchestrator_conformance_payload(
+            failures,
+            category=category,
+            context="not-applicable external orchestrator conformance",
+            payload=absent_payload,
+        )
+        external_profile = absent_payload.get("external_orchestrator") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must pass"))
+        elif not isinstance(external_profile, dict) or external_profile.get("status") != "not_applicable":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must expose not_applicable status"))
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    with tempfile.TemporaryDirectory(prefix="loom-external-orchestrator-conformance-") as tmp:
+        base = Path(tmp)
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        happy_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-happy"), None)
+        if isinstance(happy_fixture, dict):
+            interop = load_json_file(present_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [happy_fixture["entry"]]
+                write_json_local(present_target / ".loom/companion/interop.json", interop)
+                write_json_local(present_target / happy_fixture["entry"]["locator"], happy_fixture["payload"])
+            present_payload, present_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(present_target)],
+            )
+            if present_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` happy sample failed: {present_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="happy external orchestrator conformance",
+                    payload=present_payload,
+                )
+                if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                    failures.append(Failure(category, "happy external orchestrator conformance must pass"))
+
+        drift_target = base / "drift"
+        shutil.copytree(example_target, drift_target)
+        drift_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-truth-drift"), None)
+        if isinstance(drift_fixture, dict):
+            interop = load_json_file(drift_target / ".loom/companion/interop.json")
+            if isinstance(interop, dict):
+                interop["external_orchestrators"] = [drift_fixture["entry"]]
+                write_json_local(drift_target / ".loom/companion/interop.json", interop)
+                write_json_local(drift_target / drift_fixture["entry"]["locator"], drift_fixture["payload"])
+            drift_payload, drift_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(drift_target)],
+            )
+            if drift_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` drift sample failed: {drift_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="drift external orchestrator conformance",
+                    payload=drift_payload,
+                )
+                core_profile = drift_payload.get("core_profile") if isinstance(drift_payload, dict) else None
+                if not isinstance(drift_payload, dict) or drift_payload.get("result") != "block":
+                    failures.append(Failure(category, "truth drift external orchestrator conformance must block"))
+                elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                    failures.append(Failure(category, "external orchestrator conformance drift must not rewrite core profile"))
+
+    return failures
+
+
 def check_external_runtime_devendor_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     required_anchors = {
@@ -14373,6 +14607,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
     failures.extend(check_external_orchestrator_interop_fixture_contract(root))
+    failures.extend(check_external_orchestrator_conformance_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -14401,7 +14636,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 35
+    categories_checked = 36
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    EXTERNAL_ORCHESTRATOR_OPERATIONS,
     empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
@@ -122,6 +123,7 @@ DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -162,6 +164,41 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "current_lane",
     "recovery_boundary",
     "closing_condition",
+}
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+    "daemon",
+    "scheduler_queue",
+    "branch_ownership",
+    "pr_ownership",
+    "worktree_ownership",
+    "worker_lifecycle",
+}
+EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS = {
+    "work_item",
+    "admission",
+    "binding_repair",
+    "current_checkpoint",
+    "spec_gate",
+    "build_gate",
+    "review_gate",
+    "merge_gate",
+    "build",
+    "review",
+    "merge_ready",
+    "closeout",
 }
 HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
@@ -553,7 +590,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
+    live_smoke.add_argument(
+        "operation",
+        choices=(
+            "run",
+            "replay",
+            "host-adapter-drift",
+            "dynamic-tool-availability",
+            "hook-envelope",
+            "hooks-extension",
+            "external-orchestrator-interop",
+        ),
+    )
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -899,6 +947,41 @@ def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
     ]
 
 
+def external_orchestrator_conformance_command_plan(
+    target_root: Path,
+    external_orchestrators: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading external orchestrator declarations.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'} external_orchestrators",
+            "description": "Read external orchestrator locator declarations without starting a scheduler or daemon.",
+        },
+        {
+            "id": "status-consumer-view",
+            "command": f"{shlex.quote(sys.executable)} tools/loom_status.py --target {shlex.quote(str(target_root))} --item INIT-0001",
+            "description": "Confirm status/gate consumption reuses Loom status control plane v2 and the existing gate chain.",
+        },
+    ]
+    for index, entry in enumerate(external_orchestrators or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"external-orchestrator-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read external orchestrator retained evidence without accepting scheduler-owned status or gate truth.",
+            }
+        )
+    return plan
+
+
 def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
     found: list[str] = []
     if isinstance(value, dict):
@@ -911,6 +994,21 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     elif isinstance(value, list):
         for index, nested in enumerate(value):
             found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def find_forbidden_external_orchestrator_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=f"{prefix}[{index}]"))
     return found
 
 
@@ -1875,6 +1973,313 @@ def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
             "profile_check": {"id": "hooks-extension", "result": result},
             "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
             "hooks_extension": hook_profile,
+        }
+    )
+    return payload
+
+
+def empty_external_orchestrator_conformance() -> dict[str, Any]:
+    return {
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "profile_id": "orchestration-extension/external-orchestrator",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "external orchestrator interop profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+        "non_goals": {
+            "daemon": False,
+            "scheduler_state_machine": False,
+            "tracker_polling_product": False,
+            "second_status_surface": False,
+            "host_lifecycle_ownership": False,
+        },
+    }
+
+
+def external_orchestrator_conformance_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+) -> dict[str, Any]:
+    prefix = f"external_orchestrators[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "requirement": "required",
+            "operations": [],
+            "locator": "",
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            "evidence": {"locator_status": "invalid-declaration"},
+        }
+
+    entry_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"external-orchestrator-{index}"
+    requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+    locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "admission"
+    operations = entry.get("operations") if isinstance(entry.get("operations"), list) else []
+    blocking: list[str] = []
+    optional: list[str] = []
+
+    if requirement not in {"required", "optional", "advisory"}:
+        blocking.append(f"{prefix}.requirement must be required, optional, or advisory")
+        requirement = "required"
+    if not operations:
+        blocking.append(f"{prefix}.operations must be a non-empty list")
+    unsupported = [str(operation) for operation in operations if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS]
+    if unsupported:
+        blocking.append(f"{prefix}.operations contains unsupported operations: {', '.join(unsupported)}")
+    if isinstance(fallback_to, str) and fallback_to not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+        blocking.append(f"{prefix}.fallback_to must point back to a Loom checkpoint or gate repair surface")
+
+    locator_path, locator_errors = resolve_repo_relative_path(target_root, locator, label=f"{prefix} locator")
+    if locator_errors:
+        blocking.extend(locator_errors)
+    elif locator_path is None or not locator_path.exists() or locator_path.is_dir():
+        message = f"{prefix} locator points to missing or unreadable retained evidence `{locator}`"
+        if requirement in {"optional", "advisory"}:
+            optional.append(message)
+        else:
+            blocking.append(message)
+
+    payload: object = None
+    if locator_path is not None and locator_path.exists() and locator_path.is_file():
+        try:
+            payload = load_json_file(locator_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            blocking.append(f"{prefix} retained evidence is not readable JSON: {exc}")
+    if payload is not None and not isinstance(payload, dict):
+        blocking.append(f"{prefix} retained evidence must be a JSON object")
+    if isinstance(payload, dict):
+        forbidden = find_forbidden_external_orchestrator_fields(payload)
+        if forbidden:
+            blocking.append(f"{prefix} retained evidence contains forbidden authored/scheduler fields: {', '.join(forbidden)}")
+        payload_operation = payload.get("operation")
+        if isinstance(payload_operation, str) and operations and payload_operation not in operations:
+            blocking.append(f"{prefix} retained evidence operation is not declared by the locator")
+        if payload.get("operation") in {"status_read", "gate_read"}:
+            if payload.get("source_layer") != "derived_surface":
+                blocking.append(f"{prefix} status/gate reads must consume the derived status surface")
+            if payload.get("consumed_as") != "summary":
+                blocking.append(f"{prefix} status/gate reads must be consumed as summary")
+        if payload.get("host_lifecycle_ownership") not in {None, "host", "external"}:
+            blocking.append(f"{prefix} retained evidence must not claim Loom owns host lifecycle")
+        payload_fallback = payload.get("fallback_to")
+        if isinstance(payload_fallback, str) and payload_fallback not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+            blocking.append(f"{prefix} retained evidence fallback_to must point back to Loom")
+
+    result = "block" if blocking else "warn" if optional else "pass"
+    if result == "warn" and requirement in {"required"}:
+        result = "block"
+    return {
+        "id": entry_id,
+        "requirement": requirement,
+        "operations": operations,
+        "locator": locator,
+        "result": result,
+        "classification": "truth_pollution" if blocking and isinstance(payload, dict) and find_forbidden_external_orchestrator_fields(payload) else "locator_or_contract",
+        "summary": (
+            "external orchestrator retained evidence is readable and respects Loom truth boundaries."
+            if result == "pass"
+            else "external orchestrator retained evidence has profile-local warnings."
+            if result == "warn"
+            else "external orchestrator retained evidence violates interop conformance boundaries."
+        ),
+        "missing_inputs": blocking if result == "block" else [],
+        "missing_optional": optional,
+        "fallback_to": fallback_to if result == "block" else None,
+        "evidence": {
+            "locator_status": "readable" if isinstance(payload, dict) else "missing_or_invalid",
+            "payload_schema_version": payload.get("schema_version") if isinstance(payload, dict) else None,
+            "payload_operation": payload.get("operation") if isinstance(payload, dict) else None,
+        },
+    }
+
+
+def external_orchestrator_conformance_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "external-orchestrator-interop",
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": external_orchestrator_conformance_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "external orchestrator conformance is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "external orchestrator conformance recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    interop_path = target_root / ".loom" / "companion" / "interop.json"
+    if not interop_path.exists():
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop does not declare external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    try:
+        interop_payload = load_json_file(interop_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update(
+            {
+                "enabled": True,
+                "result": "block",
+                "status": "invalid_declaration",
+                "summary": "repo interop contract is unreadable for external orchestrator conformance.",
+                "missing_inputs": [f"repo interop contract is unreadable: {exc}"],
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": conformance["summary"],
+                "missing_inputs": conformance["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+    external_orchestrators = interop_payload.get("external_orchestrators", []) if isinstance(interop_payload, dict) else []
+    if not isinstance(external_orchestrators, list) or not external_orchestrators:
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop is readable but declares no external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    checks = [
+        external_orchestrator_conformance_check(target_root, entry=entry, index=index)
+        for index, entry in enumerate(external_orchestrators)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "repo-interop.external_orchestrator",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    conformance = empty_external_orchestrator_conformance()
+    conformance.update(
+        {
+            "enabled": True,
+            "result": result,
+            "status": "present",
+            "summary": (
+                "external orchestrator conformance passed without introducing a daemon, scheduler state, or second status surface."
+                if result == "pass"
+                else "external orchestrator conformance produced profile-local warnings."
+                if result == "warn"
+                else "external orchestrator conformance found blocking interop drift."
+            ),
+            "missing_inputs": live_smoke_missing_inputs([message for check in checks for message in check.get("missing_inputs", [])]),
+            "missing_optional": [message for check in checks for message in check.get("missing_optional", [])],
+            "checks": checks,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": conformance["summary"],
+            "missing_inputs": conformance["missing_inputs"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "external-orchestrator-interop", "result": result},
+            "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+            "external_orchestrator": conformance,
+            "command_plan": external_orchestrator_conformance_command_plan(target_root, external_orchestrators=external_orchestrators),
         }
     )
     return payload
@@ -12754,6 +13159,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "external-orchestrator-interop":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "external-orchestrator-interop",
+                    "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+                    "result": "block",
+                    "summary": "external orchestrator conformance requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                    "external_orchestrator": {
+                        **empty_external_orchestrator_conformance(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(external_orchestrator_conformance_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)


### PR DESCRIPTION
## Summary

Closes #641, #642, #643, #644.

Batch 4 for #535 establishes the external orchestrator interop conformance profile and release threshold.

## Changes

- Adds `live-smoke external-orchestrator-interop` with evidence schema `loom-external-orchestrator-conformance/v1`.
- Adds fake external orchestrator conformance fixtures for happy path, truth drift, scheduler-private fallback, and no-daemon / no-host-lifecycle boundaries.
- Documents the `orchestration-extension/external-orchestrator` profile and v0.12.0 release threshold.
- Extends `loom_check` to validate the conformance command, fixtures, release threshold, and profile-local behavior.
- Bumps the installer package version to `0.1.103` because shared runtime payloads changed.

## Validation

- `python3 -m py_compile tools/loom_check.py tools/loom_flow.py tools/loom_init.py tools/loom_status.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py`
- `python3 tools/skills_surface.py generate`
- `python3 tools/skills_surface.py check`
- `python3 tools/host_adapter_check.py`
- `python3 tools/version_surface_check.py`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `git diff --check`
- `python3 tools/loom_flow.py live-smoke external-orchestrator-interop --target examples/new-project`
- `python3 tools/loom_check.py` (`OK`, checked 36 surfaces)
- `npm --prefix packages/loom-installer run check:release`

## Non-goals preserved

- No daemon.
- No real external scheduler requirement.
- No scheduler state machine.
- No tracker polling product.
- No external authored status or gate truth.
- No branch/PR/git-worktree/worker lifecycle ownership.
- No second status surface.
