### PR TITLE
feat(harness): Codex App review shadow adapter

### DIFF
--- a/.agents/skills/loom-adopt
+++ b/.agents/skills/loom-adopt
@@ -1,0 +1,1 @@
+/Users/claw/dev/Loom/skills/loom-adopt

--- a/.agents/skills/loom-build
+++ b/.agents/skills/loom-build
@@ -1,0 +1,1 @@
+/Users/claw/dev/Loom/skills/loom-build

--- a/.agents/skills/loom-handoff
+++ b/.agents/skills/loom-handoff
@@ -1,0 +1,1 @@
+/Users/claw/dev/Loom/skills/loom-handoff

--- a/.agents/skills/loom-init
+++ b/.agents/skills/loom-init
@@ -1,0 +1,1 @@
+/Users/claw/dev/Loom/skills/loom-init

--- a/.agents/skills/loom-merge-ready
+++ b/.agents/skills/loom-merge-ready
@@ -1,0 +1,1 @@
+/Users/claw/dev/Loom/skills/loom-merge-ready

--- a/.agents/skills/loom-pre-review
+++ b/.agents/skills/loom-pre-review
@@ -1,0 +1,1 @@
+/Users/claw/dev/Loom/skills/loom-pre-review

--- a/.agents/skills/loom-resume
+++ b/.agents/skills/loom-resume
@@ -1,0 +1,1 @@
+/Users/claw/dev/Loom/skills/loom-resume

--- a/.agents/skills/loom-retire
+++ b/.agents/skills/loom-retire
@@ -1,0 +1,1 @@
+/Users/claw/dev/Loom/skills/loom-retire

--- a/.agents/skills/loom-review
+++ b/.agents/skills/loom-review
@@ -1,0 +1,1 @@
+/Users/claw/dev/Loom/skills/loom-review

--- a/.agents/skills/loom-spec-review
+++ b/.agents/skills/loom-spec-review
@@ -1,0 +1,1 @@
+/Users/claw/dev/Loom/skills/loom-spec-review

--- a/.agents/skills/loom-story
+++ b/.agents/skills/loom-story
@@ -1,0 +1,1 @@
+/Users/claw/dev/Loom/skills/loom-story

--- a/docs/methodology/harness/review-execution.md
+++ b/docs/methodology/harness/review-execution.md
@@ -53,6 +53,15 @@ Loom 把 review 分成三层：
 默认 engine 当前固定为 Codex。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 checkpoint fallback。
 
+阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+
+- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
+- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
+- shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
+- shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
+- shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.104",
+  "version": "0.1.105",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.104",
+      "version": "0.1.105",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.104",
+  "version": "0.1.105",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/review-execution.md
@@ -55,6 +55,15 @@ Loom 把 review 分成四层：
 默认 engine 当前固定为 Codex。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
+阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+
+- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
+- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
+- shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
+- shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
+- shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -3079,6 +3079,26 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
                 failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+    shadow_engine = payload.get("shadow_engine")
+    if shadow_engine is not None:
+        if not isinstance(shadow_engine, dict):
+            failures.append(Failure(category, f"{context} shadow_engine must be an object when present"))
+        else:
+            if shadow_engine.get("adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} shadow_engine adapter must stay shadow-only `loom/codex-app-review`"))
+            if shadow_engine.get("result") not in {"pass", "block", "unavailable"}:
+                failures.append(Failure(category, f"{context} shadow_engine result must stay within the stable shadow contract"))
+            if shadow_engine.get("authoritative") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must declare authoritative=false"))
+            if shadow_engine.get("blocking") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must not block review or merge-ready"))
+            evidence = shadow_engine.get("evidence")
+            if not isinstance(evidence, dict):
+                failures.append(Failure(category, f"{context} shadow_engine must include runtime evidence locators"))
+            else:
+                for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    if not isinstance(evidence.get(key), str) or not evidence.get(key):
+                        failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
 
 
 def require_runtime_state_payload(
@@ -5716,6 +5736,114 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        shadow_target = Path(tmp) / "review-run-shadow"
+        prepare_review_target(shadow_target, "review run shadow adapter")
+        shadow_raw = shadow_target / ".loom/runtime/tmp/codex-app-review-raw.json"
+        shadow_raw.parent.mkdir(parents=True, exist_ok=True)
+        shadow_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "fallback",
+                    "summary": "Codex App reviewer produced shadow-only findings.",
+                    "findings": [
+                        {
+                            "id": "shadow-warn-1",
+                            "summary": "Codex App shadow review noted a comparison-only issue.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "deferred",
+                                "summary": "Shadow evidence must not author the formal review record.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+                "--shadow-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-raw.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow adapter",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must not replace default review_record_input engine adapter"))
+                shadow_engine = payload.get("shadow_engine") if isinstance(payload.get("shadow_engine"), dict) else {}
+                if shadow_engine.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must pass when raw review evidence is provided"))
+                evidence = shadow_engine.get("evidence") if isinstance(shadow_engine.get("evidence"), dict) else {}
+                for key in ("raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    value = evidence.get(key)
+                    if not isinstance(value, str) or not (shadow_target / value).exists():
+                        failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter must write {key} evidence"))
+                if shadow_engine.get("authoritative") is not False or shadow_engine.get("blocking") is not False:
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must stay non-authoritative and non-blocking"))
+
+        shadow_unavailable_target = Path(tmp) / "review-run-shadow-unavailable"
+        prepare_review_target(shadow_unavailable_target, "review run shadow unavailable")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_unavailable_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow unavailable failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow unavailable",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            shadow_engine = payload.get("shadow_engine") if isinstance(payload, dict) and isinstance(payload.get("shadow_engine"), dict) else {}
+            if shadow_engine.get("result") != "unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must not block the default review path"))
+            review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
+            if review_record_input.get("engine_adapter") != "loom/default-codex":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -5593,7 +5593,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         review_target = Path(tmp) / "new-project"
         fake_bin = Path(tmp) / "bin"
         fake_bin.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
         def prepare_review_target(target: Path, label: str) -> bool:
             shutil.copytree(source_snapshot, target)
@@ -6801,7 +6801,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             write_fake_codex(fake_bin / "codex", mode="success")
             installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
-            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
             def prepare_target(target: Path) -> tuple[str | None, list[str]]:
                 errors: list[str] = []

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,8 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -449,6 +451,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
     review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
+    review.add_argument(
+        "--shadow-engine-adapter",
+        choices=tuple(sorted(SHADOW_REVIEW_ADAPTERS)),
+        help="Optional shadow-only review adapter. Does not replace the default authoritative review engine.",
+    )
+    review.add_argument(
+        "--shadow-review-raw-file",
+        help="Optional repo-relative captured Codex App review text to normalize as shadow evidence.",
+    )
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -7115,6 +7126,228 @@ def normalize_engine_review_result(payload: Any, *, relative: str) -> tuple[dict
     }, []
 
 
+def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App review raw output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+        if normalized is not None and not errors:
+            return normalized, []
+
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+    summary = first_line[:240] if first_line else "Codex App review returned raw text."
+    return {
+        "decision": "fallback",
+        "summary": "Codex App review raw output was captured as shadow evidence and normalized for comparison only.",
+        "findings": [
+            {
+                "id": "codex-app-review-raw-output",
+                "summary": summary,
+                "severity": "warn",
+                "rebuttal": None,
+                "disposition": {
+                    "status": "deferred",
+                    "summary": "Shadow-only finding; formal disposition must still be authored through the single review record.",
+                },
+                "details": text[:4000],
+            }
+        ],
+    }, []
+
+
+def shadow_adapter_slug(adapter: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
+
+
+def compare_review_findings(default_findings: list[dict[str, Any]], shadow_findings: list[dict[str, Any]]) -> dict[str, Any]:
+    default_ids = {str(finding.get("id")) for finding in default_findings if isinstance(finding, dict) and finding.get("id")}
+    shadow_ids = {str(finding.get("id")) for finding in shadow_findings if isinstance(finding, dict) and finding.get("id")}
+    shared = sorted(default_ids & shadow_ids)
+    default_only = sorted(default_ids - shadow_ids)
+    shadow_only = sorted(shadow_ids - default_ids)
+    result = "match" if not default_only and not shadow_only else "difference"
+    return {
+        "schema_version": "loom-review-shadow-diff/v1",
+        "result": result,
+        "summary": (
+            "Shadow review findings match the default review finding ids."
+            if result == "match"
+            else "Shadow review findings differ from the default review finding ids."
+        ),
+        "default_finding_ids": sorted(default_ids),
+        "shadow_finding_ids": sorted(shadow_ids),
+        "shared_finding_ids": shared,
+        "default_only_finding_ids": default_only,
+        "shadow_only_finding_ids": shadow_only,
+    }
+
+
+def run_codex_app_review_shadow_adapter(
+    context: dict[str, Any],
+    *,
+    adapter: str | None,
+    raw_file: str | None,
+    default_engine_payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not adapter:
+        return None
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    shadow_root = runtime_root / "shadow" / shadow_adapter_slug(adapter)
+    raw_path = shadow_root / "raw-review.txt"
+    findings_path = shadow_root / "normalized-findings.json"
+    metadata_path = shadow_root / "metadata.json"
+    diff_path = shadow_root / "parity-diff.json"
+    evidence = {
+        "runtime_root": relative_to_root(shadow_root, context["target_root"]),
+        "raw_review": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "parity_diff": relative_to_root(diff_path, context["target_root"]),
+    }
+
+    if adapter != CODEX_APP_REVIEW_SHADOW_ADAPTER:
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Unsupported shadow review adapter.",
+            "missing_inputs": [f"unsupported shadow review adapter: {adapter}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    if not raw_file:
+        metadata = {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "unavailable",
+            "reviewed_head": reviewed_head,
+            "summary": "Codex App review shadow adapter requires captured raw review text or a future live app-server runner.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "authoritative": False,
+        }
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(metadata_path, metadata)
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Codex App review shadow adapter was requested but no raw review evidence was provided.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    source_path, source_errors = resolve_repo_relative_path(context["target_root"], raw_file, label="shadow review raw file")
+    if source_errors or source_path is None:
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": source_errors,
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter refused an unsafe raw review locator.",
+            "missing_inputs": source_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter could not read raw review evidence.",
+            "missing_inputs": [f"shadow review raw file: {exc.strerror or exc}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    shadow_root.mkdir(parents=True, exist_ok=True)
+    raw_path.write_text(raw_text, encoding="utf-8")
+    normalized, normalization_errors = normalize_codex_app_review_text(
+        raw_text,
+        relative=relative_to_root(source_path, context["target_root"]),
+    )
+    if normalization_errors or normalized is None:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": normalization_errors,
+                "raw_source": relative_to_root(source_path, context["target_root"]),
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    default_findings: list[dict[str, Any]] = []
+    review_record_input = default_engine_payload.get("review_record_input")
+    if isinstance(review_record_input, dict):
+        default_findings_file = review_record_input.get("findings_file")
+        if isinstance(default_findings_file, str):
+            loaded_findings, _ = load_findings_file(context["target_root"], default_findings_file)
+            if isinstance(loaded_findings, list):
+                default_findings = loaded_findings
+    parity_diff = compare_review_findings(default_findings, normalized["findings"])
+    write_json_file(diff_path, parity_diff)
+    write_json_file(
+        metadata_path,
+        {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "pass",
+            "reviewed_head": reviewed_head,
+            "raw_source": relative_to_root(source_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "parity_diff": relative_to_root(diff_path, context["target_root"]),
+            "authoritative": False,
+            "summary": normalized["summary"],
+        },
+    )
+    return {
+        "adapter": adapter,
+        "result": "pass",
+        "summary": "Codex App review shadow evidence was captured and normalized for comparison only.",
+        "missing_inputs": [],
+        "blocking": False,
+        "authoritative": False,
+        "evidence": evidence,
+        "decision": normalized["decision"],
+        "parity_diff": parity_diff,
+    }
+
+
 def manual_review_payload(
     *,
     context: dict[str, Any],
@@ -11375,6 +11608,12 @@ def handle_review(args: argparse.Namespace) -> int:
             engine_profile,
             review_kind=review_kind,
         )
+        shadow_engine_payload = run_codex_app_review_shadow_adapter(
+            context,
+            adapter=args.shadow_engine_adapter,
+            raw_file=args.shadow_review_raw_file,
+            default_engine_payload=engine_payload,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")
@@ -11413,6 +11652,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),
             }

--- a/skills/loom-build/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/review-execution.md
@@ -55,6 +55,15 @@ Loom 把 review 分成四层：
 默认 engine 当前固定为 Codex。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
+阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+
+- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
+- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
+- shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
+- shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
+- shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -3079,6 +3079,26 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
                 failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+    shadow_engine = payload.get("shadow_engine")
+    if shadow_engine is not None:
+        if not isinstance(shadow_engine, dict):
+            failures.append(Failure(category, f"{context} shadow_engine must be an object when present"))
+        else:
+            if shadow_engine.get("adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} shadow_engine adapter must stay shadow-only `loom/codex-app-review`"))
+            if shadow_engine.get("result") not in {"pass", "block", "unavailable"}:
+                failures.append(Failure(category, f"{context} shadow_engine result must stay within the stable shadow contract"))
+            if shadow_engine.get("authoritative") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must declare authoritative=false"))
+            if shadow_engine.get("blocking") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must not block review or merge-ready"))
+            evidence = shadow_engine.get("evidence")
+            if not isinstance(evidence, dict):
+                failures.append(Failure(category, f"{context} shadow_engine must include runtime evidence locators"))
+            else:
+                for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    if not isinstance(evidence.get(key), str) or not evidence.get(key):
+                        failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
 
 
 def require_runtime_state_payload(
@@ -5716,6 +5736,114 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        shadow_target = Path(tmp) / "review-run-shadow"
+        prepare_review_target(shadow_target, "review run shadow adapter")
+        shadow_raw = shadow_target / ".loom/runtime/tmp/codex-app-review-raw.json"
+        shadow_raw.parent.mkdir(parents=True, exist_ok=True)
+        shadow_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "fallback",
+                    "summary": "Codex App reviewer produced shadow-only findings.",
+                    "findings": [
+                        {
+                            "id": "shadow-warn-1",
+                            "summary": "Codex App shadow review noted a comparison-only issue.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "deferred",
+                                "summary": "Shadow evidence must not author the formal review record.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+                "--shadow-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-raw.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow adapter",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must not replace default review_record_input engine adapter"))
+                shadow_engine = payload.get("shadow_engine") if isinstance(payload.get("shadow_engine"), dict) else {}
+                if shadow_engine.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must pass when raw review evidence is provided"))
+                evidence = shadow_engine.get("evidence") if isinstance(shadow_engine.get("evidence"), dict) else {}
+                for key in ("raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    value = evidence.get(key)
+                    if not isinstance(value, str) or not (shadow_target / value).exists():
+                        failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter must write {key} evidence"))
+                if shadow_engine.get("authoritative") is not False or shadow_engine.get("blocking") is not False:
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must stay non-authoritative and non-blocking"))
+
+        shadow_unavailable_target = Path(tmp) / "review-run-shadow-unavailable"
+        prepare_review_target(shadow_unavailable_target, "review run shadow unavailable")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_unavailable_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow unavailable failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow unavailable",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            shadow_engine = payload.get("shadow_engine") if isinstance(payload, dict) and isinstance(payload.get("shadow_engine"), dict) else {}
+            if shadow_engine.get("result") != "unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must not block the default review path"))
+            review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
+            if review_record_input.get("engine_adapter") != "loom/default-codex":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -5593,7 +5593,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         review_target = Path(tmp) / "new-project"
         fake_bin = Path(tmp) / "bin"
         fake_bin.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
         def prepare_review_target(target: Path, label: str) -> bool:
             shutil.copytree(source_snapshot, target)
@@ -6801,7 +6801,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             write_fake_codex(fake_bin / "codex", mode="success")
             installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
-            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
             def prepare_target(target: Path) -> tuple[str | None, list[str]]:
                 errors: list[str] = []

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,8 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -449,6 +451,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
     review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
+    review.add_argument(
+        "--shadow-engine-adapter",
+        choices=tuple(sorted(SHADOW_REVIEW_ADAPTERS)),
+        help="Optional shadow-only review adapter. Does not replace the default authoritative review engine.",
+    )
+    review.add_argument(
+        "--shadow-review-raw-file",
+        help="Optional repo-relative captured Codex App review text to normalize as shadow evidence.",
+    )
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -7115,6 +7126,228 @@ def normalize_engine_review_result(payload: Any, *, relative: str) -> tuple[dict
     }, []
 
 
+def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App review raw output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+        if normalized is not None and not errors:
+            return normalized, []
+
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+    summary = first_line[:240] if first_line else "Codex App review returned raw text."
+    return {
+        "decision": "fallback",
+        "summary": "Codex App review raw output was captured as shadow evidence and normalized for comparison only.",
+        "findings": [
+            {
+                "id": "codex-app-review-raw-output",
+                "summary": summary,
+                "severity": "warn",
+                "rebuttal": None,
+                "disposition": {
+                    "status": "deferred",
+                    "summary": "Shadow-only finding; formal disposition must still be authored through the single review record.",
+                },
+                "details": text[:4000],
+            }
+        ],
+    }, []
+
+
+def shadow_adapter_slug(adapter: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
+
+
+def compare_review_findings(default_findings: list[dict[str, Any]], shadow_findings: list[dict[str, Any]]) -> dict[str, Any]:
+    default_ids = {str(finding.get("id")) for finding in default_findings if isinstance(finding, dict) and finding.get("id")}
+    shadow_ids = {str(finding.get("id")) for finding in shadow_findings if isinstance(finding, dict) and finding.get("id")}
+    shared = sorted(default_ids & shadow_ids)
+    default_only = sorted(default_ids - shadow_ids)
+    shadow_only = sorted(shadow_ids - default_ids)
+    result = "match" if not default_only and not shadow_only else "difference"
+    return {
+        "schema_version": "loom-review-shadow-diff/v1",
+        "result": result,
+        "summary": (
+            "Shadow review findings match the default review finding ids."
+            if result == "match"
+            else "Shadow review findings differ from the default review finding ids."
+        ),
+        "default_finding_ids": sorted(default_ids),
+        "shadow_finding_ids": sorted(shadow_ids),
+        "shared_finding_ids": shared,
+        "default_only_finding_ids": default_only,
+        "shadow_only_finding_ids": shadow_only,
+    }
+
+
+def run_codex_app_review_shadow_adapter(
+    context: dict[str, Any],
+    *,
+    adapter: str | None,
+    raw_file: str | None,
+    default_engine_payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not adapter:
+        return None
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    shadow_root = runtime_root / "shadow" / shadow_adapter_slug(adapter)
+    raw_path = shadow_root / "raw-review.txt"
+    findings_path = shadow_root / "normalized-findings.json"
+    metadata_path = shadow_root / "metadata.json"
+    diff_path = shadow_root / "parity-diff.json"
+    evidence = {
+        "runtime_root": relative_to_root(shadow_root, context["target_root"]),
+        "raw_review": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "parity_diff": relative_to_root(diff_path, context["target_root"]),
+    }
+
+    if adapter != CODEX_APP_REVIEW_SHADOW_ADAPTER:
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Unsupported shadow review adapter.",
+            "missing_inputs": [f"unsupported shadow review adapter: {adapter}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    if not raw_file:
+        metadata = {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "unavailable",
+            "reviewed_head": reviewed_head,
+            "summary": "Codex App review shadow adapter requires captured raw review text or a future live app-server runner.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "authoritative": False,
+        }
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(metadata_path, metadata)
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Codex App review shadow adapter was requested but no raw review evidence was provided.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    source_path, source_errors = resolve_repo_relative_path(context["target_root"], raw_file, label="shadow review raw file")
+    if source_errors or source_path is None:
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": source_errors,
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter refused an unsafe raw review locator.",
+            "missing_inputs": source_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter could not read raw review evidence.",
+            "missing_inputs": [f"shadow review raw file: {exc.strerror or exc}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    shadow_root.mkdir(parents=True, exist_ok=True)
+    raw_path.write_text(raw_text, encoding="utf-8")
+    normalized, normalization_errors = normalize_codex_app_review_text(
+        raw_text,
+        relative=relative_to_root(source_path, context["target_root"]),
+    )
+    if normalization_errors or normalized is None:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": normalization_errors,
+                "raw_source": relative_to_root(source_path, context["target_root"]),
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    default_findings: list[dict[str, Any]] = []
+    review_record_input = default_engine_payload.get("review_record_input")
+    if isinstance(review_record_input, dict):
+        default_findings_file = review_record_input.get("findings_file")
+        if isinstance(default_findings_file, str):
+            loaded_findings, _ = load_findings_file(context["target_root"], default_findings_file)
+            if isinstance(loaded_findings, list):
+                default_findings = loaded_findings
+    parity_diff = compare_review_findings(default_findings, normalized["findings"])
+    write_json_file(diff_path, parity_diff)
+    write_json_file(
+        metadata_path,
+        {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "pass",
+            "reviewed_head": reviewed_head,
+            "raw_source": relative_to_root(source_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "parity_diff": relative_to_root(diff_path, context["target_root"]),
+            "authoritative": False,
+            "summary": normalized["summary"],
+        },
+    )
+    return {
+        "adapter": adapter,
+        "result": "pass",
+        "summary": "Codex App review shadow evidence was captured and normalized for comparison only.",
+        "missing_inputs": [],
+        "blocking": False,
+        "authoritative": False,
+        "evidence": evidence,
+        "decision": normalized["decision"],
+        "parity_diff": parity_diff,
+    }
+
+
 def manual_review_payload(
     *,
     context: dict[str, Any],
@@ -11375,6 +11608,12 @@ def handle_review(args: argparse.Namespace) -> int:
             engine_profile,
             review_kind=review_kind,
         )
+        shadow_engine_payload = run_codex_app_review_shadow_adapter(
+            context,
+            adapter=args.shadow_engine_adapter,
+            raw_file=args.shadow_review_raw_file,
+            default_engine_payload=engine_payload,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")
@@ -11413,6 +11652,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),
             }

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/review-execution.md
@@ -55,6 +55,15 @@ Loom 把 review 分成四层：
 默认 engine 当前固定为 Codex。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
+阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+
+- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
+- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
+- shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
+- shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
+- shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -3079,6 +3079,26 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
                 failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+    shadow_engine = payload.get("shadow_engine")
+    if shadow_engine is not None:
+        if not isinstance(shadow_engine, dict):
+            failures.append(Failure(category, f"{context} shadow_engine must be an object when present"))
+        else:
+            if shadow_engine.get("adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} shadow_engine adapter must stay shadow-only `loom/codex-app-review`"))
+            if shadow_engine.get("result") not in {"pass", "block", "unavailable"}:
+                failures.append(Failure(category, f"{context} shadow_engine result must stay within the stable shadow contract"))
+            if shadow_engine.get("authoritative") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must declare authoritative=false"))
+            if shadow_engine.get("blocking") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must not block review or merge-ready"))
+            evidence = shadow_engine.get("evidence")
+            if not isinstance(evidence, dict):
+                failures.append(Failure(category, f"{context} shadow_engine must include runtime evidence locators"))
+            else:
+                for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    if not isinstance(evidence.get(key), str) or not evidence.get(key):
+                        failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
 
 
 def require_runtime_state_payload(
@@ -5716,6 +5736,114 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        shadow_target = Path(tmp) / "review-run-shadow"
+        prepare_review_target(shadow_target, "review run shadow adapter")
+        shadow_raw = shadow_target / ".loom/runtime/tmp/codex-app-review-raw.json"
+        shadow_raw.parent.mkdir(parents=True, exist_ok=True)
+        shadow_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "fallback",
+                    "summary": "Codex App reviewer produced shadow-only findings.",
+                    "findings": [
+                        {
+                            "id": "shadow-warn-1",
+                            "summary": "Codex App shadow review noted a comparison-only issue.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "deferred",
+                                "summary": "Shadow evidence must not author the formal review record.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+                "--shadow-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-raw.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow adapter",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must not replace default review_record_input engine adapter"))
+                shadow_engine = payload.get("shadow_engine") if isinstance(payload.get("shadow_engine"), dict) else {}
+                if shadow_engine.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must pass when raw review evidence is provided"))
+                evidence = shadow_engine.get("evidence") if isinstance(shadow_engine.get("evidence"), dict) else {}
+                for key in ("raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    value = evidence.get(key)
+                    if not isinstance(value, str) or not (shadow_target / value).exists():
+                        failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter must write {key} evidence"))
+                if shadow_engine.get("authoritative") is not False or shadow_engine.get("blocking") is not False:
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must stay non-authoritative and non-blocking"))
+
+        shadow_unavailable_target = Path(tmp) / "review-run-shadow-unavailable"
+        prepare_review_target(shadow_unavailable_target, "review run shadow unavailable")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_unavailable_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow unavailable failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow unavailable",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            shadow_engine = payload.get("shadow_engine") if isinstance(payload, dict) and isinstance(payload.get("shadow_engine"), dict) else {}
+            if shadow_engine.get("result") != "unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must not block the default review path"))
+            review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
+            if review_record_input.get("engine_adapter") != "loom/default-codex":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -5593,7 +5593,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         review_target = Path(tmp) / "new-project"
         fake_bin = Path(tmp) / "bin"
         fake_bin.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
         def prepare_review_target(target: Path, label: str) -> bool:
             shutil.copytree(source_snapshot, target)
@@ -6801,7 +6801,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             write_fake_codex(fake_bin / "codex", mode="success")
             installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
-            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
             def prepare_target(target: Path) -> tuple[str | None, list[str]]:
                 errors: list[str] = []

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,8 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -449,6 +451,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
     review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
+    review.add_argument(
+        "--shadow-engine-adapter",
+        choices=tuple(sorted(SHADOW_REVIEW_ADAPTERS)),
+        help="Optional shadow-only review adapter. Does not replace the default authoritative review engine.",
+    )
+    review.add_argument(
+        "--shadow-review-raw-file",
+        help="Optional repo-relative captured Codex App review text to normalize as shadow evidence.",
+    )
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -7115,6 +7126,228 @@ def normalize_engine_review_result(payload: Any, *, relative: str) -> tuple[dict
     }, []
 
 
+def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App review raw output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+        if normalized is not None and not errors:
+            return normalized, []
+
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+    summary = first_line[:240] if first_line else "Codex App review returned raw text."
+    return {
+        "decision": "fallback",
+        "summary": "Codex App review raw output was captured as shadow evidence and normalized for comparison only.",
+        "findings": [
+            {
+                "id": "codex-app-review-raw-output",
+                "summary": summary,
+                "severity": "warn",
+                "rebuttal": None,
+                "disposition": {
+                    "status": "deferred",
+                    "summary": "Shadow-only finding; formal disposition must still be authored through the single review record.",
+                },
+                "details": text[:4000],
+            }
+        ],
+    }, []
+
+
+def shadow_adapter_slug(adapter: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
+
+
+def compare_review_findings(default_findings: list[dict[str, Any]], shadow_findings: list[dict[str, Any]]) -> dict[str, Any]:
+    default_ids = {str(finding.get("id")) for finding in default_findings if isinstance(finding, dict) and finding.get("id")}
+    shadow_ids = {str(finding.get("id")) for finding in shadow_findings if isinstance(finding, dict) and finding.get("id")}
+    shared = sorted(default_ids & shadow_ids)
+    default_only = sorted(default_ids - shadow_ids)
+    shadow_only = sorted(shadow_ids - default_ids)
+    result = "match" if not default_only and not shadow_only else "difference"
+    return {
+        "schema_version": "loom-review-shadow-diff/v1",
+        "result": result,
+        "summary": (
+            "Shadow review findings match the default review finding ids."
+            if result == "match"
+            else "Shadow review findings differ from the default review finding ids."
+        ),
+        "default_finding_ids": sorted(default_ids),
+        "shadow_finding_ids": sorted(shadow_ids),
+        "shared_finding_ids": shared,
+        "default_only_finding_ids": default_only,
+        "shadow_only_finding_ids": shadow_only,
+    }
+
+
+def run_codex_app_review_shadow_adapter(
+    context: dict[str, Any],
+    *,
+    adapter: str | None,
+    raw_file: str | None,
+    default_engine_payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not adapter:
+        return None
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    shadow_root = runtime_root / "shadow" / shadow_adapter_slug(adapter)
+    raw_path = shadow_root / "raw-review.txt"
+    findings_path = shadow_root / "normalized-findings.json"
+    metadata_path = shadow_root / "metadata.json"
+    diff_path = shadow_root / "parity-diff.json"
+    evidence = {
+        "runtime_root": relative_to_root(shadow_root, context["target_root"]),
+        "raw_review": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "parity_diff": relative_to_root(diff_path, context["target_root"]),
+    }
+
+    if adapter != CODEX_APP_REVIEW_SHADOW_ADAPTER:
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Unsupported shadow review adapter.",
+            "missing_inputs": [f"unsupported shadow review adapter: {adapter}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    if not raw_file:
+        metadata = {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "unavailable",
+            "reviewed_head": reviewed_head,
+            "summary": "Codex App review shadow adapter requires captured raw review text or a future live app-server runner.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "authoritative": False,
+        }
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(metadata_path, metadata)
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Codex App review shadow adapter was requested but no raw review evidence was provided.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    source_path, source_errors = resolve_repo_relative_path(context["target_root"], raw_file, label="shadow review raw file")
+    if source_errors or source_path is None:
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": source_errors,
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter refused an unsafe raw review locator.",
+            "missing_inputs": source_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter could not read raw review evidence.",
+            "missing_inputs": [f"shadow review raw file: {exc.strerror or exc}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    shadow_root.mkdir(parents=True, exist_ok=True)
+    raw_path.write_text(raw_text, encoding="utf-8")
+    normalized, normalization_errors = normalize_codex_app_review_text(
+        raw_text,
+        relative=relative_to_root(source_path, context["target_root"]),
+    )
+    if normalization_errors or normalized is None:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": normalization_errors,
+                "raw_source": relative_to_root(source_path, context["target_root"]),
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    default_findings: list[dict[str, Any]] = []
+    review_record_input = default_engine_payload.get("review_record_input")
+    if isinstance(review_record_input, dict):
+        default_findings_file = review_record_input.get("findings_file")
+        if isinstance(default_findings_file, str):
+            loaded_findings, _ = load_findings_file(context["target_root"], default_findings_file)
+            if isinstance(loaded_findings, list):
+                default_findings = loaded_findings
+    parity_diff = compare_review_findings(default_findings, normalized["findings"])
+    write_json_file(diff_path, parity_diff)
+    write_json_file(
+        metadata_path,
+        {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "pass",
+            "reviewed_head": reviewed_head,
+            "raw_source": relative_to_root(source_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "parity_diff": relative_to_root(diff_path, context["target_root"]),
+            "authoritative": False,
+            "summary": normalized["summary"],
+        },
+    )
+    return {
+        "adapter": adapter,
+        "result": "pass",
+        "summary": "Codex App review shadow evidence was captured and normalized for comparison only.",
+        "missing_inputs": [],
+        "blocking": False,
+        "authoritative": False,
+        "evidence": evidence,
+        "decision": normalized["decision"],
+        "parity_diff": parity_diff,
+    }
+
+
 def manual_review_payload(
     *,
     context: dict[str, Any],
@@ -11375,6 +11608,12 @@ def handle_review(args: argparse.Namespace) -> int:
             engine_profile,
             review_kind=review_kind,
         )
+        shadow_engine_payload = run_codex_app_review_shadow_adapter(
+            context,
+            adapter=args.shadow_engine_adapter,
+            raw_file=args.shadow_review_raw_file,
+            default_engine_payload=engine_payload,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")
@@ -11413,6 +11652,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),
             }

--- a/skills/loom-init/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/review-execution.md
@@ -55,6 +55,15 @@ Loom 把 review 分成四层：
 默认 engine 当前固定为 Codex。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
+阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+
+- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
+- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
+- shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
+- shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
+- shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -3079,6 +3079,26 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
                 failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+    shadow_engine = payload.get("shadow_engine")
+    if shadow_engine is not None:
+        if not isinstance(shadow_engine, dict):
+            failures.append(Failure(category, f"{context} shadow_engine must be an object when present"))
+        else:
+            if shadow_engine.get("adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} shadow_engine adapter must stay shadow-only `loom/codex-app-review`"))
+            if shadow_engine.get("result") not in {"pass", "block", "unavailable"}:
+                failures.append(Failure(category, f"{context} shadow_engine result must stay within the stable shadow contract"))
+            if shadow_engine.get("authoritative") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must declare authoritative=false"))
+            if shadow_engine.get("blocking") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must not block review or merge-ready"))
+            evidence = shadow_engine.get("evidence")
+            if not isinstance(evidence, dict):
+                failures.append(Failure(category, f"{context} shadow_engine must include runtime evidence locators"))
+            else:
+                for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    if not isinstance(evidence.get(key), str) or not evidence.get(key):
+                        failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
 
 
 def require_runtime_state_payload(
@@ -5716,6 +5736,114 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        shadow_target = Path(tmp) / "review-run-shadow"
+        prepare_review_target(shadow_target, "review run shadow adapter")
+        shadow_raw = shadow_target / ".loom/runtime/tmp/codex-app-review-raw.json"
+        shadow_raw.parent.mkdir(parents=True, exist_ok=True)
+        shadow_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "fallback",
+                    "summary": "Codex App reviewer produced shadow-only findings.",
+                    "findings": [
+                        {
+                            "id": "shadow-warn-1",
+                            "summary": "Codex App shadow review noted a comparison-only issue.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "deferred",
+                                "summary": "Shadow evidence must not author the formal review record.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+                "--shadow-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-raw.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow adapter",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must not replace default review_record_input engine adapter"))
+                shadow_engine = payload.get("shadow_engine") if isinstance(payload.get("shadow_engine"), dict) else {}
+                if shadow_engine.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must pass when raw review evidence is provided"))
+                evidence = shadow_engine.get("evidence") if isinstance(shadow_engine.get("evidence"), dict) else {}
+                for key in ("raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    value = evidence.get(key)
+                    if not isinstance(value, str) or not (shadow_target / value).exists():
+                        failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter must write {key} evidence"))
+                if shadow_engine.get("authoritative") is not False or shadow_engine.get("blocking") is not False:
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must stay non-authoritative and non-blocking"))
+
+        shadow_unavailable_target = Path(tmp) / "review-run-shadow-unavailable"
+        prepare_review_target(shadow_unavailable_target, "review run shadow unavailable")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_unavailable_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow unavailable failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow unavailable",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            shadow_engine = payload.get("shadow_engine") if isinstance(payload, dict) and isinstance(payload.get("shadow_engine"), dict) else {}
+            if shadow_engine.get("result") != "unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must not block the default review path"))
+            review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
+            if review_record_input.get("engine_adapter") != "loom/default-codex":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -5593,7 +5593,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         review_target = Path(tmp) / "new-project"
         fake_bin = Path(tmp) / "bin"
         fake_bin.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
         def prepare_review_target(target: Path, label: str) -> bool:
             shutil.copytree(source_snapshot, target)
@@ -6801,7 +6801,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             write_fake_codex(fake_bin / "codex", mode="success")
             installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
-            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
             def prepare_target(target: Path) -> tuple[str | None, list[str]]:
                 errors: list[str] = []

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,8 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -449,6 +451,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
     review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
+    review.add_argument(
+        "--shadow-engine-adapter",
+        choices=tuple(sorted(SHADOW_REVIEW_ADAPTERS)),
+        help="Optional shadow-only review adapter. Does not replace the default authoritative review engine.",
+    )
+    review.add_argument(
+        "--shadow-review-raw-file",
+        help="Optional repo-relative captured Codex App review text to normalize as shadow evidence.",
+    )
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -7115,6 +7126,228 @@ def normalize_engine_review_result(payload: Any, *, relative: str) -> tuple[dict
     }, []
 
 
+def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App review raw output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+        if normalized is not None and not errors:
+            return normalized, []
+
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+    summary = first_line[:240] if first_line else "Codex App review returned raw text."
+    return {
+        "decision": "fallback",
+        "summary": "Codex App review raw output was captured as shadow evidence and normalized for comparison only.",
+        "findings": [
+            {
+                "id": "codex-app-review-raw-output",
+                "summary": summary,
+                "severity": "warn",
+                "rebuttal": None,
+                "disposition": {
+                    "status": "deferred",
+                    "summary": "Shadow-only finding; formal disposition must still be authored through the single review record.",
+                },
+                "details": text[:4000],
+            }
+        ],
+    }, []
+
+
+def shadow_adapter_slug(adapter: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
+
+
+def compare_review_findings(default_findings: list[dict[str, Any]], shadow_findings: list[dict[str, Any]]) -> dict[str, Any]:
+    default_ids = {str(finding.get("id")) for finding in default_findings if isinstance(finding, dict) and finding.get("id")}
+    shadow_ids = {str(finding.get("id")) for finding in shadow_findings if isinstance(finding, dict) and finding.get("id")}
+    shared = sorted(default_ids & shadow_ids)
+    default_only = sorted(default_ids - shadow_ids)
+    shadow_only = sorted(shadow_ids - default_ids)
+    result = "match" if not default_only and not shadow_only else "difference"
+    return {
+        "schema_version": "loom-review-shadow-diff/v1",
+        "result": result,
+        "summary": (
+            "Shadow review findings match the default review finding ids."
+            if result == "match"
+            else "Shadow review findings differ from the default review finding ids."
+        ),
+        "default_finding_ids": sorted(default_ids),
+        "shadow_finding_ids": sorted(shadow_ids),
+        "shared_finding_ids": shared,
+        "default_only_finding_ids": default_only,
+        "shadow_only_finding_ids": shadow_only,
+    }
+
+
+def run_codex_app_review_shadow_adapter(
+    context: dict[str, Any],
+    *,
+    adapter: str | None,
+    raw_file: str | None,
+    default_engine_payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not adapter:
+        return None
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    shadow_root = runtime_root / "shadow" / shadow_adapter_slug(adapter)
+    raw_path = shadow_root / "raw-review.txt"
+    findings_path = shadow_root / "normalized-findings.json"
+    metadata_path = shadow_root / "metadata.json"
+    diff_path = shadow_root / "parity-diff.json"
+    evidence = {
+        "runtime_root": relative_to_root(shadow_root, context["target_root"]),
+        "raw_review": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "parity_diff": relative_to_root(diff_path, context["target_root"]),
+    }
+
+    if adapter != CODEX_APP_REVIEW_SHADOW_ADAPTER:
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Unsupported shadow review adapter.",
+            "missing_inputs": [f"unsupported shadow review adapter: {adapter}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    if not raw_file:
+        metadata = {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "unavailable",
+            "reviewed_head": reviewed_head,
+            "summary": "Codex App review shadow adapter requires captured raw review text or a future live app-server runner.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "authoritative": False,
+        }
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(metadata_path, metadata)
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Codex App review shadow adapter was requested but no raw review evidence was provided.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    source_path, source_errors = resolve_repo_relative_path(context["target_root"], raw_file, label="shadow review raw file")
+    if source_errors or source_path is None:
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": source_errors,
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter refused an unsafe raw review locator.",
+            "missing_inputs": source_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter could not read raw review evidence.",
+            "missing_inputs": [f"shadow review raw file: {exc.strerror or exc}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    shadow_root.mkdir(parents=True, exist_ok=True)
+    raw_path.write_text(raw_text, encoding="utf-8")
+    normalized, normalization_errors = normalize_codex_app_review_text(
+        raw_text,
+        relative=relative_to_root(source_path, context["target_root"]),
+    )
+    if normalization_errors or normalized is None:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": normalization_errors,
+                "raw_source": relative_to_root(source_path, context["target_root"]),
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    default_findings: list[dict[str, Any]] = []
+    review_record_input = default_engine_payload.get("review_record_input")
+    if isinstance(review_record_input, dict):
+        default_findings_file = review_record_input.get("findings_file")
+        if isinstance(default_findings_file, str):
+            loaded_findings, _ = load_findings_file(context["target_root"], default_findings_file)
+            if isinstance(loaded_findings, list):
+                default_findings = loaded_findings
+    parity_diff = compare_review_findings(default_findings, normalized["findings"])
+    write_json_file(diff_path, parity_diff)
+    write_json_file(
+        metadata_path,
+        {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "pass",
+            "reviewed_head": reviewed_head,
+            "raw_source": relative_to_root(source_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "parity_diff": relative_to_root(diff_path, context["target_root"]),
+            "authoritative": False,
+            "summary": normalized["summary"],
+        },
+    )
+    return {
+        "adapter": adapter,
+        "result": "pass",
+        "summary": "Codex App review shadow evidence was captured and normalized for comparison only.",
+        "missing_inputs": [],
+        "blocking": False,
+        "authoritative": False,
+        "evidence": evidence,
+        "decision": normalized["decision"],
+        "parity_diff": parity_diff,
+    }
+
+
 def manual_review_payload(
     *,
     context: dict[str, Any],
@@ -11375,6 +11608,12 @@ def handle_review(args: argparse.Namespace) -> int:
             engine_profile,
             review_kind=review_kind,
         )
+        shadow_engine_payload = run_codex_app_review_shadow_adapter(
+            context,
+            adapter=args.shadow_engine_adapter,
+            raw_file=args.shadow_review_raw_file,
+            default_engine_payload=engine_payload,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")
@@ -11413,6 +11652,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),
             }

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/review-execution.md
@@ -55,6 +55,15 @@ Loom 把 review 分成四层：
 默认 engine 当前固定为 Codex。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
+阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+
+- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
+- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
+- shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
+- shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
+- shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -3079,6 +3079,26 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
                 failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+    shadow_engine = payload.get("shadow_engine")
+    if shadow_engine is not None:
+        if not isinstance(shadow_engine, dict):
+            failures.append(Failure(category, f"{context} shadow_engine must be an object when present"))
+        else:
+            if shadow_engine.get("adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} shadow_engine adapter must stay shadow-only `loom/codex-app-review`"))
+            if shadow_engine.get("result") not in {"pass", "block", "unavailable"}:
+                failures.append(Failure(category, f"{context} shadow_engine result must stay within the stable shadow contract"))
+            if shadow_engine.get("authoritative") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must declare authoritative=false"))
+            if shadow_engine.get("blocking") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must not block review or merge-ready"))
+            evidence = shadow_engine.get("evidence")
+            if not isinstance(evidence, dict):
+                failures.append(Failure(category, f"{context} shadow_engine must include runtime evidence locators"))
+            else:
+                for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    if not isinstance(evidence.get(key), str) or not evidence.get(key):
+                        failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
 
 
 def require_runtime_state_payload(
@@ -5716,6 +5736,114 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        shadow_target = Path(tmp) / "review-run-shadow"
+        prepare_review_target(shadow_target, "review run shadow adapter")
+        shadow_raw = shadow_target / ".loom/runtime/tmp/codex-app-review-raw.json"
+        shadow_raw.parent.mkdir(parents=True, exist_ok=True)
+        shadow_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "fallback",
+                    "summary": "Codex App reviewer produced shadow-only findings.",
+                    "findings": [
+                        {
+                            "id": "shadow-warn-1",
+                            "summary": "Codex App shadow review noted a comparison-only issue.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "deferred",
+                                "summary": "Shadow evidence must not author the formal review record.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+                "--shadow-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-raw.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow adapter",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must not replace default review_record_input engine adapter"))
+                shadow_engine = payload.get("shadow_engine") if isinstance(payload.get("shadow_engine"), dict) else {}
+                if shadow_engine.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must pass when raw review evidence is provided"))
+                evidence = shadow_engine.get("evidence") if isinstance(shadow_engine.get("evidence"), dict) else {}
+                for key in ("raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    value = evidence.get(key)
+                    if not isinstance(value, str) or not (shadow_target / value).exists():
+                        failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter must write {key} evidence"))
+                if shadow_engine.get("authoritative") is not False or shadow_engine.get("blocking") is not False:
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must stay non-authoritative and non-blocking"))
+
+        shadow_unavailable_target = Path(tmp) / "review-run-shadow-unavailable"
+        prepare_review_target(shadow_unavailable_target, "review run shadow unavailable")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_unavailable_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow unavailable failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow unavailable",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            shadow_engine = payload.get("shadow_engine") if isinstance(payload, dict) and isinstance(payload.get("shadow_engine"), dict) else {}
+            if shadow_engine.get("result") != "unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must not block the default review path"))
+            review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
+            if review_record_input.get("engine_adapter") != "loom/default-codex":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -5593,7 +5593,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         review_target = Path(tmp) / "new-project"
         fake_bin = Path(tmp) / "bin"
         fake_bin.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
         def prepare_review_target(target: Path, label: str) -> bool:
             shutil.copytree(source_snapshot, target)
@@ -6801,7 +6801,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             write_fake_codex(fake_bin / "codex", mode="success")
             installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
-            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
             def prepare_target(target: Path) -> tuple[str | None, list[str]]:
                 errors: list[str] = []

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,8 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -449,6 +451,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
     review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
+    review.add_argument(
+        "--shadow-engine-adapter",
+        choices=tuple(sorted(SHADOW_REVIEW_ADAPTERS)),
+        help="Optional shadow-only review adapter. Does not replace the default authoritative review engine.",
+    )
+    review.add_argument(
+        "--shadow-review-raw-file",
+        help="Optional repo-relative captured Codex App review text to normalize as shadow evidence.",
+    )
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -7115,6 +7126,228 @@ def normalize_engine_review_result(payload: Any, *, relative: str) -> tuple[dict
     }, []
 
 
+def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App review raw output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+        if normalized is not None and not errors:
+            return normalized, []
+
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+    summary = first_line[:240] if first_line else "Codex App review returned raw text."
+    return {
+        "decision": "fallback",
+        "summary": "Codex App review raw output was captured as shadow evidence and normalized for comparison only.",
+        "findings": [
+            {
+                "id": "codex-app-review-raw-output",
+                "summary": summary,
+                "severity": "warn",
+                "rebuttal": None,
+                "disposition": {
+                    "status": "deferred",
+                    "summary": "Shadow-only finding; formal disposition must still be authored through the single review record.",
+                },
+                "details": text[:4000],
+            }
+        ],
+    }, []
+
+
+def shadow_adapter_slug(adapter: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
+
+
+def compare_review_findings(default_findings: list[dict[str, Any]], shadow_findings: list[dict[str, Any]]) -> dict[str, Any]:
+    default_ids = {str(finding.get("id")) for finding in default_findings if isinstance(finding, dict) and finding.get("id")}
+    shadow_ids = {str(finding.get("id")) for finding in shadow_findings if isinstance(finding, dict) and finding.get("id")}
+    shared = sorted(default_ids & shadow_ids)
+    default_only = sorted(default_ids - shadow_ids)
+    shadow_only = sorted(shadow_ids - default_ids)
+    result = "match" if not default_only and not shadow_only else "difference"
+    return {
+        "schema_version": "loom-review-shadow-diff/v1",
+        "result": result,
+        "summary": (
+            "Shadow review findings match the default review finding ids."
+            if result == "match"
+            else "Shadow review findings differ from the default review finding ids."
+        ),
+        "default_finding_ids": sorted(default_ids),
+        "shadow_finding_ids": sorted(shadow_ids),
+        "shared_finding_ids": shared,
+        "default_only_finding_ids": default_only,
+        "shadow_only_finding_ids": shadow_only,
+    }
+
+
+def run_codex_app_review_shadow_adapter(
+    context: dict[str, Any],
+    *,
+    adapter: str | None,
+    raw_file: str | None,
+    default_engine_payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not adapter:
+        return None
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    shadow_root = runtime_root / "shadow" / shadow_adapter_slug(adapter)
+    raw_path = shadow_root / "raw-review.txt"
+    findings_path = shadow_root / "normalized-findings.json"
+    metadata_path = shadow_root / "metadata.json"
+    diff_path = shadow_root / "parity-diff.json"
+    evidence = {
+        "runtime_root": relative_to_root(shadow_root, context["target_root"]),
+        "raw_review": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "parity_diff": relative_to_root(diff_path, context["target_root"]),
+    }
+
+    if adapter != CODEX_APP_REVIEW_SHADOW_ADAPTER:
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Unsupported shadow review adapter.",
+            "missing_inputs": [f"unsupported shadow review adapter: {adapter}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    if not raw_file:
+        metadata = {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "unavailable",
+            "reviewed_head": reviewed_head,
+            "summary": "Codex App review shadow adapter requires captured raw review text or a future live app-server runner.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "authoritative": False,
+        }
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(metadata_path, metadata)
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Codex App review shadow adapter was requested but no raw review evidence was provided.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    source_path, source_errors = resolve_repo_relative_path(context["target_root"], raw_file, label="shadow review raw file")
+    if source_errors or source_path is None:
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": source_errors,
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter refused an unsafe raw review locator.",
+            "missing_inputs": source_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter could not read raw review evidence.",
+            "missing_inputs": [f"shadow review raw file: {exc.strerror or exc}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    shadow_root.mkdir(parents=True, exist_ok=True)
+    raw_path.write_text(raw_text, encoding="utf-8")
+    normalized, normalization_errors = normalize_codex_app_review_text(
+        raw_text,
+        relative=relative_to_root(source_path, context["target_root"]),
+    )
+    if normalization_errors or normalized is None:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": normalization_errors,
+                "raw_source": relative_to_root(source_path, context["target_root"]),
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    default_findings: list[dict[str, Any]] = []
+    review_record_input = default_engine_payload.get("review_record_input")
+    if isinstance(review_record_input, dict):
+        default_findings_file = review_record_input.get("findings_file")
+        if isinstance(default_findings_file, str):
+            loaded_findings, _ = load_findings_file(context["target_root"], default_findings_file)
+            if isinstance(loaded_findings, list):
+                default_findings = loaded_findings
+    parity_diff = compare_review_findings(default_findings, normalized["findings"])
+    write_json_file(diff_path, parity_diff)
+    write_json_file(
+        metadata_path,
+        {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "pass",
+            "reviewed_head": reviewed_head,
+            "raw_source": relative_to_root(source_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "parity_diff": relative_to_root(diff_path, context["target_root"]),
+            "authoritative": False,
+            "summary": normalized["summary"],
+        },
+    )
+    return {
+        "adapter": adapter,
+        "result": "pass",
+        "summary": "Codex App review shadow evidence was captured and normalized for comparison only.",
+        "missing_inputs": [],
+        "blocking": False,
+        "authoritative": False,
+        "evidence": evidence,
+        "decision": normalized["decision"],
+        "parity_diff": parity_diff,
+    }
+
+
 def manual_review_payload(
     *,
     context: dict[str, Any],
@@ -11375,6 +11608,12 @@ def handle_review(args: argparse.Namespace) -> int:
             engine_profile,
             review_kind=review_kind,
         )
+        shadow_engine_payload = run_codex_app_review_shadow_adapter(
+            context,
+            adapter=args.shadow_engine_adapter,
+            raw_file=args.shadow_review_raw_file,
+            default_engine_payload=engine_payload,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")
@@ -11413,6 +11652,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),
             }

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/review-execution.md
@@ -55,6 +55,15 @@ Loom 把 review 分成四层：
 默认 engine 当前固定为 Codex。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
+阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+
+- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
+- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
+- shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
+- shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
+- shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -3079,6 +3079,26 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
                 failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+    shadow_engine = payload.get("shadow_engine")
+    if shadow_engine is not None:
+        if not isinstance(shadow_engine, dict):
+            failures.append(Failure(category, f"{context} shadow_engine must be an object when present"))
+        else:
+            if shadow_engine.get("adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} shadow_engine adapter must stay shadow-only `loom/codex-app-review`"))
+            if shadow_engine.get("result") not in {"pass", "block", "unavailable"}:
+                failures.append(Failure(category, f"{context} shadow_engine result must stay within the stable shadow contract"))
+            if shadow_engine.get("authoritative") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must declare authoritative=false"))
+            if shadow_engine.get("blocking") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must not block review or merge-ready"))
+            evidence = shadow_engine.get("evidence")
+            if not isinstance(evidence, dict):
+                failures.append(Failure(category, f"{context} shadow_engine must include runtime evidence locators"))
+            else:
+                for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    if not isinstance(evidence.get(key), str) or not evidence.get(key):
+                        failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
 
 
 def require_runtime_state_payload(
@@ -5716,6 +5736,114 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        shadow_target = Path(tmp) / "review-run-shadow"
+        prepare_review_target(shadow_target, "review run shadow adapter")
+        shadow_raw = shadow_target / ".loom/runtime/tmp/codex-app-review-raw.json"
+        shadow_raw.parent.mkdir(parents=True, exist_ok=True)
+        shadow_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "fallback",
+                    "summary": "Codex App reviewer produced shadow-only findings.",
+                    "findings": [
+                        {
+                            "id": "shadow-warn-1",
+                            "summary": "Codex App shadow review noted a comparison-only issue.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "deferred",
+                                "summary": "Shadow evidence must not author the formal review record.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+                "--shadow-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-raw.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow adapter",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must not replace default review_record_input engine adapter"))
+                shadow_engine = payload.get("shadow_engine") if isinstance(payload.get("shadow_engine"), dict) else {}
+                if shadow_engine.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must pass when raw review evidence is provided"))
+                evidence = shadow_engine.get("evidence") if isinstance(shadow_engine.get("evidence"), dict) else {}
+                for key in ("raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    value = evidence.get(key)
+                    if not isinstance(value, str) or not (shadow_target / value).exists():
+                        failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter must write {key} evidence"))
+                if shadow_engine.get("authoritative") is not False or shadow_engine.get("blocking") is not False:
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must stay non-authoritative and non-blocking"))
+
+        shadow_unavailable_target = Path(tmp) / "review-run-shadow-unavailable"
+        prepare_review_target(shadow_unavailable_target, "review run shadow unavailable")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_unavailable_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow unavailable failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow unavailable",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            shadow_engine = payload.get("shadow_engine") if isinstance(payload, dict) and isinstance(payload.get("shadow_engine"), dict) else {}
+            if shadow_engine.get("result") != "unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must not block the default review path"))
+            review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
+            if review_record_input.get("engine_adapter") != "loom/default-codex":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -5593,7 +5593,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         review_target = Path(tmp) / "new-project"
         fake_bin = Path(tmp) / "bin"
         fake_bin.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
         def prepare_review_target(target: Path, label: str) -> bool:
             shutil.copytree(source_snapshot, target)
@@ -6801,7 +6801,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             write_fake_codex(fake_bin / "codex", mode="success")
             installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
-            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
             def prepare_target(target: Path) -> tuple[str | None, list[str]]:
                 errors: list[str] = []

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,8 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -449,6 +451,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
     review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
+    review.add_argument(
+        "--shadow-engine-adapter",
+        choices=tuple(sorted(SHADOW_REVIEW_ADAPTERS)),
+        help="Optional shadow-only review adapter. Does not replace the default authoritative review engine.",
+    )
+    review.add_argument(
+        "--shadow-review-raw-file",
+        help="Optional repo-relative captured Codex App review text to normalize as shadow evidence.",
+    )
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -7115,6 +7126,228 @@ def normalize_engine_review_result(payload: Any, *, relative: str) -> tuple[dict
     }, []
 
 
+def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App review raw output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+        if normalized is not None and not errors:
+            return normalized, []
+
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+    summary = first_line[:240] if first_line else "Codex App review returned raw text."
+    return {
+        "decision": "fallback",
+        "summary": "Codex App review raw output was captured as shadow evidence and normalized for comparison only.",
+        "findings": [
+            {
+                "id": "codex-app-review-raw-output",
+                "summary": summary,
+                "severity": "warn",
+                "rebuttal": None,
+                "disposition": {
+                    "status": "deferred",
+                    "summary": "Shadow-only finding; formal disposition must still be authored through the single review record.",
+                },
+                "details": text[:4000],
+            }
+        ],
+    }, []
+
+
+def shadow_adapter_slug(adapter: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
+
+
+def compare_review_findings(default_findings: list[dict[str, Any]], shadow_findings: list[dict[str, Any]]) -> dict[str, Any]:
+    default_ids = {str(finding.get("id")) for finding in default_findings if isinstance(finding, dict) and finding.get("id")}
+    shadow_ids = {str(finding.get("id")) for finding in shadow_findings if isinstance(finding, dict) and finding.get("id")}
+    shared = sorted(default_ids & shadow_ids)
+    default_only = sorted(default_ids - shadow_ids)
+    shadow_only = sorted(shadow_ids - default_ids)
+    result = "match" if not default_only and not shadow_only else "difference"
+    return {
+        "schema_version": "loom-review-shadow-diff/v1",
+        "result": result,
+        "summary": (
+            "Shadow review findings match the default review finding ids."
+            if result == "match"
+            else "Shadow review findings differ from the default review finding ids."
+        ),
+        "default_finding_ids": sorted(default_ids),
+        "shadow_finding_ids": sorted(shadow_ids),
+        "shared_finding_ids": shared,
+        "default_only_finding_ids": default_only,
+        "shadow_only_finding_ids": shadow_only,
+    }
+
+
+def run_codex_app_review_shadow_adapter(
+    context: dict[str, Any],
+    *,
+    adapter: str | None,
+    raw_file: str | None,
+    default_engine_payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not adapter:
+        return None
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    shadow_root = runtime_root / "shadow" / shadow_adapter_slug(adapter)
+    raw_path = shadow_root / "raw-review.txt"
+    findings_path = shadow_root / "normalized-findings.json"
+    metadata_path = shadow_root / "metadata.json"
+    diff_path = shadow_root / "parity-diff.json"
+    evidence = {
+        "runtime_root": relative_to_root(shadow_root, context["target_root"]),
+        "raw_review": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "parity_diff": relative_to_root(diff_path, context["target_root"]),
+    }
+
+    if adapter != CODEX_APP_REVIEW_SHADOW_ADAPTER:
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Unsupported shadow review adapter.",
+            "missing_inputs": [f"unsupported shadow review adapter: {adapter}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    if not raw_file:
+        metadata = {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "unavailable",
+            "reviewed_head": reviewed_head,
+            "summary": "Codex App review shadow adapter requires captured raw review text or a future live app-server runner.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "authoritative": False,
+        }
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(metadata_path, metadata)
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Codex App review shadow adapter was requested but no raw review evidence was provided.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    source_path, source_errors = resolve_repo_relative_path(context["target_root"], raw_file, label="shadow review raw file")
+    if source_errors or source_path is None:
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": source_errors,
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter refused an unsafe raw review locator.",
+            "missing_inputs": source_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter could not read raw review evidence.",
+            "missing_inputs": [f"shadow review raw file: {exc.strerror or exc}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    shadow_root.mkdir(parents=True, exist_ok=True)
+    raw_path.write_text(raw_text, encoding="utf-8")
+    normalized, normalization_errors = normalize_codex_app_review_text(
+        raw_text,
+        relative=relative_to_root(source_path, context["target_root"]),
+    )
+    if normalization_errors or normalized is None:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": normalization_errors,
+                "raw_source": relative_to_root(source_path, context["target_root"]),
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    default_findings: list[dict[str, Any]] = []
+    review_record_input = default_engine_payload.get("review_record_input")
+    if isinstance(review_record_input, dict):
+        default_findings_file = review_record_input.get("findings_file")
+        if isinstance(default_findings_file, str):
+            loaded_findings, _ = load_findings_file(context["target_root"], default_findings_file)
+            if isinstance(loaded_findings, list):
+                default_findings = loaded_findings
+    parity_diff = compare_review_findings(default_findings, normalized["findings"])
+    write_json_file(diff_path, parity_diff)
+    write_json_file(
+        metadata_path,
+        {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "pass",
+            "reviewed_head": reviewed_head,
+            "raw_source": relative_to_root(source_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "parity_diff": relative_to_root(diff_path, context["target_root"]),
+            "authoritative": False,
+            "summary": normalized["summary"],
+        },
+    )
+    return {
+        "adapter": adapter,
+        "result": "pass",
+        "summary": "Codex App review shadow evidence was captured and normalized for comparison only.",
+        "missing_inputs": [],
+        "blocking": False,
+        "authoritative": False,
+        "evidence": evidence,
+        "decision": normalized["decision"],
+        "parity_diff": parity_diff,
+    }
+
+
 def manual_review_payload(
     *,
     context: dict[str, Any],
@@ -11375,6 +11608,12 @@ def handle_review(args: argparse.Namespace) -> int:
             engine_profile,
             review_kind=review_kind,
         )
+        shadow_engine_payload = run_codex_app_review_shadow_adapter(
+            context,
+            adapter=args.shadow_engine_adapter,
+            raw_file=args.shadow_review_raw_file,
+            default_engine_payload=engine_payload,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")
@@ -11413,6 +11652,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),
             }

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/review-execution.md
@@ -55,6 +55,15 @@ Loom 把 review 分成四层：
 默认 engine 当前固定为 Codex。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
+阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+
+- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
+- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
+- shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
+- shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
+- shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -3079,6 +3079,26 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
                 failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+    shadow_engine = payload.get("shadow_engine")
+    if shadow_engine is not None:
+        if not isinstance(shadow_engine, dict):
+            failures.append(Failure(category, f"{context} shadow_engine must be an object when present"))
+        else:
+            if shadow_engine.get("adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} shadow_engine adapter must stay shadow-only `loom/codex-app-review`"))
+            if shadow_engine.get("result") not in {"pass", "block", "unavailable"}:
+                failures.append(Failure(category, f"{context} shadow_engine result must stay within the stable shadow contract"))
+            if shadow_engine.get("authoritative") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must declare authoritative=false"))
+            if shadow_engine.get("blocking") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must not block review or merge-ready"))
+            evidence = shadow_engine.get("evidence")
+            if not isinstance(evidence, dict):
+                failures.append(Failure(category, f"{context} shadow_engine must include runtime evidence locators"))
+            else:
+                for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    if not isinstance(evidence.get(key), str) or not evidence.get(key):
+                        failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
 
 
 def require_runtime_state_payload(
@@ -5716,6 +5736,114 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        shadow_target = Path(tmp) / "review-run-shadow"
+        prepare_review_target(shadow_target, "review run shadow adapter")
+        shadow_raw = shadow_target / ".loom/runtime/tmp/codex-app-review-raw.json"
+        shadow_raw.parent.mkdir(parents=True, exist_ok=True)
+        shadow_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "fallback",
+                    "summary": "Codex App reviewer produced shadow-only findings.",
+                    "findings": [
+                        {
+                            "id": "shadow-warn-1",
+                            "summary": "Codex App shadow review noted a comparison-only issue.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "deferred",
+                                "summary": "Shadow evidence must not author the formal review record.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+                "--shadow-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-raw.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow adapter",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must not replace default review_record_input engine adapter"))
+                shadow_engine = payload.get("shadow_engine") if isinstance(payload.get("shadow_engine"), dict) else {}
+                if shadow_engine.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must pass when raw review evidence is provided"))
+                evidence = shadow_engine.get("evidence") if isinstance(shadow_engine.get("evidence"), dict) else {}
+                for key in ("raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    value = evidence.get(key)
+                    if not isinstance(value, str) or not (shadow_target / value).exists():
+                        failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter must write {key} evidence"))
+                if shadow_engine.get("authoritative") is not False or shadow_engine.get("blocking") is not False:
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must stay non-authoritative and non-blocking"))
+
+        shadow_unavailable_target = Path(tmp) / "review-run-shadow-unavailable"
+        prepare_review_target(shadow_unavailable_target, "review run shadow unavailable")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_unavailable_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow unavailable failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow unavailable",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            shadow_engine = payload.get("shadow_engine") if isinstance(payload, dict) and isinstance(payload.get("shadow_engine"), dict) else {}
+            if shadow_engine.get("result") != "unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must not block the default review path"))
+            review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
+            if review_record_input.get("engine_adapter") != "loom/default-codex":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -5593,7 +5593,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         review_target = Path(tmp) / "new-project"
         fake_bin = Path(tmp) / "bin"
         fake_bin.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
         def prepare_review_target(target: Path, label: str) -> bool:
             shutil.copytree(source_snapshot, target)
@@ -6801,7 +6801,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             write_fake_codex(fake_bin / "codex", mode="success")
             installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
-            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
             def prepare_target(target: Path) -> tuple[str | None, list[str]]:
                 errors: list[str] = []

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,8 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -449,6 +451,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
     review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
+    review.add_argument(
+        "--shadow-engine-adapter",
+        choices=tuple(sorted(SHADOW_REVIEW_ADAPTERS)),
+        help="Optional shadow-only review adapter. Does not replace the default authoritative review engine.",
+    )
+    review.add_argument(
+        "--shadow-review-raw-file",
+        help="Optional repo-relative captured Codex App review text to normalize as shadow evidence.",
+    )
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -7115,6 +7126,228 @@ def normalize_engine_review_result(payload: Any, *, relative: str) -> tuple[dict
     }, []
 
 
+def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App review raw output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+        if normalized is not None and not errors:
+            return normalized, []
+
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+    summary = first_line[:240] if first_line else "Codex App review returned raw text."
+    return {
+        "decision": "fallback",
+        "summary": "Codex App review raw output was captured as shadow evidence and normalized for comparison only.",
+        "findings": [
+            {
+                "id": "codex-app-review-raw-output",
+                "summary": summary,
+                "severity": "warn",
+                "rebuttal": None,
+                "disposition": {
+                    "status": "deferred",
+                    "summary": "Shadow-only finding; formal disposition must still be authored through the single review record.",
+                },
+                "details": text[:4000],
+            }
+        ],
+    }, []
+
+
+def shadow_adapter_slug(adapter: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
+
+
+def compare_review_findings(default_findings: list[dict[str, Any]], shadow_findings: list[dict[str, Any]]) -> dict[str, Any]:
+    default_ids = {str(finding.get("id")) for finding in default_findings if isinstance(finding, dict) and finding.get("id")}
+    shadow_ids = {str(finding.get("id")) for finding in shadow_findings if isinstance(finding, dict) and finding.get("id")}
+    shared = sorted(default_ids & shadow_ids)
+    default_only = sorted(default_ids - shadow_ids)
+    shadow_only = sorted(shadow_ids - default_ids)
+    result = "match" if not default_only and not shadow_only else "difference"
+    return {
+        "schema_version": "loom-review-shadow-diff/v1",
+        "result": result,
+        "summary": (
+            "Shadow review findings match the default review finding ids."
+            if result == "match"
+            else "Shadow review findings differ from the default review finding ids."
+        ),
+        "default_finding_ids": sorted(default_ids),
+        "shadow_finding_ids": sorted(shadow_ids),
+        "shared_finding_ids": shared,
+        "default_only_finding_ids": default_only,
+        "shadow_only_finding_ids": shadow_only,
+    }
+
+
+def run_codex_app_review_shadow_adapter(
+    context: dict[str, Any],
+    *,
+    adapter: str | None,
+    raw_file: str | None,
+    default_engine_payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not adapter:
+        return None
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    shadow_root = runtime_root / "shadow" / shadow_adapter_slug(adapter)
+    raw_path = shadow_root / "raw-review.txt"
+    findings_path = shadow_root / "normalized-findings.json"
+    metadata_path = shadow_root / "metadata.json"
+    diff_path = shadow_root / "parity-diff.json"
+    evidence = {
+        "runtime_root": relative_to_root(shadow_root, context["target_root"]),
+        "raw_review": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "parity_diff": relative_to_root(diff_path, context["target_root"]),
+    }
+
+    if adapter != CODEX_APP_REVIEW_SHADOW_ADAPTER:
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Unsupported shadow review adapter.",
+            "missing_inputs": [f"unsupported shadow review adapter: {adapter}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    if not raw_file:
+        metadata = {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "unavailable",
+            "reviewed_head": reviewed_head,
+            "summary": "Codex App review shadow adapter requires captured raw review text or a future live app-server runner.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "authoritative": False,
+        }
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(metadata_path, metadata)
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Codex App review shadow adapter was requested but no raw review evidence was provided.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    source_path, source_errors = resolve_repo_relative_path(context["target_root"], raw_file, label="shadow review raw file")
+    if source_errors or source_path is None:
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": source_errors,
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter refused an unsafe raw review locator.",
+            "missing_inputs": source_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter could not read raw review evidence.",
+            "missing_inputs": [f"shadow review raw file: {exc.strerror or exc}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    shadow_root.mkdir(parents=True, exist_ok=True)
+    raw_path.write_text(raw_text, encoding="utf-8")
+    normalized, normalization_errors = normalize_codex_app_review_text(
+        raw_text,
+        relative=relative_to_root(source_path, context["target_root"]),
+    )
+    if normalization_errors or normalized is None:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": normalization_errors,
+                "raw_source": relative_to_root(source_path, context["target_root"]),
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    default_findings: list[dict[str, Any]] = []
+    review_record_input = default_engine_payload.get("review_record_input")
+    if isinstance(review_record_input, dict):
+        default_findings_file = review_record_input.get("findings_file")
+        if isinstance(default_findings_file, str):
+            loaded_findings, _ = load_findings_file(context["target_root"], default_findings_file)
+            if isinstance(loaded_findings, list):
+                default_findings = loaded_findings
+    parity_diff = compare_review_findings(default_findings, normalized["findings"])
+    write_json_file(diff_path, parity_diff)
+    write_json_file(
+        metadata_path,
+        {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "pass",
+            "reviewed_head": reviewed_head,
+            "raw_source": relative_to_root(source_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "parity_diff": relative_to_root(diff_path, context["target_root"]),
+            "authoritative": False,
+            "summary": normalized["summary"],
+        },
+    )
+    return {
+        "adapter": adapter,
+        "result": "pass",
+        "summary": "Codex App review shadow evidence was captured and normalized for comparison only.",
+        "missing_inputs": [],
+        "blocking": False,
+        "authoritative": False,
+        "evidence": evidence,
+        "decision": normalized["decision"],
+        "parity_diff": parity_diff,
+    }
+
+
 def manual_review_payload(
     *,
     context: dict[str, Any],
@@ -11375,6 +11608,12 @@ def handle_review(args: argparse.Namespace) -> int:
             engine_profile,
             review_kind=review_kind,
         )
+        shadow_engine_payload = run_codex_app_review_shadow_adapter(
+            context,
+            adapter=args.shadow_engine_adapter,
+            raw_file=args.shadow_review_raw_file,
+            default_engine_payload=engine_payload,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")
@@ -11413,6 +11652,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),
             }

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/review-execution.md
@@ -55,6 +55,15 @@ Loom 把 review 分成四层：
 默认 engine 当前固定为 Codex。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
+阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+
+- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
+- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
+- shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
+- shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
+- shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -3079,6 +3079,26 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
                 failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+    shadow_engine = payload.get("shadow_engine")
+    if shadow_engine is not None:
+        if not isinstance(shadow_engine, dict):
+            failures.append(Failure(category, f"{context} shadow_engine must be an object when present"))
+        else:
+            if shadow_engine.get("adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} shadow_engine adapter must stay shadow-only `loom/codex-app-review`"))
+            if shadow_engine.get("result") not in {"pass", "block", "unavailable"}:
+                failures.append(Failure(category, f"{context} shadow_engine result must stay within the stable shadow contract"))
+            if shadow_engine.get("authoritative") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must declare authoritative=false"))
+            if shadow_engine.get("blocking") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must not block review or merge-ready"))
+            evidence = shadow_engine.get("evidence")
+            if not isinstance(evidence, dict):
+                failures.append(Failure(category, f"{context} shadow_engine must include runtime evidence locators"))
+            else:
+                for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    if not isinstance(evidence.get(key), str) or not evidence.get(key):
+                        failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
 
 
 def require_runtime_state_payload(
@@ -5716,6 +5736,114 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        shadow_target = Path(tmp) / "review-run-shadow"
+        prepare_review_target(shadow_target, "review run shadow adapter")
+        shadow_raw = shadow_target / ".loom/runtime/tmp/codex-app-review-raw.json"
+        shadow_raw.parent.mkdir(parents=True, exist_ok=True)
+        shadow_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "fallback",
+                    "summary": "Codex App reviewer produced shadow-only findings.",
+                    "findings": [
+                        {
+                            "id": "shadow-warn-1",
+                            "summary": "Codex App shadow review noted a comparison-only issue.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "deferred",
+                                "summary": "Shadow evidence must not author the formal review record.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+                "--shadow-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-raw.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow adapter",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must not replace default review_record_input engine adapter"))
+                shadow_engine = payload.get("shadow_engine") if isinstance(payload.get("shadow_engine"), dict) else {}
+                if shadow_engine.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must pass when raw review evidence is provided"))
+                evidence = shadow_engine.get("evidence") if isinstance(shadow_engine.get("evidence"), dict) else {}
+                for key in ("raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    value = evidence.get(key)
+                    if not isinstance(value, str) or not (shadow_target / value).exists():
+                        failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter must write {key} evidence"))
+                if shadow_engine.get("authoritative") is not False or shadow_engine.get("blocking") is not False:
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must stay non-authoritative and non-blocking"))
+
+        shadow_unavailable_target = Path(tmp) / "review-run-shadow-unavailable"
+        prepare_review_target(shadow_unavailable_target, "review run shadow unavailable")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_unavailable_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow unavailable failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow unavailable",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            shadow_engine = payload.get("shadow_engine") if isinstance(payload, dict) and isinstance(payload.get("shadow_engine"), dict) else {}
+            if shadow_engine.get("result") != "unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must not block the default review path"))
+            review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
+            if review_record_input.get("engine_adapter") != "loom/default-codex":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -5593,7 +5593,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         review_target = Path(tmp) / "new-project"
         fake_bin = Path(tmp) / "bin"
         fake_bin.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
         def prepare_review_target(target: Path, label: str) -> bool:
             shutil.copytree(source_snapshot, target)
@@ -6801,7 +6801,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             write_fake_codex(fake_bin / "codex", mode="success")
             installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
-            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
             def prepare_target(target: Path) -> tuple[str | None, list[str]]:
                 errors: list[str] = []

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,8 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -449,6 +451,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
     review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
+    review.add_argument(
+        "--shadow-engine-adapter",
+        choices=tuple(sorted(SHADOW_REVIEW_ADAPTERS)),
+        help="Optional shadow-only review adapter. Does not replace the default authoritative review engine.",
+    )
+    review.add_argument(
+        "--shadow-review-raw-file",
+        help="Optional repo-relative captured Codex App review text to normalize as shadow evidence.",
+    )
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -7115,6 +7126,228 @@ def normalize_engine_review_result(payload: Any, *, relative: str) -> tuple[dict
     }, []
 
 
+def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App review raw output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+        if normalized is not None and not errors:
+            return normalized, []
+
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+    summary = first_line[:240] if first_line else "Codex App review returned raw text."
+    return {
+        "decision": "fallback",
+        "summary": "Codex App review raw output was captured as shadow evidence and normalized for comparison only.",
+        "findings": [
+            {
+                "id": "codex-app-review-raw-output",
+                "summary": summary,
+                "severity": "warn",
+                "rebuttal": None,
+                "disposition": {
+                    "status": "deferred",
+                    "summary": "Shadow-only finding; formal disposition must still be authored through the single review record.",
+                },
+                "details": text[:4000],
+            }
+        ],
+    }, []
+
+
+def shadow_adapter_slug(adapter: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
+
+
+def compare_review_findings(default_findings: list[dict[str, Any]], shadow_findings: list[dict[str, Any]]) -> dict[str, Any]:
+    default_ids = {str(finding.get("id")) for finding in default_findings if isinstance(finding, dict) and finding.get("id")}
+    shadow_ids = {str(finding.get("id")) for finding in shadow_findings if isinstance(finding, dict) and finding.get("id")}
+    shared = sorted(default_ids & shadow_ids)
+    default_only = sorted(default_ids - shadow_ids)
+    shadow_only = sorted(shadow_ids - default_ids)
+    result = "match" if not default_only and not shadow_only else "difference"
+    return {
+        "schema_version": "loom-review-shadow-diff/v1",
+        "result": result,
+        "summary": (
+            "Shadow review findings match the default review finding ids."
+            if result == "match"
+            else "Shadow review findings differ from the default review finding ids."
+        ),
+        "default_finding_ids": sorted(default_ids),
+        "shadow_finding_ids": sorted(shadow_ids),
+        "shared_finding_ids": shared,
+        "default_only_finding_ids": default_only,
+        "shadow_only_finding_ids": shadow_only,
+    }
+
+
+def run_codex_app_review_shadow_adapter(
+    context: dict[str, Any],
+    *,
+    adapter: str | None,
+    raw_file: str | None,
+    default_engine_payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not adapter:
+        return None
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    shadow_root = runtime_root / "shadow" / shadow_adapter_slug(adapter)
+    raw_path = shadow_root / "raw-review.txt"
+    findings_path = shadow_root / "normalized-findings.json"
+    metadata_path = shadow_root / "metadata.json"
+    diff_path = shadow_root / "parity-diff.json"
+    evidence = {
+        "runtime_root": relative_to_root(shadow_root, context["target_root"]),
+        "raw_review": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "parity_diff": relative_to_root(diff_path, context["target_root"]),
+    }
+
+    if adapter != CODEX_APP_REVIEW_SHADOW_ADAPTER:
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Unsupported shadow review adapter.",
+            "missing_inputs": [f"unsupported shadow review adapter: {adapter}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    if not raw_file:
+        metadata = {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "unavailable",
+            "reviewed_head": reviewed_head,
+            "summary": "Codex App review shadow adapter requires captured raw review text or a future live app-server runner.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "authoritative": False,
+        }
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(metadata_path, metadata)
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Codex App review shadow adapter was requested but no raw review evidence was provided.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    source_path, source_errors = resolve_repo_relative_path(context["target_root"], raw_file, label="shadow review raw file")
+    if source_errors or source_path is None:
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": source_errors,
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter refused an unsafe raw review locator.",
+            "missing_inputs": source_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter could not read raw review evidence.",
+            "missing_inputs": [f"shadow review raw file: {exc.strerror or exc}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    shadow_root.mkdir(parents=True, exist_ok=True)
+    raw_path.write_text(raw_text, encoding="utf-8")
+    normalized, normalization_errors = normalize_codex_app_review_text(
+        raw_text,
+        relative=relative_to_root(source_path, context["target_root"]),
+    )
+    if normalization_errors or normalized is None:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": normalization_errors,
+                "raw_source": relative_to_root(source_path, context["target_root"]),
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    default_findings: list[dict[str, Any]] = []
+    review_record_input = default_engine_payload.get("review_record_input")
+    if isinstance(review_record_input, dict):
+        default_findings_file = review_record_input.get("findings_file")
+        if isinstance(default_findings_file, str):
+            loaded_findings, _ = load_findings_file(context["target_root"], default_findings_file)
+            if isinstance(loaded_findings, list):
+                default_findings = loaded_findings
+    parity_diff = compare_review_findings(default_findings, normalized["findings"])
+    write_json_file(diff_path, parity_diff)
+    write_json_file(
+        metadata_path,
+        {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "pass",
+            "reviewed_head": reviewed_head,
+            "raw_source": relative_to_root(source_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "parity_diff": relative_to_root(diff_path, context["target_root"]),
+            "authoritative": False,
+            "summary": normalized["summary"],
+        },
+    )
+    return {
+        "adapter": adapter,
+        "result": "pass",
+        "summary": "Codex App review shadow evidence was captured and normalized for comparison only.",
+        "missing_inputs": [],
+        "blocking": False,
+        "authoritative": False,
+        "evidence": evidence,
+        "decision": normalized["decision"],
+        "parity_diff": parity_diff,
+    }
+
+
 def manual_review_payload(
     *,
     context: dict[str, Any],
@@ -11375,6 +11608,12 @@ def handle_review(args: argparse.Namespace) -> int:
             engine_profile,
             review_kind=review_kind,
         )
+        shadow_engine_payload = run_codex_app_review_shadow_adapter(
+            context,
+            adapter=args.shadow_engine_adapter,
+            raw_file=args.shadow_review_raw_file,
+            default_engine_payload=engine_payload,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")
@@ -11413,6 +11652,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),
             }

--- a/skills/loom-review/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/review-execution.md
@@ -55,6 +55,15 @@ Loom 把 review 分成四层：
 默认 engine 当前固定为 Codex。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
+阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+
+- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
+- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
+- shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
+- shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
+- shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -3079,6 +3079,26 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
                 failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+    shadow_engine = payload.get("shadow_engine")
+    if shadow_engine is not None:
+        if not isinstance(shadow_engine, dict):
+            failures.append(Failure(category, f"{context} shadow_engine must be an object when present"))
+        else:
+            if shadow_engine.get("adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} shadow_engine adapter must stay shadow-only `loom/codex-app-review`"))
+            if shadow_engine.get("result") not in {"pass", "block", "unavailable"}:
+                failures.append(Failure(category, f"{context} shadow_engine result must stay within the stable shadow contract"))
+            if shadow_engine.get("authoritative") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must declare authoritative=false"))
+            if shadow_engine.get("blocking") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must not block review or merge-ready"))
+            evidence = shadow_engine.get("evidence")
+            if not isinstance(evidence, dict):
+                failures.append(Failure(category, f"{context} shadow_engine must include runtime evidence locators"))
+            else:
+                for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    if not isinstance(evidence.get(key), str) or not evidence.get(key):
+                        failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
 
 
 def require_runtime_state_payload(
@@ -5716,6 +5736,114 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        shadow_target = Path(tmp) / "review-run-shadow"
+        prepare_review_target(shadow_target, "review run shadow adapter")
+        shadow_raw = shadow_target / ".loom/runtime/tmp/codex-app-review-raw.json"
+        shadow_raw.parent.mkdir(parents=True, exist_ok=True)
+        shadow_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "fallback",
+                    "summary": "Codex App reviewer produced shadow-only findings.",
+                    "findings": [
+                        {
+                            "id": "shadow-warn-1",
+                            "summary": "Codex App shadow review noted a comparison-only issue.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "deferred",
+                                "summary": "Shadow evidence must not author the formal review record.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+                "--shadow-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-raw.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow adapter",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must not replace default review_record_input engine adapter"))
+                shadow_engine = payload.get("shadow_engine") if isinstance(payload.get("shadow_engine"), dict) else {}
+                if shadow_engine.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must pass when raw review evidence is provided"))
+                evidence = shadow_engine.get("evidence") if isinstance(shadow_engine.get("evidence"), dict) else {}
+                for key in ("raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    value = evidence.get(key)
+                    if not isinstance(value, str) or not (shadow_target / value).exists():
+                        failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter must write {key} evidence"))
+                if shadow_engine.get("authoritative") is not False or shadow_engine.get("blocking") is not False:
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must stay non-authoritative and non-blocking"))
+
+        shadow_unavailable_target = Path(tmp) / "review-run-shadow-unavailable"
+        prepare_review_target(shadow_unavailable_target, "review run shadow unavailable")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_unavailable_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow unavailable failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow unavailable",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            shadow_engine = payload.get("shadow_engine") if isinstance(payload, dict) and isinstance(payload.get("shadow_engine"), dict) else {}
+            if shadow_engine.get("result") != "unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must not block the default review path"))
+            review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
+            if review_record_input.get("engine_adapter") != "loom/default-codex":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -5593,7 +5593,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         review_target = Path(tmp) / "new-project"
         fake_bin = Path(tmp) / "bin"
         fake_bin.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
         def prepare_review_target(target: Path, label: str) -> bool:
             shutil.copytree(source_snapshot, target)
@@ -6801,7 +6801,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             write_fake_codex(fake_bin / "codex", mode="success")
             installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
-            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
             def prepare_target(target: Path) -> tuple[str | None, list[str]]:
                 errors: list[str] = []

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,8 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -449,6 +451,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
     review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
+    review.add_argument(
+        "--shadow-engine-adapter",
+        choices=tuple(sorted(SHADOW_REVIEW_ADAPTERS)),
+        help="Optional shadow-only review adapter. Does not replace the default authoritative review engine.",
+    )
+    review.add_argument(
+        "--shadow-review-raw-file",
+        help="Optional repo-relative captured Codex App review text to normalize as shadow evidence.",
+    )
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -7115,6 +7126,228 @@ def normalize_engine_review_result(payload: Any, *, relative: str) -> tuple[dict
     }, []
 
 
+def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App review raw output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+        if normalized is not None and not errors:
+            return normalized, []
+
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+    summary = first_line[:240] if first_line else "Codex App review returned raw text."
+    return {
+        "decision": "fallback",
+        "summary": "Codex App review raw output was captured as shadow evidence and normalized for comparison only.",
+        "findings": [
+            {
+                "id": "codex-app-review-raw-output",
+                "summary": summary,
+                "severity": "warn",
+                "rebuttal": None,
+                "disposition": {
+                    "status": "deferred",
+                    "summary": "Shadow-only finding; formal disposition must still be authored through the single review record.",
+                },
+                "details": text[:4000],
+            }
+        ],
+    }, []
+
+
+def shadow_adapter_slug(adapter: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
+
+
+def compare_review_findings(default_findings: list[dict[str, Any]], shadow_findings: list[dict[str, Any]]) -> dict[str, Any]:
+    default_ids = {str(finding.get("id")) for finding in default_findings if isinstance(finding, dict) and finding.get("id")}
+    shadow_ids = {str(finding.get("id")) for finding in shadow_findings if isinstance(finding, dict) and finding.get("id")}
+    shared = sorted(default_ids & shadow_ids)
+    default_only = sorted(default_ids - shadow_ids)
+    shadow_only = sorted(shadow_ids - default_ids)
+    result = "match" if not default_only and not shadow_only else "difference"
+    return {
+        "schema_version": "loom-review-shadow-diff/v1",
+        "result": result,
+        "summary": (
+            "Shadow review findings match the default review finding ids."
+            if result == "match"
+            else "Shadow review findings differ from the default review finding ids."
+        ),
+        "default_finding_ids": sorted(default_ids),
+        "shadow_finding_ids": sorted(shadow_ids),
+        "shared_finding_ids": shared,
+        "default_only_finding_ids": default_only,
+        "shadow_only_finding_ids": shadow_only,
+    }
+
+
+def run_codex_app_review_shadow_adapter(
+    context: dict[str, Any],
+    *,
+    adapter: str | None,
+    raw_file: str | None,
+    default_engine_payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not adapter:
+        return None
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    shadow_root = runtime_root / "shadow" / shadow_adapter_slug(adapter)
+    raw_path = shadow_root / "raw-review.txt"
+    findings_path = shadow_root / "normalized-findings.json"
+    metadata_path = shadow_root / "metadata.json"
+    diff_path = shadow_root / "parity-diff.json"
+    evidence = {
+        "runtime_root": relative_to_root(shadow_root, context["target_root"]),
+        "raw_review": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "parity_diff": relative_to_root(diff_path, context["target_root"]),
+    }
+
+    if adapter != CODEX_APP_REVIEW_SHADOW_ADAPTER:
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Unsupported shadow review adapter.",
+            "missing_inputs": [f"unsupported shadow review adapter: {adapter}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    if not raw_file:
+        metadata = {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "unavailable",
+            "reviewed_head": reviewed_head,
+            "summary": "Codex App review shadow adapter requires captured raw review text or a future live app-server runner.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "authoritative": False,
+        }
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(metadata_path, metadata)
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Codex App review shadow adapter was requested but no raw review evidence was provided.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    source_path, source_errors = resolve_repo_relative_path(context["target_root"], raw_file, label="shadow review raw file")
+    if source_errors or source_path is None:
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": source_errors,
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter refused an unsafe raw review locator.",
+            "missing_inputs": source_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter could not read raw review evidence.",
+            "missing_inputs": [f"shadow review raw file: {exc.strerror or exc}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    shadow_root.mkdir(parents=True, exist_ok=True)
+    raw_path.write_text(raw_text, encoding="utf-8")
+    normalized, normalization_errors = normalize_codex_app_review_text(
+        raw_text,
+        relative=relative_to_root(source_path, context["target_root"]),
+    )
+    if normalization_errors or normalized is None:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": normalization_errors,
+                "raw_source": relative_to_root(source_path, context["target_root"]),
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    default_findings: list[dict[str, Any]] = []
+    review_record_input = default_engine_payload.get("review_record_input")
+    if isinstance(review_record_input, dict):
+        default_findings_file = review_record_input.get("findings_file")
+        if isinstance(default_findings_file, str):
+            loaded_findings, _ = load_findings_file(context["target_root"], default_findings_file)
+            if isinstance(loaded_findings, list):
+                default_findings = loaded_findings
+    parity_diff = compare_review_findings(default_findings, normalized["findings"])
+    write_json_file(diff_path, parity_diff)
+    write_json_file(
+        metadata_path,
+        {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "pass",
+            "reviewed_head": reviewed_head,
+            "raw_source": relative_to_root(source_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "parity_diff": relative_to_root(diff_path, context["target_root"]),
+            "authoritative": False,
+            "summary": normalized["summary"],
+        },
+    )
+    return {
+        "adapter": adapter,
+        "result": "pass",
+        "summary": "Codex App review shadow evidence was captured and normalized for comparison only.",
+        "missing_inputs": [],
+        "blocking": False,
+        "authoritative": False,
+        "evidence": evidence,
+        "decision": normalized["decision"],
+        "parity_diff": parity_diff,
+    }
+
+
 def manual_review_payload(
     *,
     context: dict[str, Any],
@@ -11375,6 +11608,12 @@ def handle_review(args: argparse.Namespace) -> int:
             engine_profile,
             review_kind=review_kind,
         )
+        shadow_engine_payload = run_codex_app_review_shadow_adapter(
+            context,
+            adapter=args.shadow_engine_adapter,
+            raw_file=args.shadow_review_raw_file,
+            default_engine_payload=engine_payload,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")
@@ -11413,6 +11652,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),
             }

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/review-execution.md
@@ -55,6 +55,15 @@ Loom 把 review 分成四层：
 默认 engine 当前固定为 Codex。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
+阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+
+- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
+- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
+- shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
+- shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
+- shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -3079,6 +3079,26 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
                 failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+    shadow_engine = payload.get("shadow_engine")
+    if shadow_engine is not None:
+        if not isinstance(shadow_engine, dict):
+            failures.append(Failure(category, f"{context} shadow_engine must be an object when present"))
+        else:
+            if shadow_engine.get("adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} shadow_engine adapter must stay shadow-only `loom/codex-app-review`"))
+            if shadow_engine.get("result") not in {"pass", "block", "unavailable"}:
+                failures.append(Failure(category, f"{context} shadow_engine result must stay within the stable shadow contract"))
+            if shadow_engine.get("authoritative") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must declare authoritative=false"))
+            if shadow_engine.get("blocking") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must not block review or merge-ready"))
+            evidence = shadow_engine.get("evidence")
+            if not isinstance(evidence, dict):
+                failures.append(Failure(category, f"{context} shadow_engine must include runtime evidence locators"))
+            else:
+                for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    if not isinstance(evidence.get(key), str) or not evidence.get(key):
+                        failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
 
 
 def require_runtime_state_payload(
@@ -5716,6 +5736,114 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        shadow_target = Path(tmp) / "review-run-shadow"
+        prepare_review_target(shadow_target, "review run shadow adapter")
+        shadow_raw = shadow_target / ".loom/runtime/tmp/codex-app-review-raw.json"
+        shadow_raw.parent.mkdir(parents=True, exist_ok=True)
+        shadow_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "fallback",
+                    "summary": "Codex App reviewer produced shadow-only findings.",
+                    "findings": [
+                        {
+                            "id": "shadow-warn-1",
+                            "summary": "Codex App shadow review noted a comparison-only issue.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "deferred",
+                                "summary": "Shadow evidence must not author the formal review record.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+                "--shadow-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-raw.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow adapter",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must not replace default review_record_input engine adapter"))
+                shadow_engine = payload.get("shadow_engine") if isinstance(payload.get("shadow_engine"), dict) else {}
+                if shadow_engine.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must pass when raw review evidence is provided"))
+                evidence = shadow_engine.get("evidence") if isinstance(shadow_engine.get("evidence"), dict) else {}
+                for key in ("raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    value = evidence.get(key)
+                    if not isinstance(value, str) or not (shadow_target / value).exists():
+                        failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter must write {key} evidence"))
+                if shadow_engine.get("authoritative") is not False or shadow_engine.get("blocking") is not False:
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must stay non-authoritative and non-blocking"))
+
+        shadow_unavailable_target = Path(tmp) / "review-run-shadow-unavailable"
+        prepare_review_target(shadow_unavailable_target, "review run shadow unavailable")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_unavailable_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow unavailable failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow unavailable",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            shadow_engine = payload.get("shadow_engine") if isinstance(payload, dict) and isinstance(payload.get("shadow_engine"), dict) else {}
+            if shadow_engine.get("result") != "unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must not block the default review path"))
+            review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
+            if review_record_input.get("engine_adapter") != "loom/default-codex":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -5593,7 +5593,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         review_target = Path(tmp) / "new-project"
         fake_bin = Path(tmp) / "bin"
         fake_bin.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
         def prepare_review_target(target: Path, label: str) -> bool:
             shutil.copytree(source_snapshot, target)
@@ -6801,7 +6801,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             write_fake_codex(fake_bin / "codex", mode="success")
             installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
-            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
             def prepare_target(target: Path) -> tuple[str | None, list[str]]:
                 errors: list[str] = []

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,8 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -449,6 +451,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
     review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
+    review.add_argument(
+        "--shadow-engine-adapter",
+        choices=tuple(sorted(SHADOW_REVIEW_ADAPTERS)),
+        help="Optional shadow-only review adapter. Does not replace the default authoritative review engine.",
+    )
+    review.add_argument(
+        "--shadow-review-raw-file",
+        help="Optional repo-relative captured Codex App review text to normalize as shadow evidence.",
+    )
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -7115,6 +7126,228 @@ def normalize_engine_review_result(payload: Any, *, relative: str) -> tuple[dict
     }, []
 
 
+def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App review raw output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+        if normalized is not None and not errors:
+            return normalized, []
+
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+    summary = first_line[:240] if first_line else "Codex App review returned raw text."
+    return {
+        "decision": "fallback",
+        "summary": "Codex App review raw output was captured as shadow evidence and normalized for comparison only.",
+        "findings": [
+            {
+                "id": "codex-app-review-raw-output",
+                "summary": summary,
+                "severity": "warn",
+                "rebuttal": None,
+                "disposition": {
+                    "status": "deferred",
+                    "summary": "Shadow-only finding; formal disposition must still be authored through the single review record.",
+                },
+                "details": text[:4000],
+            }
+        ],
+    }, []
+
+
+def shadow_adapter_slug(adapter: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
+
+
+def compare_review_findings(default_findings: list[dict[str, Any]], shadow_findings: list[dict[str, Any]]) -> dict[str, Any]:
+    default_ids = {str(finding.get("id")) for finding in default_findings if isinstance(finding, dict) and finding.get("id")}
+    shadow_ids = {str(finding.get("id")) for finding in shadow_findings if isinstance(finding, dict) and finding.get("id")}
+    shared = sorted(default_ids & shadow_ids)
+    default_only = sorted(default_ids - shadow_ids)
+    shadow_only = sorted(shadow_ids - default_ids)
+    result = "match" if not default_only and not shadow_only else "difference"
+    return {
+        "schema_version": "loom-review-shadow-diff/v1",
+        "result": result,
+        "summary": (
+            "Shadow review findings match the default review finding ids."
+            if result == "match"
+            else "Shadow review findings differ from the default review finding ids."
+        ),
+        "default_finding_ids": sorted(default_ids),
+        "shadow_finding_ids": sorted(shadow_ids),
+        "shared_finding_ids": shared,
+        "default_only_finding_ids": default_only,
+        "shadow_only_finding_ids": shadow_only,
+    }
+
+
+def run_codex_app_review_shadow_adapter(
+    context: dict[str, Any],
+    *,
+    adapter: str | None,
+    raw_file: str | None,
+    default_engine_payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not adapter:
+        return None
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    shadow_root = runtime_root / "shadow" / shadow_adapter_slug(adapter)
+    raw_path = shadow_root / "raw-review.txt"
+    findings_path = shadow_root / "normalized-findings.json"
+    metadata_path = shadow_root / "metadata.json"
+    diff_path = shadow_root / "parity-diff.json"
+    evidence = {
+        "runtime_root": relative_to_root(shadow_root, context["target_root"]),
+        "raw_review": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "parity_diff": relative_to_root(diff_path, context["target_root"]),
+    }
+
+    if adapter != CODEX_APP_REVIEW_SHADOW_ADAPTER:
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Unsupported shadow review adapter.",
+            "missing_inputs": [f"unsupported shadow review adapter: {adapter}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    if not raw_file:
+        metadata = {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "unavailable",
+            "reviewed_head": reviewed_head,
+            "summary": "Codex App review shadow adapter requires captured raw review text or a future live app-server runner.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "authoritative": False,
+        }
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(metadata_path, metadata)
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Codex App review shadow adapter was requested but no raw review evidence was provided.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    source_path, source_errors = resolve_repo_relative_path(context["target_root"], raw_file, label="shadow review raw file")
+    if source_errors or source_path is None:
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": source_errors,
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter refused an unsafe raw review locator.",
+            "missing_inputs": source_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter could not read raw review evidence.",
+            "missing_inputs": [f"shadow review raw file: {exc.strerror or exc}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    shadow_root.mkdir(parents=True, exist_ok=True)
+    raw_path.write_text(raw_text, encoding="utf-8")
+    normalized, normalization_errors = normalize_codex_app_review_text(
+        raw_text,
+        relative=relative_to_root(source_path, context["target_root"]),
+    )
+    if normalization_errors or normalized is None:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": normalization_errors,
+                "raw_source": relative_to_root(source_path, context["target_root"]),
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    default_findings: list[dict[str, Any]] = []
+    review_record_input = default_engine_payload.get("review_record_input")
+    if isinstance(review_record_input, dict):
+        default_findings_file = review_record_input.get("findings_file")
+        if isinstance(default_findings_file, str):
+            loaded_findings, _ = load_findings_file(context["target_root"], default_findings_file)
+            if isinstance(loaded_findings, list):
+                default_findings = loaded_findings
+    parity_diff = compare_review_findings(default_findings, normalized["findings"])
+    write_json_file(diff_path, parity_diff)
+    write_json_file(
+        metadata_path,
+        {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "pass",
+            "reviewed_head": reviewed_head,
+            "raw_source": relative_to_root(source_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "parity_diff": relative_to_root(diff_path, context["target_root"]),
+            "authoritative": False,
+            "summary": normalized["summary"],
+        },
+    )
+    return {
+        "adapter": adapter,
+        "result": "pass",
+        "summary": "Codex App review shadow evidence was captured and normalized for comparison only.",
+        "missing_inputs": [],
+        "blocking": False,
+        "authoritative": False,
+        "evidence": evidence,
+        "decision": normalized["decision"],
+        "parity_diff": parity_diff,
+    }
+
+
 def manual_review_payload(
     *,
     context: dict[str, Any],
@@ -11375,6 +11608,12 @@ def handle_review(args: argparse.Namespace) -> int:
             engine_profile,
             review_kind=review_kind,
         )
+        shadow_engine_payload = run_codex_app_review_shadow_adapter(
+            context,
+            adapter=args.shadow_engine_adapter,
+            raw_file=args.shadow_review_raw_file,
+            default_engine_payload=engine_payload,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")
@@ -11413,6 +11652,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),
             }

--- a/skills/loom-story/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-story/.loom-runtime/shared/references/harness/review-execution.md
@@ -55,6 +55,15 @@ Loom 把 review 分成四层：
 默认 engine 当前固定为 Codex。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
+阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+
+- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
+- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
+- shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
+- shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
+- shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
@@ -3079,6 +3079,26 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
                 failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+    shadow_engine = payload.get("shadow_engine")
+    if shadow_engine is not None:
+        if not isinstance(shadow_engine, dict):
+            failures.append(Failure(category, f"{context} shadow_engine must be an object when present"))
+        else:
+            if shadow_engine.get("adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} shadow_engine adapter must stay shadow-only `loom/codex-app-review`"))
+            if shadow_engine.get("result") not in {"pass", "block", "unavailable"}:
+                failures.append(Failure(category, f"{context} shadow_engine result must stay within the stable shadow contract"))
+            if shadow_engine.get("authoritative") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must declare authoritative=false"))
+            if shadow_engine.get("blocking") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must not block review or merge-ready"))
+            evidence = shadow_engine.get("evidence")
+            if not isinstance(evidence, dict):
+                failures.append(Failure(category, f"{context} shadow_engine must include runtime evidence locators"))
+            else:
+                for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    if not isinstance(evidence.get(key), str) or not evidence.get(key):
+                        failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
 
 
 def require_runtime_state_payload(
@@ -5716,6 +5736,114 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        shadow_target = Path(tmp) / "review-run-shadow"
+        prepare_review_target(shadow_target, "review run shadow adapter")
+        shadow_raw = shadow_target / ".loom/runtime/tmp/codex-app-review-raw.json"
+        shadow_raw.parent.mkdir(parents=True, exist_ok=True)
+        shadow_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "fallback",
+                    "summary": "Codex App reviewer produced shadow-only findings.",
+                    "findings": [
+                        {
+                            "id": "shadow-warn-1",
+                            "summary": "Codex App shadow review noted a comparison-only issue.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "deferred",
+                                "summary": "Shadow evidence must not author the formal review record.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+                "--shadow-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-raw.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow adapter",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must not replace default review_record_input engine adapter"))
+                shadow_engine = payload.get("shadow_engine") if isinstance(payload.get("shadow_engine"), dict) else {}
+                if shadow_engine.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must pass when raw review evidence is provided"))
+                evidence = shadow_engine.get("evidence") if isinstance(shadow_engine.get("evidence"), dict) else {}
+                for key in ("raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    value = evidence.get(key)
+                    if not isinstance(value, str) or not (shadow_target / value).exists():
+                        failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter must write {key} evidence"))
+                if shadow_engine.get("authoritative") is not False or shadow_engine.get("blocking") is not False:
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must stay non-authoritative and non-blocking"))
+
+        shadow_unavailable_target = Path(tmp) / "review-run-shadow-unavailable"
+        prepare_review_target(shadow_unavailable_target, "review run shadow unavailable")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_unavailable_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow unavailable failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow unavailable",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            shadow_engine = payload.get("shadow_engine") if isinstance(payload, dict) and isinstance(payload.get("shadow_engine"), dict) else {}
+            if shadow_engine.get("result") != "unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must not block the default review path"))
+            review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
+            if review_record_input.get("engine_adapter") != "loom/default-codex":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
@@ -5593,7 +5593,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         review_target = Path(tmp) / "new-project"
         fake_bin = Path(tmp) / "bin"
         fake_bin.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
         def prepare_review_target(target: Path, label: str) -> bool:
             shutil.copytree(source_snapshot, target)
@@ -6801,7 +6801,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             write_fake_codex(fake_bin / "codex", mode="success")
             installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
-            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
             def prepare_target(target: Path) -> tuple[str | None, list[str]]:
                 errors: list[str] = []

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,8 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -449,6 +451,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
     review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
+    review.add_argument(
+        "--shadow-engine-adapter",
+        choices=tuple(sorted(SHADOW_REVIEW_ADAPTERS)),
+        help="Optional shadow-only review adapter. Does not replace the default authoritative review engine.",
+    )
+    review.add_argument(
+        "--shadow-review-raw-file",
+        help="Optional repo-relative captured Codex App review text to normalize as shadow evidence.",
+    )
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -7115,6 +7126,228 @@ def normalize_engine_review_result(payload: Any, *, relative: str) -> tuple[dict
     }, []
 
 
+def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App review raw output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+        if normalized is not None and not errors:
+            return normalized, []
+
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+    summary = first_line[:240] if first_line else "Codex App review returned raw text."
+    return {
+        "decision": "fallback",
+        "summary": "Codex App review raw output was captured as shadow evidence and normalized for comparison only.",
+        "findings": [
+            {
+                "id": "codex-app-review-raw-output",
+                "summary": summary,
+                "severity": "warn",
+                "rebuttal": None,
+                "disposition": {
+                    "status": "deferred",
+                    "summary": "Shadow-only finding; formal disposition must still be authored through the single review record.",
+                },
+                "details": text[:4000],
+            }
+        ],
+    }, []
+
+
+def shadow_adapter_slug(adapter: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
+
+
+def compare_review_findings(default_findings: list[dict[str, Any]], shadow_findings: list[dict[str, Any]]) -> dict[str, Any]:
+    default_ids = {str(finding.get("id")) for finding in default_findings if isinstance(finding, dict) and finding.get("id")}
+    shadow_ids = {str(finding.get("id")) for finding in shadow_findings if isinstance(finding, dict) and finding.get("id")}
+    shared = sorted(default_ids & shadow_ids)
+    default_only = sorted(default_ids - shadow_ids)
+    shadow_only = sorted(shadow_ids - default_ids)
+    result = "match" if not default_only and not shadow_only else "difference"
+    return {
+        "schema_version": "loom-review-shadow-diff/v1",
+        "result": result,
+        "summary": (
+            "Shadow review findings match the default review finding ids."
+            if result == "match"
+            else "Shadow review findings differ from the default review finding ids."
+        ),
+        "default_finding_ids": sorted(default_ids),
+        "shadow_finding_ids": sorted(shadow_ids),
+        "shared_finding_ids": shared,
+        "default_only_finding_ids": default_only,
+        "shadow_only_finding_ids": shadow_only,
+    }
+
+
+def run_codex_app_review_shadow_adapter(
+    context: dict[str, Any],
+    *,
+    adapter: str | None,
+    raw_file: str | None,
+    default_engine_payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not adapter:
+        return None
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    shadow_root = runtime_root / "shadow" / shadow_adapter_slug(adapter)
+    raw_path = shadow_root / "raw-review.txt"
+    findings_path = shadow_root / "normalized-findings.json"
+    metadata_path = shadow_root / "metadata.json"
+    diff_path = shadow_root / "parity-diff.json"
+    evidence = {
+        "runtime_root": relative_to_root(shadow_root, context["target_root"]),
+        "raw_review": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "parity_diff": relative_to_root(diff_path, context["target_root"]),
+    }
+
+    if adapter != CODEX_APP_REVIEW_SHADOW_ADAPTER:
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Unsupported shadow review adapter.",
+            "missing_inputs": [f"unsupported shadow review adapter: {adapter}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    if not raw_file:
+        metadata = {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "unavailable",
+            "reviewed_head": reviewed_head,
+            "summary": "Codex App review shadow adapter requires captured raw review text or a future live app-server runner.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "authoritative": False,
+        }
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(metadata_path, metadata)
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Codex App review shadow adapter was requested but no raw review evidence was provided.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    source_path, source_errors = resolve_repo_relative_path(context["target_root"], raw_file, label="shadow review raw file")
+    if source_errors or source_path is None:
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": source_errors,
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter refused an unsafe raw review locator.",
+            "missing_inputs": source_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter could not read raw review evidence.",
+            "missing_inputs": [f"shadow review raw file: {exc.strerror or exc}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    shadow_root.mkdir(parents=True, exist_ok=True)
+    raw_path.write_text(raw_text, encoding="utf-8")
+    normalized, normalization_errors = normalize_codex_app_review_text(
+        raw_text,
+        relative=relative_to_root(source_path, context["target_root"]),
+    )
+    if normalization_errors or normalized is None:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": normalization_errors,
+                "raw_source": relative_to_root(source_path, context["target_root"]),
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    default_findings: list[dict[str, Any]] = []
+    review_record_input = default_engine_payload.get("review_record_input")
+    if isinstance(review_record_input, dict):
+        default_findings_file = review_record_input.get("findings_file")
+        if isinstance(default_findings_file, str):
+            loaded_findings, _ = load_findings_file(context["target_root"], default_findings_file)
+            if isinstance(loaded_findings, list):
+                default_findings = loaded_findings
+    parity_diff = compare_review_findings(default_findings, normalized["findings"])
+    write_json_file(diff_path, parity_diff)
+    write_json_file(
+        metadata_path,
+        {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "pass",
+            "reviewed_head": reviewed_head,
+            "raw_source": relative_to_root(source_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "parity_diff": relative_to_root(diff_path, context["target_root"]),
+            "authoritative": False,
+            "summary": normalized["summary"],
+        },
+    )
+    return {
+        "adapter": adapter,
+        "result": "pass",
+        "summary": "Codex App review shadow evidence was captured and normalized for comparison only.",
+        "missing_inputs": [],
+        "blocking": False,
+        "authoritative": False,
+        "evidence": evidence,
+        "decision": normalized["decision"],
+        "parity_diff": parity_diff,
+    }
+
+
 def manual_review_payload(
     *,
     context: dict[str, Any],
@@ -11375,6 +11608,12 @@ def handle_review(args: argparse.Namespace) -> int:
             engine_profile,
             review_kind=review_kind,
         )
+        shadow_engine_payload = run_codex_app_review_shadow_adapter(
+            context,
+            adapter=args.shadow_engine_adapter,
+            raw_file=args.shadow_review_raw_file,
+            default_engine_payload=engine_payload,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")
@@ -11413,6 +11652,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),
             }

--- a/skills/shared/references/harness/review-execution.md
+++ b/skills/shared/references/harness/review-execution.md
@@ -55,6 +55,15 @@ Loom 把 review 分成四层：
 默认 engine 当前固定为 Codex。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
+阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+
+- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
+- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
+- shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
+- shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
+- shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -3079,6 +3079,26 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
                 failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+    shadow_engine = payload.get("shadow_engine")
+    if shadow_engine is not None:
+        if not isinstance(shadow_engine, dict):
+            failures.append(Failure(category, f"{context} shadow_engine must be an object when present"))
+        else:
+            if shadow_engine.get("adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} shadow_engine adapter must stay shadow-only `loom/codex-app-review`"))
+            if shadow_engine.get("result") not in {"pass", "block", "unavailable"}:
+                failures.append(Failure(category, f"{context} shadow_engine result must stay within the stable shadow contract"))
+            if shadow_engine.get("authoritative") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must declare authoritative=false"))
+            if shadow_engine.get("blocking") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must not block review or merge-ready"))
+            evidence = shadow_engine.get("evidence")
+            if not isinstance(evidence, dict):
+                failures.append(Failure(category, f"{context} shadow_engine must include runtime evidence locators"))
+            else:
+                for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    if not isinstance(evidence.get(key), str) or not evidence.get(key):
+                        failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
 
 
 def require_runtime_state_payload(
@@ -5716,6 +5736,114 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        shadow_target = Path(tmp) / "review-run-shadow"
+        prepare_review_target(shadow_target, "review run shadow adapter")
+        shadow_raw = shadow_target / ".loom/runtime/tmp/codex-app-review-raw.json"
+        shadow_raw.parent.mkdir(parents=True, exist_ok=True)
+        shadow_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "fallback",
+                    "summary": "Codex App reviewer produced shadow-only findings.",
+                    "findings": [
+                        {
+                            "id": "shadow-warn-1",
+                            "summary": "Codex App shadow review noted a comparison-only issue.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "deferred",
+                                "summary": "Shadow evidence must not author the formal review record.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+                "--shadow-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-raw.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow adapter",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must not replace default review_record_input engine adapter"))
+                shadow_engine = payload.get("shadow_engine") if isinstance(payload.get("shadow_engine"), dict) else {}
+                if shadow_engine.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must pass when raw review evidence is provided"))
+                evidence = shadow_engine.get("evidence") if isinstance(shadow_engine.get("evidence"), dict) else {}
+                for key in ("raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    value = evidence.get(key)
+                    if not isinstance(value, str) or not (shadow_target / value).exists():
+                        failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter must write {key} evidence"))
+                if shadow_engine.get("authoritative") is not False or shadow_engine.get("blocking") is not False:
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must stay non-authoritative and non-blocking"))
+
+        shadow_unavailable_target = Path(tmp) / "review-run-shadow-unavailable"
+        prepare_review_target(shadow_unavailable_target, "review run shadow unavailable")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_unavailable_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow unavailable failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow unavailable",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            shadow_engine = payload.get("shadow_engine") if isinstance(payload, dict) and isinstance(payload.get("shadow_engine"), dict) else {}
+            if shadow_engine.get("result") != "unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must not block the default review path"))
+            review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
+            if review_record_input.get("engine_adapter") != "loom/default-codex":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -5593,7 +5593,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         review_target = Path(tmp) / "new-project"
         fake_bin = Path(tmp) / "bin"
         fake_bin.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
         def prepare_review_target(target: Path, label: str) -> bool:
             shutil.copytree(source_snapshot, target)
@@ -6801,7 +6801,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             write_fake_codex(fake_bin / "codex", mode="success")
             installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
-            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
             def prepare_target(target: Path) -> tuple[str | None, list[str]]:
                 errors: list[str] = []

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -113,6 +113,8 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -449,6 +451,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
     review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
+    review.add_argument(
+        "--shadow-engine-adapter",
+        choices=tuple(sorted(SHADOW_REVIEW_ADAPTERS)),
+        help="Optional shadow-only review adapter. Does not replace the default authoritative review engine.",
+    )
+    review.add_argument(
+        "--shadow-review-raw-file",
+        help="Optional repo-relative captured Codex App review text to normalize as shadow evidence.",
+    )
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -7115,6 +7126,228 @@ def normalize_engine_review_result(payload: Any, *, relative: str) -> tuple[dict
     }, []
 
 
+def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App review raw output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+        if normalized is not None and not errors:
+            return normalized, []
+
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+    summary = first_line[:240] if first_line else "Codex App review returned raw text."
+    return {
+        "decision": "fallback",
+        "summary": "Codex App review raw output was captured as shadow evidence and normalized for comparison only.",
+        "findings": [
+            {
+                "id": "codex-app-review-raw-output",
+                "summary": summary,
+                "severity": "warn",
+                "rebuttal": None,
+                "disposition": {
+                    "status": "deferred",
+                    "summary": "Shadow-only finding; formal disposition must still be authored through the single review record.",
+                },
+                "details": text[:4000],
+            }
+        ],
+    }, []
+
+
+def shadow_adapter_slug(adapter: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
+
+
+def compare_review_findings(default_findings: list[dict[str, Any]], shadow_findings: list[dict[str, Any]]) -> dict[str, Any]:
+    default_ids = {str(finding.get("id")) for finding in default_findings if isinstance(finding, dict) and finding.get("id")}
+    shadow_ids = {str(finding.get("id")) for finding in shadow_findings if isinstance(finding, dict) and finding.get("id")}
+    shared = sorted(default_ids & shadow_ids)
+    default_only = sorted(default_ids - shadow_ids)
+    shadow_only = sorted(shadow_ids - default_ids)
+    result = "match" if not default_only and not shadow_only else "difference"
+    return {
+        "schema_version": "loom-review-shadow-diff/v1",
+        "result": result,
+        "summary": (
+            "Shadow review findings match the default review finding ids."
+            if result == "match"
+            else "Shadow review findings differ from the default review finding ids."
+        ),
+        "default_finding_ids": sorted(default_ids),
+        "shadow_finding_ids": sorted(shadow_ids),
+        "shared_finding_ids": shared,
+        "default_only_finding_ids": default_only,
+        "shadow_only_finding_ids": shadow_only,
+    }
+
+
+def run_codex_app_review_shadow_adapter(
+    context: dict[str, Any],
+    *,
+    adapter: str | None,
+    raw_file: str | None,
+    default_engine_payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not adapter:
+        return None
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    shadow_root = runtime_root / "shadow" / shadow_adapter_slug(adapter)
+    raw_path = shadow_root / "raw-review.txt"
+    findings_path = shadow_root / "normalized-findings.json"
+    metadata_path = shadow_root / "metadata.json"
+    diff_path = shadow_root / "parity-diff.json"
+    evidence = {
+        "runtime_root": relative_to_root(shadow_root, context["target_root"]),
+        "raw_review": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "parity_diff": relative_to_root(diff_path, context["target_root"]),
+    }
+
+    if adapter != CODEX_APP_REVIEW_SHADOW_ADAPTER:
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Unsupported shadow review adapter.",
+            "missing_inputs": [f"unsupported shadow review adapter: {adapter}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    if not raw_file:
+        metadata = {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "unavailable",
+            "reviewed_head": reviewed_head,
+            "summary": "Codex App review shadow adapter requires captured raw review text or a future live app-server runner.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "authoritative": False,
+        }
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(metadata_path, metadata)
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Codex App review shadow adapter was requested but no raw review evidence was provided.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    source_path, source_errors = resolve_repo_relative_path(context["target_root"], raw_file, label="shadow review raw file")
+    if source_errors or source_path is None:
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": source_errors,
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter refused an unsafe raw review locator.",
+            "missing_inputs": source_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter could not read raw review evidence.",
+            "missing_inputs": [f"shadow review raw file: {exc.strerror or exc}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    shadow_root.mkdir(parents=True, exist_ok=True)
+    raw_path.write_text(raw_text, encoding="utf-8")
+    normalized, normalization_errors = normalize_codex_app_review_text(
+        raw_text,
+        relative=relative_to_root(source_path, context["target_root"]),
+    )
+    if normalization_errors or normalized is None:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": normalization_errors,
+                "raw_source": relative_to_root(source_path, context["target_root"]),
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    default_findings: list[dict[str, Any]] = []
+    review_record_input = default_engine_payload.get("review_record_input")
+    if isinstance(review_record_input, dict):
+        default_findings_file = review_record_input.get("findings_file")
+        if isinstance(default_findings_file, str):
+            loaded_findings, _ = load_findings_file(context["target_root"], default_findings_file)
+            if isinstance(loaded_findings, list):
+                default_findings = loaded_findings
+    parity_diff = compare_review_findings(default_findings, normalized["findings"])
+    write_json_file(diff_path, parity_diff)
+    write_json_file(
+        metadata_path,
+        {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "pass",
+            "reviewed_head": reviewed_head,
+            "raw_source": relative_to_root(source_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "parity_diff": relative_to_root(diff_path, context["target_root"]),
+            "authoritative": False,
+            "summary": normalized["summary"],
+        },
+    )
+    return {
+        "adapter": adapter,
+        "result": "pass",
+        "summary": "Codex App review shadow evidence was captured and normalized for comparison only.",
+        "missing_inputs": [],
+        "blocking": False,
+        "authoritative": False,
+        "evidence": evidence,
+        "decision": normalized["decision"],
+        "parity_diff": parity_diff,
+    }
+
+
 def manual_review_payload(
     *,
     context: dict[str, Any],
@@ -11375,6 +11608,12 @@ def handle_review(args: argparse.Namespace) -> int:
             engine_profile,
             review_kind=review_kind,
         )
+        shadow_engine_payload = run_codex_app_review_shadow_adapter(
+            context,
+            adapter=args.shadow_engine_adapter,
+            raw_file=args.shadow_review_raw_file,
+            default_engine_payload=engine_payload,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")
@@ -11413,6 +11652,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),
             }

--- a/src/skills/shared/references/harness/review-execution.md
+++ b/src/skills/shared/references/harness/review-execution.md
@@ -55,6 +55,15 @@ Loom 把 review 分成四层：
 默认 engine 当前固定为 Codex。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
+阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+
+- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
+- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
+- shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
+- shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
+- shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -3079,6 +3079,26 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
                 failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+    shadow_engine = payload.get("shadow_engine")
+    if shadow_engine is not None:
+        if not isinstance(shadow_engine, dict):
+            failures.append(Failure(category, f"{context} shadow_engine must be an object when present"))
+        else:
+            if shadow_engine.get("adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} shadow_engine adapter must stay shadow-only `loom/codex-app-review`"))
+            if shadow_engine.get("result") not in {"pass", "block", "unavailable"}:
+                failures.append(Failure(category, f"{context} shadow_engine result must stay within the stable shadow contract"))
+            if shadow_engine.get("authoritative") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must declare authoritative=false"))
+            if shadow_engine.get("blocking") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must not block review or merge-ready"))
+            evidence = shadow_engine.get("evidence")
+            if not isinstance(evidence, dict):
+                failures.append(Failure(category, f"{context} shadow_engine must include runtime evidence locators"))
+            else:
+                for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    if not isinstance(evidence.get(key), str) or not evidence.get(key):
+                        failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
 
 
 def require_runtime_state_payload(
@@ -5716,6 +5736,114 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        shadow_target = Path(tmp) / "review-run-shadow"
+        prepare_review_target(shadow_target, "review run shadow adapter")
+        shadow_raw = shadow_target / ".loom/runtime/tmp/codex-app-review-raw.json"
+        shadow_raw.parent.mkdir(parents=True, exist_ok=True)
+        shadow_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "fallback",
+                    "summary": "Codex App reviewer produced shadow-only findings.",
+                    "findings": [
+                        {
+                            "id": "shadow-warn-1",
+                            "summary": "Codex App shadow review noted a comparison-only issue.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "deferred",
+                                "summary": "Shadow evidence must not author the formal review record.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+                "--shadow-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-raw.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow adapter",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must not replace default review_record_input engine adapter"))
+                shadow_engine = payload.get("shadow_engine") if isinstance(payload.get("shadow_engine"), dict) else {}
+                if shadow_engine.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must pass when raw review evidence is provided"))
+                evidence = shadow_engine.get("evidence") if isinstance(shadow_engine.get("evidence"), dict) else {}
+                for key in ("raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    value = evidence.get(key)
+                    if not isinstance(value, str) or not (shadow_target / value).exists():
+                        failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter must write {key} evidence"))
+                if shadow_engine.get("authoritative") is not False or shadow_engine.get("blocking") is not False:
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must stay non-authoritative and non-blocking"))
+
+        shadow_unavailable_target = Path(tmp) / "review-run-shadow-unavailable"
+        prepare_review_target(shadow_unavailable_target, "review run shadow unavailable")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_unavailable_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow unavailable failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow unavailable",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            shadow_engine = payload.get("shadow_engine") if isinstance(payload, dict) and isinstance(payload.get("shadow_engine"), dict) else {}
+            if shadow_engine.get("result") != "unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must not block the default review path"))
+            review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
+            if review_record_input.get("engine_adapter") != "loom/default-codex":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -5593,7 +5593,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         review_target = Path(tmp) / "new-project"
         fake_bin = Path(tmp) / "bin"
         fake_bin.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
         def prepare_review_target(target: Path, label: str) -> bool:
             shutil.copytree(source_snapshot, target)
@@ -6801,7 +6801,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             write_fake_codex(fake_bin / "codex", mode="success")
             installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
-            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
             def prepare_target(target: Path) -> tuple[str | None, list[str]]:
                 errors: list[str] = []

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -113,6 +113,8 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -449,6 +451,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
     review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
+    review.add_argument(
+        "--shadow-engine-adapter",
+        choices=tuple(sorted(SHADOW_REVIEW_ADAPTERS)),
+        help="Optional shadow-only review adapter. Does not replace the default authoritative review engine.",
+    )
+    review.add_argument(
+        "--shadow-review-raw-file",
+        help="Optional repo-relative captured Codex App review text to normalize as shadow evidence.",
+    )
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -7115,6 +7126,228 @@ def normalize_engine_review_result(payload: Any, *, relative: str) -> tuple[dict
     }, []
 
 
+def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App review raw output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+        if normalized is not None and not errors:
+            return normalized, []
+
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+    summary = first_line[:240] if first_line else "Codex App review returned raw text."
+    return {
+        "decision": "fallback",
+        "summary": "Codex App review raw output was captured as shadow evidence and normalized for comparison only.",
+        "findings": [
+            {
+                "id": "codex-app-review-raw-output",
+                "summary": summary,
+                "severity": "warn",
+                "rebuttal": None,
+                "disposition": {
+                    "status": "deferred",
+                    "summary": "Shadow-only finding; formal disposition must still be authored through the single review record.",
+                },
+                "details": text[:4000],
+            }
+        ],
+    }, []
+
+
+def shadow_adapter_slug(adapter: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
+
+
+def compare_review_findings(default_findings: list[dict[str, Any]], shadow_findings: list[dict[str, Any]]) -> dict[str, Any]:
+    default_ids = {str(finding.get("id")) for finding in default_findings if isinstance(finding, dict) and finding.get("id")}
+    shadow_ids = {str(finding.get("id")) for finding in shadow_findings if isinstance(finding, dict) and finding.get("id")}
+    shared = sorted(default_ids & shadow_ids)
+    default_only = sorted(default_ids - shadow_ids)
+    shadow_only = sorted(shadow_ids - default_ids)
+    result = "match" if not default_only and not shadow_only else "difference"
+    return {
+        "schema_version": "loom-review-shadow-diff/v1",
+        "result": result,
+        "summary": (
+            "Shadow review findings match the default review finding ids."
+            if result == "match"
+            else "Shadow review findings differ from the default review finding ids."
+        ),
+        "default_finding_ids": sorted(default_ids),
+        "shadow_finding_ids": sorted(shadow_ids),
+        "shared_finding_ids": shared,
+        "default_only_finding_ids": default_only,
+        "shadow_only_finding_ids": shadow_only,
+    }
+
+
+def run_codex_app_review_shadow_adapter(
+    context: dict[str, Any],
+    *,
+    adapter: str | None,
+    raw_file: str | None,
+    default_engine_payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not adapter:
+        return None
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    shadow_root = runtime_root / "shadow" / shadow_adapter_slug(adapter)
+    raw_path = shadow_root / "raw-review.txt"
+    findings_path = shadow_root / "normalized-findings.json"
+    metadata_path = shadow_root / "metadata.json"
+    diff_path = shadow_root / "parity-diff.json"
+    evidence = {
+        "runtime_root": relative_to_root(shadow_root, context["target_root"]),
+        "raw_review": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "parity_diff": relative_to_root(diff_path, context["target_root"]),
+    }
+
+    if adapter != CODEX_APP_REVIEW_SHADOW_ADAPTER:
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Unsupported shadow review adapter.",
+            "missing_inputs": [f"unsupported shadow review adapter: {adapter}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    if not raw_file:
+        metadata = {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "unavailable",
+            "reviewed_head": reviewed_head,
+            "summary": "Codex App review shadow adapter requires captured raw review text or a future live app-server runner.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "authoritative": False,
+        }
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(metadata_path, metadata)
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Codex App review shadow adapter was requested but no raw review evidence was provided.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    source_path, source_errors = resolve_repo_relative_path(context["target_root"], raw_file, label="shadow review raw file")
+    if source_errors or source_path is None:
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": source_errors,
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter refused an unsafe raw review locator.",
+            "missing_inputs": source_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter could not read raw review evidence.",
+            "missing_inputs": [f"shadow review raw file: {exc.strerror or exc}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    shadow_root.mkdir(parents=True, exist_ok=True)
+    raw_path.write_text(raw_text, encoding="utf-8")
+    normalized, normalization_errors = normalize_codex_app_review_text(
+        raw_text,
+        relative=relative_to_root(source_path, context["target_root"]),
+    )
+    if normalization_errors or normalized is None:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": normalization_errors,
+                "raw_source": relative_to_root(source_path, context["target_root"]),
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    default_findings: list[dict[str, Any]] = []
+    review_record_input = default_engine_payload.get("review_record_input")
+    if isinstance(review_record_input, dict):
+        default_findings_file = review_record_input.get("findings_file")
+        if isinstance(default_findings_file, str):
+            loaded_findings, _ = load_findings_file(context["target_root"], default_findings_file)
+            if isinstance(loaded_findings, list):
+                default_findings = loaded_findings
+    parity_diff = compare_review_findings(default_findings, normalized["findings"])
+    write_json_file(diff_path, parity_diff)
+    write_json_file(
+        metadata_path,
+        {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "pass",
+            "reviewed_head": reviewed_head,
+            "raw_source": relative_to_root(source_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "parity_diff": relative_to_root(diff_path, context["target_root"]),
+            "authoritative": False,
+            "summary": normalized["summary"],
+        },
+    )
+    return {
+        "adapter": adapter,
+        "result": "pass",
+        "summary": "Codex App review shadow evidence was captured and normalized for comparison only.",
+        "missing_inputs": [],
+        "blocking": False,
+        "authoritative": False,
+        "evidence": evidence,
+        "decision": normalized["decision"],
+        "parity_diff": parity_diff,
+    }
+
+
 def manual_review_payload(
     *,
     context: dict[str, Any],
@@ -11375,6 +11608,12 @@ def handle_review(args: argparse.Namespace) -> int:
             engine_profile,
             review_kind=review_kind,
         )
+        shadow_engine_payload = run_codex_app_review_shadow_adapter(
+            context,
+            adapter=args.shadow_engine_adapter,
+            raw_file=args.shadow_review_raw_file,
+            default_engine_payload=engine_payload,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")
@@ -11413,6 +11652,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),
             }


### PR DESCRIPTION
## Summary

- Adds explicit `review run --shadow-engine-adapter loom/codex-app-review` support while preserving the default `loom/default-codex` authoritative path.
- Captures Codex App raw review text as shadow runtime evidence and normalizes it into comparison-only findings.
- Writes shadow metadata and parity diff under `.loom/runtime/review/<item>/<head>/shadow/loom-codex-app-review/`.
- Updates review execution docs and generated skills surface.

## Validation

- `python3 -m py_compile tools/loom_flow.py tools/loom_check.py skills/shared/scripts/loom_flow.py skills/shared/scripts/loom_check.py src/skills/shared/scripts/loom_flow.py src/skills/shared/scripts/loom_check.py`
- `make skills-check`
- `git diff --check`
- direct shadow adapter unit probe: `shadow unit: OK`
- `python3 tools/loom_flow.py review run --help`
- `python3 tools/loom_flow.py shadow-parity --target .` -> `result: pass`
- focused `check_daily_execution_cli(...)` -> `daily-execution-cli: OK`

## Issue State

- Closes #752
- Closes #753
- Closes #754
- Closes #755
- Advances #748 Stage 1; #748 has been updated with live proof and validation summary.

## Boundaries

- Does not make `review/start` the default engine.
- Does not let App review raw output author `review_entry`.
- Does not let merge-ready consume raw/shadow App review evidence.
- Does not remove headless / CI `codex exec` fallback.
