### PR TITLE
feat(harness): Codex App review authoritative opt-in

### DIFF
--- a/docs/methodology/harness/review-execution.md
+++ b/docs/methodology/harness/review-execution.md
@@ -45,15 +45,15 @@ Loom 把 review 分成三层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 Codex。
+默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 checkpoint fallback。
 
-阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+Codex App review adapter 有两种显式入口，默认均不启用：
 
 - 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
 - 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
@@ -61,17 +61,22 @@ Loom 把 review 分成三层：
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
+- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
+- authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract
 
-`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+`review run` 在调用 Codex-backed reviewer 或 Codex App authoritative adapter 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: 当前固定为 `loom/default-codex`
-- `engine`: 当前固定为 `codex`
+- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
+- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-adopt/.loom-runtime/loom-review/SKILL.md
@@ -42,7 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+
+默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -52,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 

--- a/skills/loom-adopt/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-adopt/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，生成 Loom-normalized spec findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,6 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/review-execution.md
@@ -47,15 +47,15 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 Codex。
+默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+Codex App review adapter 有两种显式入口，默认均不启用：
 
 - 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
 - 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
@@ -63,17 +63,22 @@ Loom 把 review 分成四层：
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
+- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
+- authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract
 
-`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+`review run` 在调用 Codex-backed reviewer 或 Codex App authoritative adapter 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: 当前固定为 `loom/default-codex`
-- `engine`: 当前固定为 `codex`
+- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
+- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -757,6 +757,13 @@ output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
 sys.exit(0)
 """
+    elif mode == "fail_if_called":
+        body = """#!/usr/bin/env python3
+import sys
+
+sys.stderr.write("codex exec must not be called for explicit Codex App review adapter\\n")
+sys.exit(41)
+"""
     else:
         raise ValueError(f"unknown fake codex mode: {mode}")
     path.write_text(body, encoding="utf-8")
@@ -3005,10 +3012,12 @@ def require_review_run_payload(
     engine = payload.get("engine")
     if not isinstance(engine, dict):
         return
-    if engine.get("engine") != "codex":
-        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
-    if engine.get("adapter") != "loom/default-codex":
-        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    engine_adapter = engine.get("adapter")
+    if engine_adapter not in {"loom/default-codex", "loom/codex-app-review"}:
+        failures.append(Failure(category, f"{context} adapter must be a supported authoritative review adapter"))
+    expected_engine = "codex-app-review" if engine_adapter == "loom/codex-app-review" else "codex"
+    if engine.get("engine") != expected_engine:
+        failures.append(Failure(category, f"{context} engine must match the selected authoritative adapter"))
     profile = engine.get("profile")
     if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
         pass
@@ -3017,8 +3026,8 @@ def require_review_run_payload(
     else:
         if profile.get("schema_version") != "loom-review-engine-profile/v1":
             failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
-        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
-            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("adapter") != engine_adapter or profile.get("engine") != expected_engine:
+            failures.append(Failure(category, f"{context} engine profile must bind the selected adapter explicitly"))
         if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
             failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
         for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
@@ -3077,8 +3086,10 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
-            if review_record_input.get("reviewer") != "loom/default-codex":
-                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+            if review_record_input.get("reviewer") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input reviewer must match the selected adapter"))
+            if review_record_input.get("engine_adapter") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input engine_adapter must match the selected adapter"))
     shadow_engine = payload.get("shadow_engine")
     if shadow_engine is not None:
         if not isinstance(shadow_engine, dict):
@@ -5709,6 +5720,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex" or engine.get("adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep the default codex exec adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex" or review_record_input.get("reviewer") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep default review_record_input adapter"))
                 evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
                 context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
                 prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
@@ -5844,6 +5861,154 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
+        prepare_review_target(app_authoritative_target, "review run Codex App authoritative")
+        app_raw = app_authoritative_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App authoritative reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-warn-1",
+                            "summary": "Codex App authoritative review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_authoritative_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_authoritative_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App authoritative failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App authoritative",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must author app adapter review_record_input"))
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must not call codex exec"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("thread_id") != "thread-stage2-live-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must expose live thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_authoritative_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume raw Codex App authoritative evidence before review record is authored"))
+
+        app_missing_target = Path(tmp) / "review-run-codex-app-missing-proof"
+        prepare_review_target(app_missing_target, "review run Codex App missing proof")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_missing_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App missing proof failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App missing proof must fail closed"))
+
+        app_invalid_target = Path(tmp) / "review-run-codex-app-invalid-raw"
+        prepare_review_target(app_invalid_target, "review run Codex App invalid raw")
+        invalid_raw = app_invalid_target / ".loom/runtime/tmp/codex-app-review-invalid.txt"
+        invalid_raw.parent.mkdir(parents=True, exist_ok=True)
+        invalid_raw.write_text("plain review text is not authoritative schema\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_invalid_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_invalid_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-invalid.txt",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App invalid raw failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App invalid raw must fail closed on schema drift"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,7 +113,10 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
-CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ENGINE = "codex-app-review"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
+AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
@@ -444,9 +447,32 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--reviewer", help="Reviewer identity")
     review.add_argument("--fallback-to", choices=("admission", "build", "merge"))
     review.add_argument("--findings-file", help="Optional findings JSON path relative to the target root")
-    review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
+    review.add_argument(
+        "--engine-adapter",
+        choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
+        help=(
+            "Optional authoritative review engine adapter for review run/record. "
+            "Default review run remains loom/default-codex."
+        ),
+    )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument(
+        "--codex-app-review-app-server",
+        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-thread-id",
+        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-cwd",
+        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-raw-file",
+        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+    )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
@@ -7034,11 +7060,14 @@ def resolve_review_engine_profile(
     context: dict[str, Any],
     review_kind: str,
     *,
+    adapter: str = DEFAULT_REVIEW_ADAPTER,
     requested_profile: str | None = None,
     requested_model: str | None = None,
     requested_reasoning: str | None = None,
     override_reason: str | None = None,
 ) -> tuple[dict[str, Any] | None, list[str]]:
+    if adapter not in AUTHORITATIVE_REVIEW_ADAPTERS:
+        return None, [f"unsupported authoritative review adapter: {adapter}"]
     selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
     if requested_profile:
         selected_profile = requested_profile
@@ -7061,8 +7090,8 @@ def resolve_review_engine_profile(
     resolved = {
         "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
         "profile_id": base_profile["profile_id"],
-        "adapter": DEFAULT_REVIEW_ADAPTER,
-        "engine": DEFAULT_REVIEW_ENGINE,
+        "adapter": adapter,
+        "engine": CODEX_APP_REVIEW_ENGINE if adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
         "model": base_profile["model"],
         "reasoning_effort": base_profile["reasoning_effort"],
         "timeout_seconds": int(base_profile["timeout_seconds"]),
@@ -7158,6 +7187,20 @@ def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[di
             }
         ],
     }, []
+
+
+def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App authoritative review output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, [f"Codex App authoritative review output `{relative}` must be normalized JSON: {exc}"]
+    normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+    if errors or normalized is None:
+        return None, errors
+    return normalized, []
 
 
 def shadow_adapter_slug(adapter: str) -> str:
@@ -7345,6 +7388,232 @@ def run_codex_app_review_shadow_adapter(
         "evidence": evidence,
         "decision": normalized["decision"],
         "parity_diff": parity_diff,
+    }
+
+
+def run_codex_app_review_authoritative_adapter(
+    context: dict[str, Any],
+    build_payload: dict[str, Any],
+    review_path: str,
+    engine_profile: dict[str, Any],
+    *,
+    review_kind: str,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    raw_path = runtime_root / "engine-result.json"
+    findings_path = runtime_root / "normalized-findings.json"
+    metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
+    instructions_path = runtime_root / "prompt.txt"
+    context_pack = build_review_context_pack(context, review_path)
+    evidence = {
+        "runtime_root": relative_to_root(runtime_root, context["target_root"]),
+        "prompt": relative_to_root(instructions_path, context["target_root"]),
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+    }
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
+    instructions_path.write_text(
+        build_default_review_prompt(
+            context=context,
+            build_payload=build_payload,
+            runtime_fields=runtime_evidence_from_report(context["report"])[0],
+            review_path=review_path,
+            context_pack=context_pack,
+        ),
+        encoding="utf-8",
+    )
+
+    missing_inputs: list[str] = []
+    for label, value in (
+        ("--codex-app-review-app-server", app_server),
+        ("--codex-app-review-thread-id", thread_id),
+        ("--codex-app-review-cwd", thread_cwd),
+        ("--codex-app-review-raw-file", raw_file),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(label)
+
+    cwd_relative: str | None = None
+    if isinstance(thread_cwd, str) and thread_cwd.strip():
+        try:
+            cwd_path = Path(thread_cwd).expanduser().resolve()
+        except OSError as exc:
+            missing_inputs.append(f"Codex App review cwd could not be resolved: {exc}")
+        else:
+            if cwd_path != context["target_root"]:
+                missing_inputs.append(
+                    f"Codex App review cwd `{cwd_path}` does not match target root `{context['target_root']}`"
+                )
+            else:
+                cwd_relative = relative_to_root(cwd_path, context["target_root"])
+
+    source_path: Path | None = None
+    source_relative: str | None = None
+    if isinstance(raw_file, str) and raw_file.strip():
+        source_path, source_errors = resolve_repo_relative_path(
+            context["target_root"],
+            raw_file,
+            label="Codex App authoritative review raw file",
+        )
+        missing_inputs.extend(source_errors)
+        if source_path is not None:
+            source_relative = relative_to_root(source_path, context["target_root"])
+
+    if missing_inputs:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "summary": "Codex App authoritative review adapter is missing required live binding proof.",
+                "missing_inputs": missing_inputs,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review adapter failed closed before a formal review record could be authored.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+                "raw_source": source_relative,
+            },
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
+    except OSError as exc:
+        raw_text = ""
+        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+        normalized = None
+    else:
+        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+            raw_text,
+            relative=source_relative or str(raw_file),
+        )
+
+    if normalization_errors or normalized is None:
+        if raw_text:
+            raw_path.write_text(raw_text, encoding="utf-8")
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "summary": "Codex App authoritative review output did not satisfy the Loom review result schema.",
+                "errors": normalization_errors,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        }
+
+    raw_path.write_text(raw_text, encoding="utf-8")
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    metadata = {
+        "schema_version": "loom-review-engine-metadata/v1",
+        "engine": CODEX_APP_REVIEW_ENGINE,
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "profile": engine_profile,
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+        "result": "pass",
+        "reviewed_head": reviewed_head,
+        "decision": normalized["decision"],
+        "summary": normalized["summary"],
+        "kind": review_kind,
+        "validation_summary": context["latest_validation_summary"],
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_relative,
+        "raw_source": source_relative,
+        "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
+    }
+    write_json_file(metadata_path, metadata)
+    return {
+        "result": "pass",
+        "summary": "Codex App authoritative review adapter produced a Loom-normalized formal review draft.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "engine": {
+            "engine": CODEX_APP_REVIEW_ENGINE,
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "profile": engine_profile,
+            "result": "pass",
+            "failure_reason": None,
+            "reviewed_head": reviewed_head,
+            "evidence": evidence,
+        },
+        "engine_metadata": metadata,
+        "review_record_input": {
+            "decision": normalized["decision"],
+            "summary": normalized["summary"],
+            "reviewer": CODEX_APP_REVIEW_ADAPTER,
+            "kind": review_kind,
+            "findings_file": relative_to_root(findings_path, context["target_root"]),
+            "engine_adapter": CODEX_APP_REVIEW_ADAPTER,
+            "engine_evidence": relative_to_root(raw_path, context["target_root"]),
+            "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
+        },
     }
 
 
@@ -11523,9 +11792,11 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
+            adapter=requested_engine_adapter,
             requested_profile=args.engine_profile,
             requested_model=args.engine_model,
             requested_reasoning=args.engine_reasoning,
@@ -11548,8 +11819,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "missing_inputs": engine_profile_errors,
                     "fallback_to": None,
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
@@ -11588,8 +11859,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                     "current_checkpoint": flow_payload.get("current_checkpoint"),
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
@@ -11601,13 +11872,26 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(
-            context,
-            build_payload,
-            review_path,
-            engine_profile,
-            review_kind=review_kind,
-        )
+        if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER:
+            engine_payload = run_codex_app_review_authoritative_adapter(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+                app_server=args.codex_app_review_app_server,
+                thread_id=args.codex_app_review_thread_id,
+                thread_cwd=args.codex_app_review_cwd,
+                raw_file=args.codex_app_review_raw_file,
+            )
+        else:
+            engine_payload = run_default_review_engine(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+            )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,
             adapter=args.shadow_engine_adapter,
@@ -11630,7 +11914,7 @@ def handle_review(args: argparse.Namespace) -> int:
         summary = (
             engine_payload["summary"]
             if result == "pass"
-            else "default review engine failed closed; record any formal review conclusion through the single review record."
+            else f"{requested_engine_adapter} review engine failed closed; record any formal review conclusion through the single review record."
         )
         return emit(
             {
@@ -11652,6 +11936,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"engine_metadata": engine_payload["engine_metadata"]} if isinstance(engine_payload.get("engine_metadata"), dict) else {}),
                 **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),

--- a/skills/loom-build/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-build/.loom-runtime/loom-review/SKILL.md
@@ -42,7 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+
+默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -52,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 

--- a/skills/loom-build/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-build/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，生成 Loom-normalized spec findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,6 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-build/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/review-execution.md
@@ -47,15 +47,15 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 Codex。
+默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+Codex App review adapter 有两种显式入口，默认均不启用：
 
 - 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
 - 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
@@ -63,17 +63,22 @@ Loom 把 review 分成四层：
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
+- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
+- authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract
 
-`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+`review run` 在调用 Codex-backed reviewer 或 Codex App authoritative adapter 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: 当前固定为 `loom/default-codex`
-- `engine`: 当前固定为 `codex`
+- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
+- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -757,6 +757,13 @@ output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
 sys.exit(0)
 """
+    elif mode == "fail_if_called":
+        body = """#!/usr/bin/env python3
+import sys
+
+sys.stderr.write("codex exec must not be called for explicit Codex App review adapter\\n")
+sys.exit(41)
+"""
     else:
         raise ValueError(f"unknown fake codex mode: {mode}")
     path.write_text(body, encoding="utf-8")
@@ -3005,10 +3012,12 @@ def require_review_run_payload(
     engine = payload.get("engine")
     if not isinstance(engine, dict):
         return
-    if engine.get("engine") != "codex":
-        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
-    if engine.get("adapter") != "loom/default-codex":
-        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    engine_adapter = engine.get("adapter")
+    if engine_adapter not in {"loom/default-codex", "loom/codex-app-review"}:
+        failures.append(Failure(category, f"{context} adapter must be a supported authoritative review adapter"))
+    expected_engine = "codex-app-review" if engine_adapter == "loom/codex-app-review" else "codex"
+    if engine.get("engine") != expected_engine:
+        failures.append(Failure(category, f"{context} engine must match the selected authoritative adapter"))
     profile = engine.get("profile")
     if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
         pass
@@ -3017,8 +3026,8 @@ def require_review_run_payload(
     else:
         if profile.get("schema_version") != "loom-review-engine-profile/v1":
             failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
-        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
-            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("adapter") != engine_adapter or profile.get("engine") != expected_engine:
+            failures.append(Failure(category, f"{context} engine profile must bind the selected adapter explicitly"))
         if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
             failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
         for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
@@ -3077,8 +3086,10 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
-            if review_record_input.get("reviewer") != "loom/default-codex":
-                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+            if review_record_input.get("reviewer") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input reviewer must match the selected adapter"))
+            if review_record_input.get("engine_adapter") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input engine_adapter must match the selected adapter"))
     shadow_engine = payload.get("shadow_engine")
     if shadow_engine is not None:
         if not isinstance(shadow_engine, dict):
@@ -5709,6 +5720,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex" or engine.get("adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep the default codex exec adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex" or review_record_input.get("reviewer") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep default review_record_input adapter"))
                 evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
                 context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
                 prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
@@ -5844,6 +5861,154 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
+        prepare_review_target(app_authoritative_target, "review run Codex App authoritative")
+        app_raw = app_authoritative_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App authoritative reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-warn-1",
+                            "summary": "Codex App authoritative review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_authoritative_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_authoritative_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App authoritative failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App authoritative",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must author app adapter review_record_input"))
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must not call codex exec"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("thread_id") != "thread-stage2-live-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must expose live thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_authoritative_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume raw Codex App authoritative evidence before review record is authored"))
+
+        app_missing_target = Path(tmp) / "review-run-codex-app-missing-proof"
+        prepare_review_target(app_missing_target, "review run Codex App missing proof")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_missing_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App missing proof failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App missing proof must fail closed"))
+
+        app_invalid_target = Path(tmp) / "review-run-codex-app-invalid-raw"
+        prepare_review_target(app_invalid_target, "review run Codex App invalid raw")
+        invalid_raw = app_invalid_target / ".loom/runtime/tmp/codex-app-review-invalid.txt"
+        invalid_raw.parent.mkdir(parents=True, exist_ok=True)
+        invalid_raw.write_text("plain review text is not authoritative schema\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_invalid_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_invalid_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-invalid.txt",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App invalid raw failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App invalid raw must fail closed on schema drift"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,7 +113,10 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
-CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ENGINE = "codex-app-review"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
+AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
@@ -444,9 +447,32 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--reviewer", help="Reviewer identity")
     review.add_argument("--fallback-to", choices=("admission", "build", "merge"))
     review.add_argument("--findings-file", help="Optional findings JSON path relative to the target root")
-    review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
+    review.add_argument(
+        "--engine-adapter",
+        choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
+        help=(
+            "Optional authoritative review engine adapter for review run/record. "
+            "Default review run remains loom/default-codex."
+        ),
+    )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument(
+        "--codex-app-review-app-server",
+        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-thread-id",
+        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-cwd",
+        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-raw-file",
+        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+    )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
@@ -7034,11 +7060,14 @@ def resolve_review_engine_profile(
     context: dict[str, Any],
     review_kind: str,
     *,
+    adapter: str = DEFAULT_REVIEW_ADAPTER,
     requested_profile: str | None = None,
     requested_model: str | None = None,
     requested_reasoning: str | None = None,
     override_reason: str | None = None,
 ) -> tuple[dict[str, Any] | None, list[str]]:
+    if adapter not in AUTHORITATIVE_REVIEW_ADAPTERS:
+        return None, [f"unsupported authoritative review adapter: {adapter}"]
     selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
     if requested_profile:
         selected_profile = requested_profile
@@ -7061,8 +7090,8 @@ def resolve_review_engine_profile(
     resolved = {
         "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
         "profile_id": base_profile["profile_id"],
-        "adapter": DEFAULT_REVIEW_ADAPTER,
-        "engine": DEFAULT_REVIEW_ENGINE,
+        "adapter": adapter,
+        "engine": CODEX_APP_REVIEW_ENGINE if adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
         "model": base_profile["model"],
         "reasoning_effort": base_profile["reasoning_effort"],
         "timeout_seconds": int(base_profile["timeout_seconds"]),
@@ -7158,6 +7187,20 @@ def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[di
             }
         ],
     }, []
+
+
+def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App authoritative review output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, [f"Codex App authoritative review output `{relative}` must be normalized JSON: {exc}"]
+    normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+    if errors or normalized is None:
+        return None, errors
+    return normalized, []
 
 
 def shadow_adapter_slug(adapter: str) -> str:
@@ -7345,6 +7388,232 @@ def run_codex_app_review_shadow_adapter(
         "evidence": evidence,
         "decision": normalized["decision"],
         "parity_diff": parity_diff,
+    }
+
+
+def run_codex_app_review_authoritative_adapter(
+    context: dict[str, Any],
+    build_payload: dict[str, Any],
+    review_path: str,
+    engine_profile: dict[str, Any],
+    *,
+    review_kind: str,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    raw_path = runtime_root / "engine-result.json"
+    findings_path = runtime_root / "normalized-findings.json"
+    metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
+    instructions_path = runtime_root / "prompt.txt"
+    context_pack = build_review_context_pack(context, review_path)
+    evidence = {
+        "runtime_root": relative_to_root(runtime_root, context["target_root"]),
+        "prompt": relative_to_root(instructions_path, context["target_root"]),
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+    }
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
+    instructions_path.write_text(
+        build_default_review_prompt(
+            context=context,
+            build_payload=build_payload,
+            runtime_fields=runtime_evidence_from_report(context["report"])[0],
+            review_path=review_path,
+            context_pack=context_pack,
+        ),
+        encoding="utf-8",
+    )
+
+    missing_inputs: list[str] = []
+    for label, value in (
+        ("--codex-app-review-app-server", app_server),
+        ("--codex-app-review-thread-id", thread_id),
+        ("--codex-app-review-cwd", thread_cwd),
+        ("--codex-app-review-raw-file", raw_file),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(label)
+
+    cwd_relative: str | None = None
+    if isinstance(thread_cwd, str) and thread_cwd.strip():
+        try:
+            cwd_path = Path(thread_cwd).expanduser().resolve()
+        except OSError as exc:
+            missing_inputs.append(f"Codex App review cwd could not be resolved: {exc}")
+        else:
+            if cwd_path != context["target_root"]:
+                missing_inputs.append(
+                    f"Codex App review cwd `{cwd_path}` does not match target root `{context['target_root']}`"
+                )
+            else:
+                cwd_relative = relative_to_root(cwd_path, context["target_root"])
+
+    source_path: Path | None = None
+    source_relative: str | None = None
+    if isinstance(raw_file, str) and raw_file.strip():
+        source_path, source_errors = resolve_repo_relative_path(
+            context["target_root"],
+            raw_file,
+            label="Codex App authoritative review raw file",
+        )
+        missing_inputs.extend(source_errors)
+        if source_path is not None:
+            source_relative = relative_to_root(source_path, context["target_root"])
+
+    if missing_inputs:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "summary": "Codex App authoritative review adapter is missing required live binding proof.",
+                "missing_inputs": missing_inputs,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review adapter failed closed before a formal review record could be authored.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+                "raw_source": source_relative,
+            },
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
+    except OSError as exc:
+        raw_text = ""
+        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+        normalized = None
+    else:
+        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+            raw_text,
+            relative=source_relative or str(raw_file),
+        )
+
+    if normalization_errors or normalized is None:
+        if raw_text:
+            raw_path.write_text(raw_text, encoding="utf-8")
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "summary": "Codex App authoritative review output did not satisfy the Loom review result schema.",
+                "errors": normalization_errors,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        }
+
+    raw_path.write_text(raw_text, encoding="utf-8")
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    metadata = {
+        "schema_version": "loom-review-engine-metadata/v1",
+        "engine": CODEX_APP_REVIEW_ENGINE,
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "profile": engine_profile,
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+        "result": "pass",
+        "reviewed_head": reviewed_head,
+        "decision": normalized["decision"],
+        "summary": normalized["summary"],
+        "kind": review_kind,
+        "validation_summary": context["latest_validation_summary"],
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_relative,
+        "raw_source": source_relative,
+        "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
+    }
+    write_json_file(metadata_path, metadata)
+    return {
+        "result": "pass",
+        "summary": "Codex App authoritative review adapter produced a Loom-normalized formal review draft.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "engine": {
+            "engine": CODEX_APP_REVIEW_ENGINE,
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "profile": engine_profile,
+            "result": "pass",
+            "failure_reason": None,
+            "reviewed_head": reviewed_head,
+            "evidence": evidence,
+        },
+        "engine_metadata": metadata,
+        "review_record_input": {
+            "decision": normalized["decision"],
+            "summary": normalized["summary"],
+            "reviewer": CODEX_APP_REVIEW_ADAPTER,
+            "kind": review_kind,
+            "findings_file": relative_to_root(findings_path, context["target_root"]),
+            "engine_adapter": CODEX_APP_REVIEW_ADAPTER,
+            "engine_evidence": relative_to_root(raw_path, context["target_root"]),
+            "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
+        },
     }
 
 
@@ -11523,9 +11792,11 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
+            adapter=requested_engine_adapter,
             requested_profile=args.engine_profile,
             requested_model=args.engine_model,
             requested_reasoning=args.engine_reasoning,
@@ -11548,8 +11819,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "missing_inputs": engine_profile_errors,
                     "fallback_to": None,
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
@@ -11588,8 +11859,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                     "current_checkpoint": flow_payload.get("current_checkpoint"),
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
@@ -11601,13 +11872,26 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(
-            context,
-            build_payload,
-            review_path,
-            engine_profile,
-            review_kind=review_kind,
-        )
+        if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER:
+            engine_payload = run_codex_app_review_authoritative_adapter(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+                app_server=args.codex_app_review_app_server,
+                thread_id=args.codex_app_review_thread_id,
+                thread_cwd=args.codex_app_review_cwd,
+                raw_file=args.codex_app_review_raw_file,
+            )
+        else:
+            engine_payload = run_default_review_engine(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+            )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,
             adapter=args.shadow_engine_adapter,
@@ -11630,7 +11914,7 @@ def handle_review(args: argparse.Namespace) -> int:
         summary = (
             engine_payload["summary"]
             if result == "pass"
-            else "default review engine failed closed; record any formal review conclusion through the single review record."
+            else f"{requested_engine_adapter} review engine failed closed; record any formal review conclusion through the single review record."
         )
         return emit(
             {
@@ -11652,6 +11936,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"engine_metadata": engine_payload["engine_metadata"]} if isinstance(engine_payload.get("engine_metadata"), dict) else {}),
                 **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),

--- a/skills/loom-handoff/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-handoff/.loom-runtime/loom-review/SKILL.md
@@ -42,7 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+
+默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -52,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 

--- a/skills/loom-handoff/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-handoff/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，生成 Loom-normalized spec findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,6 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/review-execution.md
@@ -47,15 +47,15 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 Codex。
+默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+Codex App review adapter 有两种显式入口，默认均不启用：
 
 - 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
 - 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
@@ -63,17 +63,22 @@ Loom 把 review 分成四层：
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
+- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
+- authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract
 
-`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+`review run` 在调用 Codex-backed reviewer 或 Codex App authoritative adapter 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: 当前固定为 `loom/default-codex`
-- `engine`: 当前固定为 `codex`
+- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
+- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -757,6 +757,13 @@ output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
 sys.exit(0)
 """
+    elif mode == "fail_if_called":
+        body = """#!/usr/bin/env python3
+import sys
+
+sys.stderr.write("codex exec must not be called for explicit Codex App review adapter\\n")
+sys.exit(41)
+"""
     else:
         raise ValueError(f"unknown fake codex mode: {mode}")
     path.write_text(body, encoding="utf-8")
@@ -3005,10 +3012,12 @@ def require_review_run_payload(
     engine = payload.get("engine")
     if not isinstance(engine, dict):
         return
-    if engine.get("engine") != "codex":
-        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
-    if engine.get("adapter") != "loom/default-codex":
-        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    engine_adapter = engine.get("adapter")
+    if engine_adapter not in {"loom/default-codex", "loom/codex-app-review"}:
+        failures.append(Failure(category, f"{context} adapter must be a supported authoritative review adapter"))
+    expected_engine = "codex-app-review" if engine_adapter == "loom/codex-app-review" else "codex"
+    if engine.get("engine") != expected_engine:
+        failures.append(Failure(category, f"{context} engine must match the selected authoritative adapter"))
     profile = engine.get("profile")
     if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
         pass
@@ -3017,8 +3026,8 @@ def require_review_run_payload(
     else:
         if profile.get("schema_version") != "loom-review-engine-profile/v1":
             failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
-        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
-            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("adapter") != engine_adapter or profile.get("engine") != expected_engine:
+            failures.append(Failure(category, f"{context} engine profile must bind the selected adapter explicitly"))
         if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
             failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
         for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
@@ -3077,8 +3086,10 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
-            if review_record_input.get("reviewer") != "loom/default-codex":
-                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+            if review_record_input.get("reviewer") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input reviewer must match the selected adapter"))
+            if review_record_input.get("engine_adapter") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input engine_adapter must match the selected adapter"))
     shadow_engine = payload.get("shadow_engine")
     if shadow_engine is not None:
         if not isinstance(shadow_engine, dict):
@@ -5709,6 +5720,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex" or engine.get("adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep the default codex exec adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex" or review_record_input.get("reviewer") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep default review_record_input adapter"))
                 evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
                 context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
                 prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
@@ -5844,6 +5861,154 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
+        prepare_review_target(app_authoritative_target, "review run Codex App authoritative")
+        app_raw = app_authoritative_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App authoritative reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-warn-1",
+                            "summary": "Codex App authoritative review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_authoritative_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_authoritative_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App authoritative failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App authoritative",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must author app adapter review_record_input"))
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must not call codex exec"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("thread_id") != "thread-stage2-live-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must expose live thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_authoritative_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume raw Codex App authoritative evidence before review record is authored"))
+
+        app_missing_target = Path(tmp) / "review-run-codex-app-missing-proof"
+        prepare_review_target(app_missing_target, "review run Codex App missing proof")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_missing_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App missing proof failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App missing proof must fail closed"))
+
+        app_invalid_target = Path(tmp) / "review-run-codex-app-invalid-raw"
+        prepare_review_target(app_invalid_target, "review run Codex App invalid raw")
+        invalid_raw = app_invalid_target / ".loom/runtime/tmp/codex-app-review-invalid.txt"
+        invalid_raw.parent.mkdir(parents=True, exist_ok=True)
+        invalid_raw.write_text("plain review text is not authoritative schema\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_invalid_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_invalid_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-invalid.txt",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App invalid raw failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App invalid raw must fail closed on schema drift"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,7 +113,10 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
-CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ENGINE = "codex-app-review"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
+AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
@@ -444,9 +447,32 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--reviewer", help="Reviewer identity")
     review.add_argument("--fallback-to", choices=("admission", "build", "merge"))
     review.add_argument("--findings-file", help="Optional findings JSON path relative to the target root")
-    review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
+    review.add_argument(
+        "--engine-adapter",
+        choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
+        help=(
+            "Optional authoritative review engine adapter for review run/record. "
+            "Default review run remains loom/default-codex."
+        ),
+    )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument(
+        "--codex-app-review-app-server",
+        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-thread-id",
+        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-cwd",
+        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-raw-file",
+        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+    )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
@@ -7034,11 +7060,14 @@ def resolve_review_engine_profile(
     context: dict[str, Any],
     review_kind: str,
     *,
+    adapter: str = DEFAULT_REVIEW_ADAPTER,
     requested_profile: str | None = None,
     requested_model: str | None = None,
     requested_reasoning: str | None = None,
     override_reason: str | None = None,
 ) -> tuple[dict[str, Any] | None, list[str]]:
+    if adapter not in AUTHORITATIVE_REVIEW_ADAPTERS:
+        return None, [f"unsupported authoritative review adapter: {adapter}"]
     selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
     if requested_profile:
         selected_profile = requested_profile
@@ -7061,8 +7090,8 @@ def resolve_review_engine_profile(
     resolved = {
         "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
         "profile_id": base_profile["profile_id"],
-        "adapter": DEFAULT_REVIEW_ADAPTER,
-        "engine": DEFAULT_REVIEW_ENGINE,
+        "adapter": adapter,
+        "engine": CODEX_APP_REVIEW_ENGINE if adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
         "model": base_profile["model"],
         "reasoning_effort": base_profile["reasoning_effort"],
         "timeout_seconds": int(base_profile["timeout_seconds"]),
@@ -7158,6 +7187,20 @@ def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[di
             }
         ],
     }, []
+
+
+def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App authoritative review output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, [f"Codex App authoritative review output `{relative}` must be normalized JSON: {exc}"]
+    normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+    if errors or normalized is None:
+        return None, errors
+    return normalized, []
 
 
 def shadow_adapter_slug(adapter: str) -> str:
@@ -7345,6 +7388,232 @@ def run_codex_app_review_shadow_adapter(
         "evidence": evidence,
         "decision": normalized["decision"],
         "parity_diff": parity_diff,
+    }
+
+
+def run_codex_app_review_authoritative_adapter(
+    context: dict[str, Any],
+    build_payload: dict[str, Any],
+    review_path: str,
+    engine_profile: dict[str, Any],
+    *,
+    review_kind: str,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    raw_path = runtime_root / "engine-result.json"
+    findings_path = runtime_root / "normalized-findings.json"
+    metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
+    instructions_path = runtime_root / "prompt.txt"
+    context_pack = build_review_context_pack(context, review_path)
+    evidence = {
+        "runtime_root": relative_to_root(runtime_root, context["target_root"]),
+        "prompt": relative_to_root(instructions_path, context["target_root"]),
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+    }
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
+    instructions_path.write_text(
+        build_default_review_prompt(
+            context=context,
+            build_payload=build_payload,
+            runtime_fields=runtime_evidence_from_report(context["report"])[0],
+            review_path=review_path,
+            context_pack=context_pack,
+        ),
+        encoding="utf-8",
+    )
+
+    missing_inputs: list[str] = []
+    for label, value in (
+        ("--codex-app-review-app-server", app_server),
+        ("--codex-app-review-thread-id", thread_id),
+        ("--codex-app-review-cwd", thread_cwd),
+        ("--codex-app-review-raw-file", raw_file),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(label)
+
+    cwd_relative: str | None = None
+    if isinstance(thread_cwd, str) and thread_cwd.strip():
+        try:
+            cwd_path = Path(thread_cwd).expanduser().resolve()
+        except OSError as exc:
+            missing_inputs.append(f"Codex App review cwd could not be resolved: {exc}")
+        else:
+            if cwd_path != context["target_root"]:
+                missing_inputs.append(
+                    f"Codex App review cwd `{cwd_path}` does not match target root `{context['target_root']}`"
+                )
+            else:
+                cwd_relative = relative_to_root(cwd_path, context["target_root"])
+
+    source_path: Path | None = None
+    source_relative: str | None = None
+    if isinstance(raw_file, str) and raw_file.strip():
+        source_path, source_errors = resolve_repo_relative_path(
+            context["target_root"],
+            raw_file,
+            label="Codex App authoritative review raw file",
+        )
+        missing_inputs.extend(source_errors)
+        if source_path is not None:
+            source_relative = relative_to_root(source_path, context["target_root"])
+
+    if missing_inputs:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "summary": "Codex App authoritative review adapter is missing required live binding proof.",
+                "missing_inputs": missing_inputs,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review adapter failed closed before a formal review record could be authored.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+                "raw_source": source_relative,
+            },
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
+    except OSError as exc:
+        raw_text = ""
+        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+        normalized = None
+    else:
+        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+            raw_text,
+            relative=source_relative or str(raw_file),
+        )
+
+    if normalization_errors or normalized is None:
+        if raw_text:
+            raw_path.write_text(raw_text, encoding="utf-8")
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "summary": "Codex App authoritative review output did not satisfy the Loom review result schema.",
+                "errors": normalization_errors,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        }
+
+    raw_path.write_text(raw_text, encoding="utf-8")
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    metadata = {
+        "schema_version": "loom-review-engine-metadata/v1",
+        "engine": CODEX_APP_REVIEW_ENGINE,
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "profile": engine_profile,
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+        "result": "pass",
+        "reviewed_head": reviewed_head,
+        "decision": normalized["decision"],
+        "summary": normalized["summary"],
+        "kind": review_kind,
+        "validation_summary": context["latest_validation_summary"],
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_relative,
+        "raw_source": source_relative,
+        "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
+    }
+    write_json_file(metadata_path, metadata)
+    return {
+        "result": "pass",
+        "summary": "Codex App authoritative review adapter produced a Loom-normalized formal review draft.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "engine": {
+            "engine": CODEX_APP_REVIEW_ENGINE,
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "profile": engine_profile,
+            "result": "pass",
+            "failure_reason": None,
+            "reviewed_head": reviewed_head,
+            "evidence": evidence,
+        },
+        "engine_metadata": metadata,
+        "review_record_input": {
+            "decision": normalized["decision"],
+            "summary": normalized["summary"],
+            "reviewer": CODEX_APP_REVIEW_ADAPTER,
+            "kind": review_kind,
+            "findings_file": relative_to_root(findings_path, context["target_root"]),
+            "engine_adapter": CODEX_APP_REVIEW_ADAPTER,
+            "engine_evidence": relative_to_root(raw_path, context["target_root"]),
+            "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
+        },
     }
 
 
@@ -11523,9 +11792,11 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
+            adapter=requested_engine_adapter,
             requested_profile=args.engine_profile,
             requested_model=args.engine_model,
             requested_reasoning=args.engine_reasoning,
@@ -11548,8 +11819,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "missing_inputs": engine_profile_errors,
                     "fallback_to": None,
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
@@ -11588,8 +11859,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                     "current_checkpoint": flow_payload.get("current_checkpoint"),
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
@@ -11601,13 +11872,26 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(
-            context,
-            build_payload,
-            review_path,
-            engine_profile,
-            review_kind=review_kind,
-        )
+        if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER:
+            engine_payload = run_codex_app_review_authoritative_adapter(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+                app_server=args.codex_app_review_app_server,
+                thread_id=args.codex_app_review_thread_id,
+                thread_cwd=args.codex_app_review_cwd,
+                raw_file=args.codex_app_review_raw_file,
+            )
+        else:
+            engine_payload = run_default_review_engine(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+            )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,
             adapter=args.shadow_engine_adapter,
@@ -11630,7 +11914,7 @@ def handle_review(args: argparse.Namespace) -> int:
         summary = (
             engine_payload["summary"]
             if result == "pass"
-            else "default review engine failed closed; record any formal review conclusion through the single review record."
+            else f"{requested_engine_adapter} review engine failed closed; record any formal review conclusion through the single review record."
         )
         return emit(
             {
@@ -11652,6 +11936,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"engine_metadata": engine_payload["engine_metadata"]} if isinstance(engine_payload.get("engine_metadata"), dict) else {}),
                 **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),

--- a/skills/loom-init/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-init/.loom-runtime/loom-review/SKILL.md
@@ -42,7 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+
+默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -52,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 

--- a/skills/loom-init/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-init/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，生成 Loom-normalized spec findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,6 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-init/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/review-execution.md
@@ -47,15 +47,15 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 Codex。
+默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+Codex App review adapter 有两种显式入口，默认均不启用：
 
 - 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
 - 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
@@ -63,17 +63,22 @@ Loom 把 review 分成四层：
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
+- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
+- authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract
 
-`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+`review run` 在调用 Codex-backed reviewer 或 Codex App authoritative adapter 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: 当前固定为 `loom/default-codex`
-- `engine`: 当前固定为 `codex`
+- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
+- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -757,6 +757,13 @@ output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
 sys.exit(0)
 """
+    elif mode == "fail_if_called":
+        body = """#!/usr/bin/env python3
+import sys
+
+sys.stderr.write("codex exec must not be called for explicit Codex App review adapter\\n")
+sys.exit(41)
+"""
     else:
         raise ValueError(f"unknown fake codex mode: {mode}")
     path.write_text(body, encoding="utf-8")
@@ -3005,10 +3012,12 @@ def require_review_run_payload(
     engine = payload.get("engine")
     if not isinstance(engine, dict):
         return
-    if engine.get("engine") != "codex":
-        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
-    if engine.get("adapter") != "loom/default-codex":
-        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    engine_adapter = engine.get("adapter")
+    if engine_adapter not in {"loom/default-codex", "loom/codex-app-review"}:
+        failures.append(Failure(category, f"{context} adapter must be a supported authoritative review adapter"))
+    expected_engine = "codex-app-review" if engine_adapter == "loom/codex-app-review" else "codex"
+    if engine.get("engine") != expected_engine:
+        failures.append(Failure(category, f"{context} engine must match the selected authoritative adapter"))
     profile = engine.get("profile")
     if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
         pass
@@ -3017,8 +3026,8 @@ def require_review_run_payload(
     else:
         if profile.get("schema_version") != "loom-review-engine-profile/v1":
             failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
-        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
-            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("adapter") != engine_adapter or profile.get("engine") != expected_engine:
+            failures.append(Failure(category, f"{context} engine profile must bind the selected adapter explicitly"))
         if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
             failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
         for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
@@ -3077,8 +3086,10 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
-            if review_record_input.get("reviewer") != "loom/default-codex":
-                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+            if review_record_input.get("reviewer") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input reviewer must match the selected adapter"))
+            if review_record_input.get("engine_adapter") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input engine_adapter must match the selected adapter"))
     shadow_engine = payload.get("shadow_engine")
     if shadow_engine is not None:
         if not isinstance(shadow_engine, dict):
@@ -5709,6 +5720,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex" or engine.get("adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep the default codex exec adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex" or review_record_input.get("reviewer") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep default review_record_input adapter"))
                 evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
                 context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
                 prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
@@ -5844,6 +5861,154 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
+        prepare_review_target(app_authoritative_target, "review run Codex App authoritative")
+        app_raw = app_authoritative_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App authoritative reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-warn-1",
+                            "summary": "Codex App authoritative review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_authoritative_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_authoritative_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App authoritative failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App authoritative",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must author app adapter review_record_input"))
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must not call codex exec"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("thread_id") != "thread-stage2-live-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must expose live thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_authoritative_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume raw Codex App authoritative evidence before review record is authored"))
+
+        app_missing_target = Path(tmp) / "review-run-codex-app-missing-proof"
+        prepare_review_target(app_missing_target, "review run Codex App missing proof")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_missing_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App missing proof failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App missing proof must fail closed"))
+
+        app_invalid_target = Path(tmp) / "review-run-codex-app-invalid-raw"
+        prepare_review_target(app_invalid_target, "review run Codex App invalid raw")
+        invalid_raw = app_invalid_target / ".loom/runtime/tmp/codex-app-review-invalid.txt"
+        invalid_raw.parent.mkdir(parents=True, exist_ok=True)
+        invalid_raw.write_text("plain review text is not authoritative schema\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_invalid_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_invalid_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-invalid.txt",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App invalid raw failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App invalid raw must fail closed on schema drift"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,7 +113,10 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
-CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ENGINE = "codex-app-review"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
+AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
@@ -444,9 +447,32 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--reviewer", help="Reviewer identity")
     review.add_argument("--fallback-to", choices=("admission", "build", "merge"))
     review.add_argument("--findings-file", help="Optional findings JSON path relative to the target root")
-    review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
+    review.add_argument(
+        "--engine-adapter",
+        choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
+        help=(
+            "Optional authoritative review engine adapter for review run/record. "
+            "Default review run remains loom/default-codex."
+        ),
+    )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument(
+        "--codex-app-review-app-server",
+        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-thread-id",
+        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-cwd",
+        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-raw-file",
+        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+    )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
@@ -7034,11 +7060,14 @@ def resolve_review_engine_profile(
     context: dict[str, Any],
     review_kind: str,
     *,
+    adapter: str = DEFAULT_REVIEW_ADAPTER,
     requested_profile: str | None = None,
     requested_model: str | None = None,
     requested_reasoning: str | None = None,
     override_reason: str | None = None,
 ) -> tuple[dict[str, Any] | None, list[str]]:
+    if adapter not in AUTHORITATIVE_REVIEW_ADAPTERS:
+        return None, [f"unsupported authoritative review adapter: {adapter}"]
     selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
     if requested_profile:
         selected_profile = requested_profile
@@ -7061,8 +7090,8 @@ def resolve_review_engine_profile(
     resolved = {
         "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
         "profile_id": base_profile["profile_id"],
-        "adapter": DEFAULT_REVIEW_ADAPTER,
-        "engine": DEFAULT_REVIEW_ENGINE,
+        "adapter": adapter,
+        "engine": CODEX_APP_REVIEW_ENGINE if adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
         "model": base_profile["model"],
         "reasoning_effort": base_profile["reasoning_effort"],
         "timeout_seconds": int(base_profile["timeout_seconds"]),
@@ -7158,6 +7187,20 @@ def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[di
             }
         ],
     }, []
+
+
+def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App authoritative review output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, [f"Codex App authoritative review output `{relative}` must be normalized JSON: {exc}"]
+    normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+    if errors or normalized is None:
+        return None, errors
+    return normalized, []
 
 
 def shadow_adapter_slug(adapter: str) -> str:
@@ -7345,6 +7388,232 @@ def run_codex_app_review_shadow_adapter(
         "evidence": evidence,
         "decision": normalized["decision"],
         "parity_diff": parity_diff,
+    }
+
+
+def run_codex_app_review_authoritative_adapter(
+    context: dict[str, Any],
+    build_payload: dict[str, Any],
+    review_path: str,
+    engine_profile: dict[str, Any],
+    *,
+    review_kind: str,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    raw_path = runtime_root / "engine-result.json"
+    findings_path = runtime_root / "normalized-findings.json"
+    metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
+    instructions_path = runtime_root / "prompt.txt"
+    context_pack = build_review_context_pack(context, review_path)
+    evidence = {
+        "runtime_root": relative_to_root(runtime_root, context["target_root"]),
+        "prompt": relative_to_root(instructions_path, context["target_root"]),
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+    }
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
+    instructions_path.write_text(
+        build_default_review_prompt(
+            context=context,
+            build_payload=build_payload,
+            runtime_fields=runtime_evidence_from_report(context["report"])[0],
+            review_path=review_path,
+            context_pack=context_pack,
+        ),
+        encoding="utf-8",
+    )
+
+    missing_inputs: list[str] = []
+    for label, value in (
+        ("--codex-app-review-app-server", app_server),
+        ("--codex-app-review-thread-id", thread_id),
+        ("--codex-app-review-cwd", thread_cwd),
+        ("--codex-app-review-raw-file", raw_file),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(label)
+
+    cwd_relative: str | None = None
+    if isinstance(thread_cwd, str) and thread_cwd.strip():
+        try:
+            cwd_path = Path(thread_cwd).expanduser().resolve()
+        except OSError as exc:
+            missing_inputs.append(f"Codex App review cwd could not be resolved: {exc}")
+        else:
+            if cwd_path != context["target_root"]:
+                missing_inputs.append(
+                    f"Codex App review cwd `{cwd_path}` does not match target root `{context['target_root']}`"
+                )
+            else:
+                cwd_relative = relative_to_root(cwd_path, context["target_root"])
+
+    source_path: Path | None = None
+    source_relative: str | None = None
+    if isinstance(raw_file, str) and raw_file.strip():
+        source_path, source_errors = resolve_repo_relative_path(
+            context["target_root"],
+            raw_file,
+            label="Codex App authoritative review raw file",
+        )
+        missing_inputs.extend(source_errors)
+        if source_path is not None:
+            source_relative = relative_to_root(source_path, context["target_root"])
+
+    if missing_inputs:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "summary": "Codex App authoritative review adapter is missing required live binding proof.",
+                "missing_inputs": missing_inputs,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review adapter failed closed before a formal review record could be authored.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+                "raw_source": source_relative,
+            },
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
+    except OSError as exc:
+        raw_text = ""
+        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+        normalized = None
+    else:
+        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+            raw_text,
+            relative=source_relative or str(raw_file),
+        )
+
+    if normalization_errors or normalized is None:
+        if raw_text:
+            raw_path.write_text(raw_text, encoding="utf-8")
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "summary": "Codex App authoritative review output did not satisfy the Loom review result schema.",
+                "errors": normalization_errors,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        }
+
+    raw_path.write_text(raw_text, encoding="utf-8")
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    metadata = {
+        "schema_version": "loom-review-engine-metadata/v1",
+        "engine": CODEX_APP_REVIEW_ENGINE,
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "profile": engine_profile,
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+        "result": "pass",
+        "reviewed_head": reviewed_head,
+        "decision": normalized["decision"],
+        "summary": normalized["summary"],
+        "kind": review_kind,
+        "validation_summary": context["latest_validation_summary"],
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_relative,
+        "raw_source": source_relative,
+        "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
+    }
+    write_json_file(metadata_path, metadata)
+    return {
+        "result": "pass",
+        "summary": "Codex App authoritative review adapter produced a Loom-normalized formal review draft.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "engine": {
+            "engine": CODEX_APP_REVIEW_ENGINE,
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "profile": engine_profile,
+            "result": "pass",
+            "failure_reason": None,
+            "reviewed_head": reviewed_head,
+            "evidence": evidence,
+        },
+        "engine_metadata": metadata,
+        "review_record_input": {
+            "decision": normalized["decision"],
+            "summary": normalized["summary"],
+            "reviewer": CODEX_APP_REVIEW_ADAPTER,
+            "kind": review_kind,
+            "findings_file": relative_to_root(findings_path, context["target_root"]),
+            "engine_adapter": CODEX_APP_REVIEW_ADAPTER,
+            "engine_evidence": relative_to_root(raw_path, context["target_root"]),
+            "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
+        },
     }
 
 
@@ -11523,9 +11792,11 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
+            adapter=requested_engine_adapter,
             requested_profile=args.engine_profile,
             requested_model=args.engine_model,
             requested_reasoning=args.engine_reasoning,
@@ -11548,8 +11819,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "missing_inputs": engine_profile_errors,
                     "fallback_to": None,
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
@@ -11588,8 +11859,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                     "current_checkpoint": flow_payload.get("current_checkpoint"),
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
@@ -11601,13 +11872,26 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(
-            context,
-            build_payload,
-            review_path,
-            engine_profile,
-            review_kind=review_kind,
-        )
+        if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER:
+            engine_payload = run_codex_app_review_authoritative_adapter(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+                app_server=args.codex_app_review_app_server,
+                thread_id=args.codex_app_review_thread_id,
+                thread_cwd=args.codex_app_review_cwd,
+                raw_file=args.codex_app_review_raw_file,
+            )
+        else:
+            engine_payload = run_default_review_engine(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+            )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,
             adapter=args.shadow_engine_adapter,
@@ -11630,7 +11914,7 @@ def handle_review(args: argparse.Namespace) -> int:
         summary = (
             engine_payload["summary"]
             if result == "pass"
-            else "default review engine failed closed; record any formal review conclusion through the single review record."
+            else f"{requested_engine_adapter} review engine failed closed; record any formal review conclusion through the single review record."
         )
         return emit(
             {
@@ -11652,6 +11936,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"engine_metadata": engine_payload["engine_metadata"]} if isinstance(engine_payload.get("engine_metadata"), dict) else {}),
                 **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),

--- a/skills/loom-merge-ready/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-review/SKILL.md
@@ -42,7 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+
+默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -52,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 

--- a/skills/loom-merge-ready/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，生成 Loom-normalized spec findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,6 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/review-execution.md
@@ -47,15 +47,15 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 Codex。
+默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+Codex App review adapter 有两种显式入口，默认均不启用：
 
 - 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
 - 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
@@ -63,17 +63,22 @@ Loom 把 review 分成四层：
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
+- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
+- authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract
 
-`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+`review run` 在调用 Codex-backed reviewer 或 Codex App authoritative adapter 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: 当前固定为 `loom/default-codex`
-- `engine`: 当前固定为 `codex`
+- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
+- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -757,6 +757,13 @@ output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
 sys.exit(0)
 """
+    elif mode == "fail_if_called":
+        body = """#!/usr/bin/env python3
+import sys
+
+sys.stderr.write("codex exec must not be called for explicit Codex App review adapter\\n")
+sys.exit(41)
+"""
     else:
         raise ValueError(f"unknown fake codex mode: {mode}")
     path.write_text(body, encoding="utf-8")
@@ -3005,10 +3012,12 @@ def require_review_run_payload(
     engine = payload.get("engine")
     if not isinstance(engine, dict):
         return
-    if engine.get("engine") != "codex":
-        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
-    if engine.get("adapter") != "loom/default-codex":
-        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    engine_adapter = engine.get("adapter")
+    if engine_adapter not in {"loom/default-codex", "loom/codex-app-review"}:
+        failures.append(Failure(category, f"{context} adapter must be a supported authoritative review adapter"))
+    expected_engine = "codex-app-review" if engine_adapter == "loom/codex-app-review" else "codex"
+    if engine.get("engine") != expected_engine:
+        failures.append(Failure(category, f"{context} engine must match the selected authoritative adapter"))
     profile = engine.get("profile")
     if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
         pass
@@ -3017,8 +3026,8 @@ def require_review_run_payload(
     else:
         if profile.get("schema_version") != "loom-review-engine-profile/v1":
             failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
-        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
-            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("adapter") != engine_adapter or profile.get("engine") != expected_engine:
+            failures.append(Failure(category, f"{context} engine profile must bind the selected adapter explicitly"))
         if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
             failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
         for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
@@ -3077,8 +3086,10 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
-            if review_record_input.get("reviewer") != "loom/default-codex":
-                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+            if review_record_input.get("reviewer") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input reviewer must match the selected adapter"))
+            if review_record_input.get("engine_adapter") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input engine_adapter must match the selected adapter"))
     shadow_engine = payload.get("shadow_engine")
     if shadow_engine is not None:
         if not isinstance(shadow_engine, dict):
@@ -5709,6 +5720,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex" or engine.get("adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep the default codex exec adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex" or review_record_input.get("reviewer") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep default review_record_input adapter"))
                 evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
                 context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
                 prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
@@ -5844,6 +5861,154 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
+        prepare_review_target(app_authoritative_target, "review run Codex App authoritative")
+        app_raw = app_authoritative_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App authoritative reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-warn-1",
+                            "summary": "Codex App authoritative review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_authoritative_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_authoritative_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App authoritative failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App authoritative",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must author app adapter review_record_input"))
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must not call codex exec"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("thread_id") != "thread-stage2-live-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must expose live thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_authoritative_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume raw Codex App authoritative evidence before review record is authored"))
+
+        app_missing_target = Path(tmp) / "review-run-codex-app-missing-proof"
+        prepare_review_target(app_missing_target, "review run Codex App missing proof")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_missing_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App missing proof failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App missing proof must fail closed"))
+
+        app_invalid_target = Path(tmp) / "review-run-codex-app-invalid-raw"
+        prepare_review_target(app_invalid_target, "review run Codex App invalid raw")
+        invalid_raw = app_invalid_target / ".loom/runtime/tmp/codex-app-review-invalid.txt"
+        invalid_raw.parent.mkdir(parents=True, exist_ok=True)
+        invalid_raw.write_text("plain review text is not authoritative schema\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_invalid_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_invalid_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-invalid.txt",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App invalid raw failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App invalid raw must fail closed on schema drift"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,7 +113,10 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
-CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ENGINE = "codex-app-review"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
+AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
@@ -444,9 +447,32 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--reviewer", help="Reviewer identity")
     review.add_argument("--fallback-to", choices=("admission", "build", "merge"))
     review.add_argument("--findings-file", help="Optional findings JSON path relative to the target root")
-    review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
+    review.add_argument(
+        "--engine-adapter",
+        choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
+        help=(
+            "Optional authoritative review engine adapter for review run/record. "
+            "Default review run remains loom/default-codex."
+        ),
+    )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument(
+        "--codex-app-review-app-server",
+        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-thread-id",
+        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-cwd",
+        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-raw-file",
+        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+    )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
@@ -7034,11 +7060,14 @@ def resolve_review_engine_profile(
     context: dict[str, Any],
     review_kind: str,
     *,
+    adapter: str = DEFAULT_REVIEW_ADAPTER,
     requested_profile: str | None = None,
     requested_model: str | None = None,
     requested_reasoning: str | None = None,
     override_reason: str | None = None,
 ) -> tuple[dict[str, Any] | None, list[str]]:
+    if adapter not in AUTHORITATIVE_REVIEW_ADAPTERS:
+        return None, [f"unsupported authoritative review adapter: {adapter}"]
     selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
     if requested_profile:
         selected_profile = requested_profile
@@ -7061,8 +7090,8 @@ def resolve_review_engine_profile(
     resolved = {
         "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
         "profile_id": base_profile["profile_id"],
-        "adapter": DEFAULT_REVIEW_ADAPTER,
-        "engine": DEFAULT_REVIEW_ENGINE,
+        "adapter": adapter,
+        "engine": CODEX_APP_REVIEW_ENGINE if adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
         "model": base_profile["model"],
         "reasoning_effort": base_profile["reasoning_effort"],
         "timeout_seconds": int(base_profile["timeout_seconds"]),
@@ -7158,6 +7187,20 @@ def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[di
             }
         ],
     }, []
+
+
+def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App authoritative review output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, [f"Codex App authoritative review output `{relative}` must be normalized JSON: {exc}"]
+    normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+    if errors or normalized is None:
+        return None, errors
+    return normalized, []
 
 
 def shadow_adapter_slug(adapter: str) -> str:
@@ -7345,6 +7388,232 @@ def run_codex_app_review_shadow_adapter(
         "evidence": evidence,
         "decision": normalized["decision"],
         "parity_diff": parity_diff,
+    }
+
+
+def run_codex_app_review_authoritative_adapter(
+    context: dict[str, Any],
+    build_payload: dict[str, Any],
+    review_path: str,
+    engine_profile: dict[str, Any],
+    *,
+    review_kind: str,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    raw_path = runtime_root / "engine-result.json"
+    findings_path = runtime_root / "normalized-findings.json"
+    metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
+    instructions_path = runtime_root / "prompt.txt"
+    context_pack = build_review_context_pack(context, review_path)
+    evidence = {
+        "runtime_root": relative_to_root(runtime_root, context["target_root"]),
+        "prompt": relative_to_root(instructions_path, context["target_root"]),
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+    }
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
+    instructions_path.write_text(
+        build_default_review_prompt(
+            context=context,
+            build_payload=build_payload,
+            runtime_fields=runtime_evidence_from_report(context["report"])[0],
+            review_path=review_path,
+            context_pack=context_pack,
+        ),
+        encoding="utf-8",
+    )
+
+    missing_inputs: list[str] = []
+    for label, value in (
+        ("--codex-app-review-app-server", app_server),
+        ("--codex-app-review-thread-id", thread_id),
+        ("--codex-app-review-cwd", thread_cwd),
+        ("--codex-app-review-raw-file", raw_file),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(label)
+
+    cwd_relative: str | None = None
+    if isinstance(thread_cwd, str) and thread_cwd.strip():
+        try:
+            cwd_path = Path(thread_cwd).expanduser().resolve()
+        except OSError as exc:
+            missing_inputs.append(f"Codex App review cwd could not be resolved: {exc}")
+        else:
+            if cwd_path != context["target_root"]:
+                missing_inputs.append(
+                    f"Codex App review cwd `{cwd_path}` does not match target root `{context['target_root']}`"
+                )
+            else:
+                cwd_relative = relative_to_root(cwd_path, context["target_root"])
+
+    source_path: Path | None = None
+    source_relative: str | None = None
+    if isinstance(raw_file, str) and raw_file.strip():
+        source_path, source_errors = resolve_repo_relative_path(
+            context["target_root"],
+            raw_file,
+            label="Codex App authoritative review raw file",
+        )
+        missing_inputs.extend(source_errors)
+        if source_path is not None:
+            source_relative = relative_to_root(source_path, context["target_root"])
+
+    if missing_inputs:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "summary": "Codex App authoritative review adapter is missing required live binding proof.",
+                "missing_inputs": missing_inputs,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review adapter failed closed before a formal review record could be authored.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+                "raw_source": source_relative,
+            },
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
+    except OSError as exc:
+        raw_text = ""
+        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+        normalized = None
+    else:
+        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+            raw_text,
+            relative=source_relative or str(raw_file),
+        )
+
+    if normalization_errors or normalized is None:
+        if raw_text:
+            raw_path.write_text(raw_text, encoding="utf-8")
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "summary": "Codex App authoritative review output did not satisfy the Loom review result schema.",
+                "errors": normalization_errors,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        }
+
+    raw_path.write_text(raw_text, encoding="utf-8")
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    metadata = {
+        "schema_version": "loom-review-engine-metadata/v1",
+        "engine": CODEX_APP_REVIEW_ENGINE,
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "profile": engine_profile,
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+        "result": "pass",
+        "reviewed_head": reviewed_head,
+        "decision": normalized["decision"],
+        "summary": normalized["summary"],
+        "kind": review_kind,
+        "validation_summary": context["latest_validation_summary"],
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_relative,
+        "raw_source": source_relative,
+        "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
+    }
+    write_json_file(metadata_path, metadata)
+    return {
+        "result": "pass",
+        "summary": "Codex App authoritative review adapter produced a Loom-normalized formal review draft.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "engine": {
+            "engine": CODEX_APP_REVIEW_ENGINE,
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "profile": engine_profile,
+            "result": "pass",
+            "failure_reason": None,
+            "reviewed_head": reviewed_head,
+            "evidence": evidence,
+        },
+        "engine_metadata": metadata,
+        "review_record_input": {
+            "decision": normalized["decision"],
+            "summary": normalized["summary"],
+            "reviewer": CODEX_APP_REVIEW_ADAPTER,
+            "kind": review_kind,
+            "findings_file": relative_to_root(findings_path, context["target_root"]),
+            "engine_adapter": CODEX_APP_REVIEW_ADAPTER,
+            "engine_evidence": relative_to_root(raw_path, context["target_root"]),
+            "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
+        },
     }
 
 
@@ -11523,9 +11792,11 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
+            adapter=requested_engine_adapter,
             requested_profile=args.engine_profile,
             requested_model=args.engine_model,
             requested_reasoning=args.engine_reasoning,
@@ -11548,8 +11819,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "missing_inputs": engine_profile_errors,
                     "fallback_to": None,
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
@@ -11588,8 +11859,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                     "current_checkpoint": flow_payload.get("current_checkpoint"),
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
@@ -11601,13 +11872,26 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(
-            context,
-            build_payload,
-            review_path,
-            engine_profile,
-            review_kind=review_kind,
-        )
+        if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER:
+            engine_payload = run_codex_app_review_authoritative_adapter(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+                app_server=args.codex_app_review_app_server,
+                thread_id=args.codex_app_review_thread_id,
+                thread_cwd=args.codex_app_review_cwd,
+                raw_file=args.codex_app_review_raw_file,
+            )
+        else:
+            engine_payload = run_default_review_engine(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+            )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,
             adapter=args.shadow_engine_adapter,
@@ -11630,7 +11914,7 @@ def handle_review(args: argparse.Namespace) -> int:
         summary = (
             engine_payload["summary"]
             if result == "pass"
-            else "default review engine failed closed; record any formal review conclusion through the single review record."
+            else f"{requested_engine_adapter} review engine failed closed; record any formal review conclusion through the single review record."
         )
         return emit(
             {
@@ -11652,6 +11936,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"engine_metadata": engine_payload["engine_metadata"]} if isinstance(engine_payload.get("engine_metadata"), dict) else {}),
                 **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),

--- a/skills/loom-pre-review/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-review/SKILL.md
@@ -42,7 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+
+默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -52,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 

--- a/skills/loom-pre-review/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，生成 Loom-normalized spec findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,6 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/review-execution.md
@@ -47,15 +47,15 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 Codex。
+默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+Codex App review adapter 有两种显式入口，默认均不启用：
 
 - 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
 - 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
@@ -63,17 +63,22 @@ Loom 把 review 分成四层：
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
+- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
+- authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract
 
-`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+`review run` 在调用 Codex-backed reviewer 或 Codex App authoritative adapter 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: 当前固定为 `loom/default-codex`
-- `engine`: 当前固定为 `codex`
+- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
+- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -757,6 +757,13 @@ output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
 sys.exit(0)
 """
+    elif mode == "fail_if_called":
+        body = """#!/usr/bin/env python3
+import sys
+
+sys.stderr.write("codex exec must not be called for explicit Codex App review adapter\\n")
+sys.exit(41)
+"""
     else:
         raise ValueError(f"unknown fake codex mode: {mode}")
     path.write_text(body, encoding="utf-8")
@@ -3005,10 +3012,12 @@ def require_review_run_payload(
     engine = payload.get("engine")
     if not isinstance(engine, dict):
         return
-    if engine.get("engine") != "codex":
-        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
-    if engine.get("adapter") != "loom/default-codex":
-        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    engine_adapter = engine.get("adapter")
+    if engine_adapter not in {"loom/default-codex", "loom/codex-app-review"}:
+        failures.append(Failure(category, f"{context} adapter must be a supported authoritative review adapter"))
+    expected_engine = "codex-app-review" if engine_adapter == "loom/codex-app-review" else "codex"
+    if engine.get("engine") != expected_engine:
+        failures.append(Failure(category, f"{context} engine must match the selected authoritative adapter"))
     profile = engine.get("profile")
     if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
         pass
@@ -3017,8 +3026,8 @@ def require_review_run_payload(
     else:
         if profile.get("schema_version") != "loom-review-engine-profile/v1":
             failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
-        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
-            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("adapter") != engine_adapter or profile.get("engine") != expected_engine:
+            failures.append(Failure(category, f"{context} engine profile must bind the selected adapter explicitly"))
         if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
             failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
         for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
@@ -3077,8 +3086,10 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
-            if review_record_input.get("reviewer") != "loom/default-codex":
-                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+            if review_record_input.get("reviewer") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input reviewer must match the selected adapter"))
+            if review_record_input.get("engine_adapter") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input engine_adapter must match the selected adapter"))
     shadow_engine = payload.get("shadow_engine")
     if shadow_engine is not None:
         if not isinstance(shadow_engine, dict):
@@ -5709,6 +5720,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex" or engine.get("adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep the default codex exec adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex" or review_record_input.get("reviewer") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep default review_record_input adapter"))
                 evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
                 context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
                 prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
@@ -5844,6 +5861,154 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
+        prepare_review_target(app_authoritative_target, "review run Codex App authoritative")
+        app_raw = app_authoritative_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App authoritative reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-warn-1",
+                            "summary": "Codex App authoritative review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_authoritative_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_authoritative_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App authoritative failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App authoritative",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must author app adapter review_record_input"))
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must not call codex exec"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("thread_id") != "thread-stage2-live-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must expose live thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_authoritative_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume raw Codex App authoritative evidence before review record is authored"))
+
+        app_missing_target = Path(tmp) / "review-run-codex-app-missing-proof"
+        prepare_review_target(app_missing_target, "review run Codex App missing proof")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_missing_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App missing proof failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App missing proof must fail closed"))
+
+        app_invalid_target = Path(tmp) / "review-run-codex-app-invalid-raw"
+        prepare_review_target(app_invalid_target, "review run Codex App invalid raw")
+        invalid_raw = app_invalid_target / ".loom/runtime/tmp/codex-app-review-invalid.txt"
+        invalid_raw.parent.mkdir(parents=True, exist_ok=True)
+        invalid_raw.write_text("plain review text is not authoritative schema\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_invalid_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_invalid_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-invalid.txt",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App invalid raw failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App invalid raw must fail closed on schema drift"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,7 +113,10 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
-CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ENGINE = "codex-app-review"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
+AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
@@ -444,9 +447,32 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--reviewer", help="Reviewer identity")
     review.add_argument("--fallback-to", choices=("admission", "build", "merge"))
     review.add_argument("--findings-file", help="Optional findings JSON path relative to the target root")
-    review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
+    review.add_argument(
+        "--engine-adapter",
+        choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
+        help=(
+            "Optional authoritative review engine adapter for review run/record. "
+            "Default review run remains loom/default-codex."
+        ),
+    )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument(
+        "--codex-app-review-app-server",
+        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-thread-id",
+        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-cwd",
+        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-raw-file",
+        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+    )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
@@ -7034,11 +7060,14 @@ def resolve_review_engine_profile(
     context: dict[str, Any],
     review_kind: str,
     *,
+    adapter: str = DEFAULT_REVIEW_ADAPTER,
     requested_profile: str | None = None,
     requested_model: str | None = None,
     requested_reasoning: str | None = None,
     override_reason: str | None = None,
 ) -> tuple[dict[str, Any] | None, list[str]]:
+    if adapter not in AUTHORITATIVE_REVIEW_ADAPTERS:
+        return None, [f"unsupported authoritative review adapter: {adapter}"]
     selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
     if requested_profile:
         selected_profile = requested_profile
@@ -7061,8 +7090,8 @@ def resolve_review_engine_profile(
     resolved = {
         "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
         "profile_id": base_profile["profile_id"],
-        "adapter": DEFAULT_REVIEW_ADAPTER,
-        "engine": DEFAULT_REVIEW_ENGINE,
+        "adapter": adapter,
+        "engine": CODEX_APP_REVIEW_ENGINE if adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
         "model": base_profile["model"],
         "reasoning_effort": base_profile["reasoning_effort"],
         "timeout_seconds": int(base_profile["timeout_seconds"]),
@@ -7158,6 +7187,20 @@ def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[di
             }
         ],
     }, []
+
+
+def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App authoritative review output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, [f"Codex App authoritative review output `{relative}` must be normalized JSON: {exc}"]
+    normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+    if errors or normalized is None:
+        return None, errors
+    return normalized, []
 
 
 def shadow_adapter_slug(adapter: str) -> str:
@@ -7345,6 +7388,232 @@ def run_codex_app_review_shadow_adapter(
         "evidence": evidence,
         "decision": normalized["decision"],
         "parity_diff": parity_diff,
+    }
+
+
+def run_codex_app_review_authoritative_adapter(
+    context: dict[str, Any],
+    build_payload: dict[str, Any],
+    review_path: str,
+    engine_profile: dict[str, Any],
+    *,
+    review_kind: str,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    raw_path = runtime_root / "engine-result.json"
+    findings_path = runtime_root / "normalized-findings.json"
+    metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
+    instructions_path = runtime_root / "prompt.txt"
+    context_pack = build_review_context_pack(context, review_path)
+    evidence = {
+        "runtime_root": relative_to_root(runtime_root, context["target_root"]),
+        "prompt": relative_to_root(instructions_path, context["target_root"]),
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+    }
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
+    instructions_path.write_text(
+        build_default_review_prompt(
+            context=context,
+            build_payload=build_payload,
+            runtime_fields=runtime_evidence_from_report(context["report"])[0],
+            review_path=review_path,
+            context_pack=context_pack,
+        ),
+        encoding="utf-8",
+    )
+
+    missing_inputs: list[str] = []
+    for label, value in (
+        ("--codex-app-review-app-server", app_server),
+        ("--codex-app-review-thread-id", thread_id),
+        ("--codex-app-review-cwd", thread_cwd),
+        ("--codex-app-review-raw-file", raw_file),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(label)
+
+    cwd_relative: str | None = None
+    if isinstance(thread_cwd, str) and thread_cwd.strip():
+        try:
+            cwd_path = Path(thread_cwd).expanduser().resolve()
+        except OSError as exc:
+            missing_inputs.append(f"Codex App review cwd could not be resolved: {exc}")
+        else:
+            if cwd_path != context["target_root"]:
+                missing_inputs.append(
+                    f"Codex App review cwd `{cwd_path}` does not match target root `{context['target_root']}`"
+                )
+            else:
+                cwd_relative = relative_to_root(cwd_path, context["target_root"])
+
+    source_path: Path | None = None
+    source_relative: str | None = None
+    if isinstance(raw_file, str) and raw_file.strip():
+        source_path, source_errors = resolve_repo_relative_path(
+            context["target_root"],
+            raw_file,
+            label="Codex App authoritative review raw file",
+        )
+        missing_inputs.extend(source_errors)
+        if source_path is not None:
+            source_relative = relative_to_root(source_path, context["target_root"])
+
+    if missing_inputs:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "summary": "Codex App authoritative review adapter is missing required live binding proof.",
+                "missing_inputs": missing_inputs,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review adapter failed closed before a formal review record could be authored.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+                "raw_source": source_relative,
+            },
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
+    except OSError as exc:
+        raw_text = ""
+        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+        normalized = None
+    else:
+        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+            raw_text,
+            relative=source_relative or str(raw_file),
+        )
+
+    if normalization_errors or normalized is None:
+        if raw_text:
+            raw_path.write_text(raw_text, encoding="utf-8")
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "summary": "Codex App authoritative review output did not satisfy the Loom review result schema.",
+                "errors": normalization_errors,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        }
+
+    raw_path.write_text(raw_text, encoding="utf-8")
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    metadata = {
+        "schema_version": "loom-review-engine-metadata/v1",
+        "engine": CODEX_APP_REVIEW_ENGINE,
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "profile": engine_profile,
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+        "result": "pass",
+        "reviewed_head": reviewed_head,
+        "decision": normalized["decision"],
+        "summary": normalized["summary"],
+        "kind": review_kind,
+        "validation_summary": context["latest_validation_summary"],
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_relative,
+        "raw_source": source_relative,
+        "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
+    }
+    write_json_file(metadata_path, metadata)
+    return {
+        "result": "pass",
+        "summary": "Codex App authoritative review adapter produced a Loom-normalized formal review draft.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "engine": {
+            "engine": CODEX_APP_REVIEW_ENGINE,
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "profile": engine_profile,
+            "result": "pass",
+            "failure_reason": None,
+            "reviewed_head": reviewed_head,
+            "evidence": evidence,
+        },
+        "engine_metadata": metadata,
+        "review_record_input": {
+            "decision": normalized["decision"],
+            "summary": normalized["summary"],
+            "reviewer": CODEX_APP_REVIEW_ADAPTER,
+            "kind": review_kind,
+            "findings_file": relative_to_root(findings_path, context["target_root"]),
+            "engine_adapter": CODEX_APP_REVIEW_ADAPTER,
+            "engine_evidence": relative_to_root(raw_path, context["target_root"]),
+            "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
+        },
     }
 
 
@@ -11523,9 +11792,11 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
+            adapter=requested_engine_adapter,
             requested_profile=args.engine_profile,
             requested_model=args.engine_model,
             requested_reasoning=args.engine_reasoning,
@@ -11548,8 +11819,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "missing_inputs": engine_profile_errors,
                     "fallback_to": None,
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
@@ -11588,8 +11859,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                     "current_checkpoint": flow_payload.get("current_checkpoint"),
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
@@ -11601,13 +11872,26 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(
-            context,
-            build_payload,
-            review_path,
-            engine_profile,
-            review_kind=review_kind,
-        )
+        if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER:
+            engine_payload = run_codex_app_review_authoritative_adapter(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+                app_server=args.codex_app_review_app_server,
+                thread_id=args.codex_app_review_thread_id,
+                thread_cwd=args.codex_app_review_cwd,
+                raw_file=args.codex_app_review_raw_file,
+            )
+        else:
+            engine_payload = run_default_review_engine(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+            )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,
             adapter=args.shadow_engine_adapter,
@@ -11630,7 +11914,7 @@ def handle_review(args: argparse.Namespace) -> int:
         summary = (
             engine_payload["summary"]
             if result == "pass"
-            else "default review engine failed closed; record any formal review conclusion through the single review record."
+            else f"{requested_engine_adapter} review engine failed closed; record any formal review conclusion through the single review record."
         )
         return emit(
             {
@@ -11652,6 +11936,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"engine_metadata": engine_payload["engine_metadata"]} if isinstance(engine_payload.get("engine_metadata"), dict) else {}),
                 **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),

--- a/skills/loom-resume/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-resume/.loom-runtime/loom-review/SKILL.md
@@ -42,7 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+
+默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -52,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 

--- a/skills/loom-resume/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-resume/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，生成 Loom-normalized spec findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,6 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/review-execution.md
@@ -47,15 +47,15 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 Codex。
+默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+Codex App review adapter 有两种显式入口，默认均不启用：
 
 - 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
 - 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
@@ -63,17 +63,22 @@ Loom 把 review 分成四层：
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
+- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
+- authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract
 
-`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+`review run` 在调用 Codex-backed reviewer 或 Codex App authoritative adapter 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: 当前固定为 `loom/default-codex`
-- `engine`: 当前固定为 `codex`
+- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
+- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -757,6 +757,13 @@ output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
 sys.exit(0)
 """
+    elif mode == "fail_if_called":
+        body = """#!/usr/bin/env python3
+import sys
+
+sys.stderr.write("codex exec must not be called for explicit Codex App review adapter\\n")
+sys.exit(41)
+"""
     else:
         raise ValueError(f"unknown fake codex mode: {mode}")
     path.write_text(body, encoding="utf-8")
@@ -3005,10 +3012,12 @@ def require_review_run_payload(
     engine = payload.get("engine")
     if not isinstance(engine, dict):
         return
-    if engine.get("engine") != "codex":
-        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
-    if engine.get("adapter") != "loom/default-codex":
-        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    engine_adapter = engine.get("adapter")
+    if engine_adapter not in {"loom/default-codex", "loom/codex-app-review"}:
+        failures.append(Failure(category, f"{context} adapter must be a supported authoritative review adapter"))
+    expected_engine = "codex-app-review" if engine_adapter == "loom/codex-app-review" else "codex"
+    if engine.get("engine") != expected_engine:
+        failures.append(Failure(category, f"{context} engine must match the selected authoritative adapter"))
     profile = engine.get("profile")
     if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
         pass
@@ -3017,8 +3026,8 @@ def require_review_run_payload(
     else:
         if profile.get("schema_version") != "loom-review-engine-profile/v1":
             failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
-        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
-            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("adapter") != engine_adapter or profile.get("engine") != expected_engine:
+            failures.append(Failure(category, f"{context} engine profile must bind the selected adapter explicitly"))
         if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
             failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
         for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
@@ -3077,8 +3086,10 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
-            if review_record_input.get("reviewer") != "loom/default-codex":
-                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+            if review_record_input.get("reviewer") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input reviewer must match the selected adapter"))
+            if review_record_input.get("engine_adapter") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input engine_adapter must match the selected adapter"))
     shadow_engine = payload.get("shadow_engine")
     if shadow_engine is not None:
         if not isinstance(shadow_engine, dict):
@@ -5709,6 +5720,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex" or engine.get("adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep the default codex exec adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex" or review_record_input.get("reviewer") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep default review_record_input adapter"))
                 evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
                 context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
                 prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
@@ -5844,6 +5861,154 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
+        prepare_review_target(app_authoritative_target, "review run Codex App authoritative")
+        app_raw = app_authoritative_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App authoritative reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-warn-1",
+                            "summary": "Codex App authoritative review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_authoritative_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_authoritative_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App authoritative failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App authoritative",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must author app adapter review_record_input"))
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must not call codex exec"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("thread_id") != "thread-stage2-live-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must expose live thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_authoritative_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume raw Codex App authoritative evidence before review record is authored"))
+
+        app_missing_target = Path(tmp) / "review-run-codex-app-missing-proof"
+        prepare_review_target(app_missing_target, "review run Codex App missing proof")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_missing_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App missing proof failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App missing proof must fail closed"))
+
+        app_invalid_target = Path(tmp) / "review-run-codex-app-invalid-raw"
+        prepare_review_target(app_invalid_target, "review run Codex App invalid raw")
+        invalid_raw = app_invalid_target / ".loom/runtime/tmp/codex-app-review-invalid.txt"
+        invalid_raw.parent.mkdir(parents=True, exist_ok=True)
+        invalid_raw.write_text("plain review text is not authoritative schema\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_invalid_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_invalid_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-invalid.txt",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App invalid raw failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App invalid raw must fail closed on schema drift"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,7 +113,10 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
-CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ENGINE = "codex-app-review"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
+AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
@@ -444,9 +447,32 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--reviewer", help="Reviewer identity")
     review.add_argument("--fallback-to", choices=("admission", "build", "merge"))
     review.add_argument("--findings-file", help="Optional findings JSON path relative to the target root")
-    review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
+    review.add_argument(
+        "--engine-adapter",
+        choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
+        help=(
+            "Optional authoritative review engine adapter for review run/record. "
+            "Default review run remains loom/default-codex."
+        ),
+    )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument(
+        "--codex-app-review-app-server",
+        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-thread-id",
+        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-cwd",
+        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-raw-file",
+        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+    )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
@@ -7034,11 +7060,14 @@ def resolve_review_engine_profile(
     context: dict[str, Any],
     review_kind: str,
     *,
+    adapter: str = DEFAULT_REVIEW_ADAPTER,
     requested_profile: str | None = None,
     requested_model: str | None = None,
     requested_reasoning: str | None = None,
     override_reason: str | None = None,
 ) -> tuple[dict[str, Any] | None, list[str]]:
+    if adapter not in AUTHORITATIVE_REVIEW_ADAPTERS:
+        return None, [f"unsupported authoritative review adapter: {adapter}"]
     selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
     if requested_profile:
         selected_profile = requested_profile
@@ -7061,8 +7090,8 @@ def resolve_review_engine_profile(
     resolved = {
         "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
         "profile_id": base_profile["profile_id"],
-        "adapter": DEFAULT_REVIEW_ADAPTER,
-        "engine": DEFAULT_REVIEW_ENGINE,
+        "adapter": adapter,
+        "engine": CODEX_APP_REVIEW_ENGINE if adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
         "model": base_profile["model"],
         "reasoning_effort": base_profile["reasoning_effort"],
         "timeout_seconds": int(base_profile["timeout_seconds"]),
@@ -7158,6 +7187,20 @@ def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[di
             }
         ],
     }, []
+
+
+def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App authoritative review output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, [f"Codex App authoritative review output `{relative}` must be normalized JSON: {exc}"]
+    normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+    if errors or normalized is None:
+        return None, errors
+    return normalized, []
 
 
 def shadow_adapter_slug(adapter: str) -> str:
@@ -7345,6 +7388,232 @@ def run_codex_app_review_shadow_adapter(
         "evidence": evidence,
         "decision": normalized["decision"],
         "parity_diff": parity_diff,
+    }
+
+
+def run_codex_app_review_authoritative_adapter(
+    context: dict[str, Any],
+    build_payload: dict[str, Any],
+    review_path: str,
+    engine_profile: dict[str, Any],
+    *,
+    review_kind: str,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    raw_path = runtime_root / "engine-result.json"
+    findings_path = runtime_root / "normalized-findings.json"
+    metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
+    instructions_path = runtime_root / "prompt.txt"
+    context_pack = build_review_context_pack(context, review_path)
+    evidence = {
+        "runtime_root": relative_to_root(runtime_root, context["target_root"]),
+        "prompt": relative_to_root(instructions_path, context["target_root"]),
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+    }
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
+    instructions_path.write_text(
+        build_default_review_prompt(
+            context=context,
+            build_payload=build_payload,
+            runtime_fields=runtime_evidence_from_report(context["report"])[0],
+            review_path=review_path,
+            context_pack=context_pack,
+        ),
+        encoding="utf-8",
+    )
+
+    missing_inputs: list[str] = []
+    for label, value in (
+        ("--codex-app-review-app-server", app_server),
+        ("--codex-app-review-thread-id", thread_id),
+        ("--codex-app-review-cwd", thread_cwd),
+        ("--codex-app-review-raw-file", raw_file),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(label)
+
+    cwd_relative: str | None = None
+    if isinstance(thread_cwd, str) and thread_cwd.strip():
+        try:
+            cwd_path = Path(thread_cwd).expanduser().resolve()
+        except OSError as exc:
+            missing_inputs.append(f"Codex App review cwd could not be resolved: {exc}")
+        else:
+            if cwd_path != context["target_root"]:
+                missing_inputs.append(
+                    f"Codex App review cwd `{cwd_path}` does not match target root `{context['target_root']}`"
+                )
+            else:
+                cwd_relative = relative_to_root(cwd_path, context["target_root"])
+
+    source_path: Path | None = None
+    source_relative: str | None = None
+    if isinstance(raw_file, str) and raw_file.strip():
+        source_path, source_errors = resolve_repo_relative_path(
+            context["target_root"],
+            raw_file,
+            label="Codex App authoritative review raw file",
+        )
+        missing_inputs.extend(source_errors)
+        if source_path is not None:
+            source_relative = relative_to_root(source_path, context["target_root"])
+
+    if missing_inputs:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "summary": "Codex App authoritative review adapter is missing required live binding proof.",
+                "missing_inputs": missing_inputs,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review adapter failed closed before a formal review record could be authored.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+                "raw_source": source_relative,
+            },
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
+    except OSError as exc:
+        raw_text = ""
+        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+        normalized = None
+    else:
+        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+            raw_text,
+            relative=source_relative or str(raw_file),
+        )
+
+    if normalization_errors or normalized is None:
+        if raw_text:
+            raw_path.write_text(raw_text, encoding="utf-8")
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "summary": "Codex App authoritative review output did not satisfy the Loom review result schema.",
+                "errors": normalization_errors,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        }
+
+    raw_path.write_text(raw_text, encoding="utf-8")
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    metadata = {
+        "schema_version": "loom-review-engine-metadata/v1",
+        "engine": CODEX_APP_REVIEW_ENGINE,
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "profile": engine_profile,
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+        "result": "pass",
+        "reviewed_head": reviewed_head,
+        "decision": normalized["decision"],
+        "summary": normalized["summary"],
+        "kind": review_kind,
+        "validation_summary": context["latest_validation_summary"],
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_relative,
+        "raw_source": source_relative,
+        "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
+    }
+    write_json_file(metadata_path, metadata)
+    return {
+        "result": "pass",
+        "summary": "Codex App authoritative review adapter produced a Loom-normalized formal review draft.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "engine": {
+            "engine": CODEX_APP_REVIEW_ENGINE,
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "profile": engine_profile,
+            "result": "pass",
+            "failure_reason": None,
+            "reviewed_head": reviewed_head,
+            "evidence": evidence,
+        },
+        "engine_metadata": metadata,
+        "review_record_input": {
+            "decision": normalized["decision"],
+            "summary": normalized["summary"],
+            "reviewer": CODEX_APP_REVIEW_ADAPTER,
+            "kind": review_kind,
+            "findings_file": relative_to_root(findings_path, context["target_root"]),
+            "engine_adapter": CODEX_APP_REVIEW_ADAPTER,
+            "engine_evidence": relative_to_root(raw_path, context["target_root"]),
+            "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
+        },
     }
 
 
@@ -11523,9 +11792,11 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
+            adapter=requested_engine_adapter,
             requested_profile=args.engine_profile,
             requested_model=args.engine_model,
             requested_reasoning=args.engine_reasoning,
@@ -11548,8 +11819,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "missing_inputs": engine_profile_errors,
                     "fallback_to": None,
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
@@ -11588,8 +11859,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                     "current_checkpoint": flow_payload.get("current_checkpoint"),
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
@@ -11601,13 +11872,26 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(
-            context,
-            build_payload,
-            review_path,
-            engine_profile,
-            review_kind=review_kind,
-        )
+        if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER:
+            engine_payload = run_codex_app_review_authoritative_adapter(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+                app_server=args.codex_app_review_app_server,
+                thread_id=args.codex_app_review_thread_id,
+                thread_cwd=args.codex_app_review_cwd,
+                raw_file=args.codex_app_review_raw_file,
+            )
+        else:
+            engine_payload = run_default_review_engine(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+            )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,
             adapter=args.shadow_engine_adapter,
@@ -11630,7 +11914,7 @@ def handle_review(args: argparse.Namespace) -> int:
         summary = (
             engine_payload["summary"]
             if result == "pass"
-            else "default review engine failed closed; record any formal review conclusion through the single review record."
+            else f"{requested_engine_adapter} review engine failed closed; record any formal review conclusion through the single review record."
         )
         return emit(
             {
@@ -11652,6 +11936,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"engine_metadata": engine_payload["engine_metadata"]} if isinstance(engine_payload.get("engine_metadata"), dict) else {}),
                 **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),

--- a/skills/loom-retire/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-retire/.loom-runtime/loom-review/SKILL.md
@@ -42,7 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+
+默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -52,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 

--- a/skills/loom-retire/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-retire/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，生成 Loom-normalized spec findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,6 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/review-execution.md
@@ -47,15 +47,15 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 Codex。
+默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+Codex App review adapter 有两种显式入口，默认均不启用：
 
 - 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
 - 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
@@ -63,17 +63,22 @@ Loom 把 review 分成四层：
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
+- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
+- authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract
 
-`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+`review run` 在调用 Codex-backed reviewer 或 Codex App authoritative adapter 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: 当前固定为 `loom/default-codex`
-- `engine`: 当前固定为 `codex`
+- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
+- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -757,6 +757,13 @@ output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
 sys.exit(0)
 """
+    elif mode == "fail_if_called":
+        body = """#!/usr/bin/env python3
+import sys
+
+sys.stderr.write("codex exec must not be called for explicit Codex App review adapter\\n")
+sys.exit(41)
+"""
     else:
         raise ValueError(f"unknown fake codex mode: {mode}")
     path.write_text(body, encoding="utf-8")
@@ -3005,10 +3012,12 @@ def require_review_run_payload(
     engine = payload.get("engine")
     if not isinstance(engine, dict):
         return
-    if engine.get("engine") != "codex":
-        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
-    if engine.get("adapter") != "loom/default-codex":
-        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    engine_adapter = engine.get("adapter")
+    if engine_adapter not in {"loom/default-codex", "loom/codex-app-review"}:
+        failures.append(Failure(category, f"{context} adapter must be a supported authoritative review adapter"))
+    expected_engine = "codex-app-review" if engine_adapter == "loom/codex-app-review" else "codex"
+    if engine.get("engine") != expected_engine:
+        failures.append(Failure(category, f"{context} engine must match the selected authoritative adapter"))
     profile = engine.get("profile")
     if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
         pass
@@ -3017,8 +3026,8 @@ def require_review_run_payload(
     else:
         if profile.get("schema_version") != "loom-review-engine-profile/v1":
             failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
-        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
-            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("adapter") != engine_adapter or profile.get("engine") != expected_engine:
+            failures.append(Failure(category, f"{context} engine profile must bind the selected adapter explicitly"))
         if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
             failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
         for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
@@ -3077,8 +3086,10 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
-            if review_record_input.get("reviewer") != "loom/default-codex":
-                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+            if review_record_input.get("reviewer") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input reviewer must match the selected adapter"))
+            if review_record_input.get("engine_adapter") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input engine_adapter must match the selected adapter"))
     shadow_engine = payload.get("shadow_engine")
     if shadow_engine is not None:
         if not isinstance(shadow_engine, dict):
@@ -5709,6 +5720,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex" or engine.get("adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep the default codex exec adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex" or review_record_input.get("reviewer") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep default review_record_input adapter"))
                 evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
                 context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
                 prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
@@ -5844,6 +5861,154 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
+        prepare_review_target(app_authoritative_target, "review run Codex App authoritative")
+        app_raw = app_authoritative_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App authoritative reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-warn-1",
+                            "summary": "Codex App authoritative review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_authoritative_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_authoritative_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App authoritative failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App authoritative",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must author app adapter review_record_input"))
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must not call codex exec"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("thread_id") != "thread-stage2-live-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must expose live thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_authoritative_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume raw Codex App authoritative evidence before review record is authored"))
+
+        app_missing_target = Path(tmp) / "review-run-codex-app-missing-proof"
+        prepare_review_target(app_missing_target, "review run Codex App missing proof")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_missing_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App missing proof failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App missing proof must fail closed"))
+
+        app_invalid_target = Path(tmp) / "review-run-codex-app-invalid-raw"
+        prepare_review_target(app_invalid_target, "review run Codex App invalid raw")
+        invalid_raw = app_invalid_target / ".loom/runtime/tmp/codex-app-review-invalid.txt"
+        invalid_raw.parent.mkdir(parents=True, exist_ok=True)
+        invalid_raw.write_text("plain review text is not authoritative schema\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_invalid_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_invalid_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-invalid.txt",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App invalid raw failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App invalid raw must fail closed on schema drift"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,7 +113,10 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
-CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ENGINE = "codex-app-review"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
+AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
@@ -444,9 +447,32 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--reviewer", help="Reviewer identity")
     review.add_argument("--fallback-to", choices=("admission", "build", "merge"))
     review.add_argument("--findings-file", help="Optional findings JSON path relative to the target root")
-    review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
+    review.add_argument(
+        "--engine-adapter",
+        choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
+        help=(
+            "Optional authoritative review engine adapter for review run/record. "
+            "Default review run remains loom/default-codex."
+        ),
+    )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument(
+        "--codex-app-review-app-server",
+        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-thread-id",
+        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-cwd",
+        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-raw-file",
+        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+    )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
@@ -7034,11 +7060,14 @@ def resolve_review_engine_profile(
     context: dict[str, Any],
     review_kind: str,
     *,
+    adapter: str = DEFAULT_REVIEW_ADAPTER,
     requested_profile: str | None = None,
     requested_model: str | None = None,
     requested_reasoning: str | None = None,
     override_reason: str | None = None,
 ) -> tuple[dict[str, Any] | None, list[str]]:
+    if adapter not in AUTHORITATIVE_REVIEW_ADAPTERS:
+        return None, [f"unsupported authoritative review adapter: {adapter}"]
     selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
     if requested_profile:
         selected_profile = requested_profile
@@ -7061,8 +7090,8 @@ def resolve_review_engine_profile(
     resolved = {
         "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
         "profile_id": base_profile["profile_id"],
-        "adapter": DEFAULT_REVIEW_ADAPTER,
-        "engine": DEFAULT_REVIEW_ENGINE,
+        "adapter": adapter,
+        "engine": CODEX_APP_REVIEW_ENGINE if adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
         "model": base_profile["model"],
         "reasoning_effort": base_profile["reasoning_effort"],
         "timeout_seconds": int(base_profile["timeout_seconds"]),
@@ -7158,6 +7187,20 @@ def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[di
             }
         ],
     }, []
+
+
+def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App authoritative review output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, [f"Codex App authoritative review output `{relative}` must be normalized JSON: {exc}"]
+    normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+    if errors or normalized is None:
+        return None, errors
+    return normalized, []
 
 
 def shadow_adapter_slug(adapter: str) -> str:
@@ -7345,6 +7388,232 @@ def run_codex_app_review_shadow_adapter(
         "evidence": evidence,
         "decision": normalized["decision"],
         "parity_diff": parity_diff,
+    }
+
+
+def run_codex_app_review_authoritative_adapter(
+    context: dict[str, Any],
+    build_payload: dict[str, Any],
+    review_path: str,
+    engine_profile: dict[str, Any],
+    *,
+    review_kind: str,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    raw_path = runtime_root / "engine-result.json"
+    findings_path = runtime_root / "normalized-findings.json"
+    metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
+    instructions_path = runtime_root / "prompt.txt"
+    context_pack = build_review_context_pack(context, review_path)
+    evidence = {
+        "runtime_root": relative_to_root(runtime_root, context["target_root"]),
+        "prompt": relative_to_root(instructions_path, context["target_root"]),
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+    }
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
+    instructions_path.write_text(
+        build_default_review_prompt(
+            context=context,
+            build_payload=build_payload,
+            runtime_fields=runtime_evidence_from_report(context["report"])[0],
+            review_path=review_path,
+            context_pack=context_pack,
+        ),
+        encoding="utf-8",
+    )
+
+    missing_inputs: list[str] = []
+    for label, value in (
+        ("--codex-app-review-app-server", app_server),
+        ("--codex-app-review-thread-id", thread_id),
+        ("--codex-app-review-cwd", thread_cwd),
+        ("--codex-app-review-raw-file", raw_file),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(label)
+
+    cwd_relative: str | None = None
+    if isinstance(thread_cwd, str) and thread_cwd.strip():
+        try:
+            cwd_path = Path(thread_cwd).expanduser().resolve()
+        except OSError as exc:
+            missing_inputs.append(f"Codex App review cwd could not be resolved: {exc}")
+        else:
+            if cwd_path != context["target_root"]:
+                missing_inputs.append(
+                    f"Codex App review cwd `{cwd_path}` does not match target root `{context['target_root']}`"
+                )
+            else:
+                cwd_relative = relative_to_root(cwd_path, context["target_root"])
+
+    source_path: Path | None = None
+    source_relative: str | None = None
+    if isinstance(raw_file, str) and raw_file.strip():
+        source_path, source_errors = resolve_repo_relative_path(
+            context["target_root"],
+            raw_file,
+            label="Codex App authoritative review raw file",
+        )
+        missing_inputs.extend(source_errors)
+        if source_path is not None:
+            source_relative = relative_to_root(source_path, context["target_root"])
+
+    if missing_inputs:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "summary": "Codex App authoritative review adapter is missing required live binding proof.",
+                "missing_inputs": missing_inputs,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review adapter failed closed before a formal review record could be authored.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+                "raw_source": source_relative,
+            },
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
+    except OSError as exc:
+        raw_text = ""
+        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+        normalized = None
+    else:
+        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+            raw_text,
+            relative=source_relative or str(raw_file),
+        )
+
+    if normalization_errors or normalized is None:
+        if raw_text:
+            raw_path.write_text(raw_text, encoding="utf-8")
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "summary": "Codex App authoritative review output did not satisfy the Loom review result schema.",
+                "errors": normalization_errors,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        }
+
+    raw_path.write_text(raw_text, encoding="utf-8")
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    metadata = {
+        "schema_version": "loom-review-engine-metadata/v1",
+        "engine": CODEX_APP_REVIEW_ENGINE,
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "profile": engine_profile,
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+        "result": "pass",
+        "reviewed_head": reviewed_head,
+        "decision": normalized["decision"],
+        "summary": normalized["summary"],
+        "kind": review_kind,
+        "validation_summary": context["latest_validation_summary"],
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_relative,
+        "raw_source": source_relative,
+        "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
+    }
+    write_json_file(metadata_path, metadata)
+    return {
+        "result": "pass",
+        "summary": "Codex App authoritative review adapter produced a Loom-normalized formal review draft.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "engine": {
+            "engine": CODEX_APP_REVIEW_ENGINE,
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "profile": engine_profile,
+            "result": "pass",
+            "failure_reason": None,
+            "reviewed_head": reviewed_head,
+            "evidence": evidence,
+        },
+        "engine_metadata": metadata,
+        "review_record_input": {
+            "decision": normalized["decision"],
+            "summary": normalized["summary"],
+            "reviewer": CODEX_APP_REVIEW_ADAPTER,
+            "kind": review_kind,
+            "findings_file": relative_to_root(findings_path, context["target_root"]),
+            "engine_adapter": CODEX_APP_REVIEW_ADAPTER,
+            "engine_evidence": relative_to_root(raw_path, context["target_root"]),
+            "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
+        },
     }
 
 
@@ -11523,9 +11792,11 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
+            adapter=requested_engine_adapter,
             requested_profile=args.engine_profile,
             requested_model=args.engine_model,
             requested_reasoning=args.engine_reasoning,
@@ -11548,8 +11819,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "missing_inputs": engine_profile_errors,
                     "fallback_to": None,
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
@@ -11588,8 +11859,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                     "current_checkpoint": flow_payload.get("current_checkpoint"),
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
@@ -11601,13 +11872,26 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(
-            context,
-            build_payload,
-            review_path,
-            engine_profile,
-            review_kind=review_kind,
-        )
+        if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER:
+            engine_payload = run_codex_app_review_authoritative_adapter(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+                app_server=args.codex_app_review_app_server,
+                thread_id=args.codex_app_review_thread_id,
+                thread_cwd=args.codex_app_review_cwd,
+                raw_file=args.codex_app_review_raw_file,
+            )
+        else:
+            engine_payload = run_default_review_engine(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+            )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,
             adapter=args.shadow_engine_adapter,
@@ -11630,7 +11914,7 @@ def handle_review(args: argparse.Namespace) -> int:
         summary = (
             engine_payload["summary"]
             if result == "pass"
-            else "default review engine failed closed; record any formal review conclusion through the single review record."
+            else f"{requested_engine_adapter} review engine failed closed; record any formal review conclusion through the single review record."
         )
         return emit(
             {
@@ -11652,6 +11936,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"engine_metadata": engine_payload["engine_metadata"]} if isinstance(engine_payload.get("engine_metadata"), dict) else {}),
                 **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),

--- a/skills/loom-review/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-review/.loom-runtime/loom-review/SKILL.md
@@ -42,7 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+
+默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -52,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 

--- a/skills/loom-review/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-review/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，生成 Loom-normalized spec findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,6 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-review/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/review-execution.md
@@ -47,15 +47,15 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 Codex。
+默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+Codex App review adapter 有两种显式入口，默认均不启用：
 
 - 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
 - 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
@@ -63,17 +63,22 @@ Loom 把 review 分成四层：
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
+- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
+- authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract
 
-`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+`review run` 在调用 Codex-backed reviewer 或 Codex App authoritative adapter 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: 当前固定为 `loom/default-codex`
-- `engine`: 当前固定为 `codex`
+- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
+- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -757,6 +757,13 @@ output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
 sys.exit(0)
 """
+    elif mode == "fail_if_called":
+        body = """#!/usr/bin/env python3
+import sys
+
+sys.stderr.write("codex exec must not be called for explicit Codex App review adapter\\n")
+sys.exit(41)
+"""
     else:
         raise ValueError(f"unknown fake codex mode: {mode}")
     path.write_text(body, encoding="utf-8")
@@ -3005,10 +3012,12 @@ def require_review_run_payload(
     engine = payload.get("engine")
     if not isinstance(engine, dict):
         return
-    if engine.get("engine") != "codex":
-        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
-    if engine.get("adapter") != "loom/default-codex":
-        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    engine_adapter = engine.get("adapter")
+    if engine_adapter not in {"loom/default-codex", "loom/codex-app-review"}:
+        failures.append(Failure(category, f"{context} adapter must be a supported authoritative review adapter"))
+    expected_engine = "codex-app-review" if engine_adapter == "loom/codex-app-review" else "codex"
+    if engine.get("engine") != expected_engine:
+        failures.append(Failure(category, f"{context} engine must match the selected authoritative adapter"))
     profile = engine.get("profile")
     if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
         pass
@@ -3017,8 +3026,8 @@ def require_review_run_payload(
     else:
         if profile.get("schema_version") != "loom-review-engine-profile/v1":
             failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
-        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
-            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("adapter") != engine_adapter or profile.get("engine") != expected_engine:
+            failures.append(Failure(category, f"{context} engine profile must bind the selected adapter explicitly"))
         if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
             failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
         for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
@@ -3077,8 +3086,10 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
-            if review_record_input.get("reviewer") != "loom/default-codex":
-                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+            if review_record_input.get("reviewer") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input reviewer must match the selected adapter"))
+            if review_record_input.get("engine_adapter") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input engine_adapter must match the selected adapter"))
     shadow_engine = payload.get("shadow_engine")
     if shadow_engine is not None:
         if not isinstance(shadow_engine, dict):
@@ -5709,6 +5720,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex" or engine.get("adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep the default codex exec adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex" or review_record_input.get("reviewer") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep default review_record_input adapter"))
                 evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
                 context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
                 prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
@@ -5844,6 +5861,154 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
+        prepare_review_target(app_authoritative_target, "review run Codex App authoritative")
+        app_raw = app_authoritative_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App authoritative reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-warn-1",
+                            "summary": "Codex App authoritative review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_authoritative_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_authoritative_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App authoritative failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App authoritative",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must author app adapter review_record_input"))
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must not call codex exec"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("thread_id") != "thread-stage2-live-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must expose live thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_authoritative_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume raw Codex App authoritative evidence before review record is authored"))
+
+        app_missing_target = Path(tmp) / "review-run-codex-app-missing-proof"
+        prepare_review_target(app_missing_target, "review run Codex App missing proof")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_missing_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App missing proof failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App missing proof must fail closed"))
+
+        app_invalid_target = Path(tmp) / "review-run-codex-app-invalid-raw"
+        prepare_review_target(app_invalid_target, "review run Codex App invalid raw")
+        invalid_raw = app_invalid_target / ".loom/runtime/tmp/codex-app-review-invalid.txt"
+        invalid_raw.parent.mkdir(parents=True, exist_ok=True)
+        invalid_raw.write_text("plain review text is not authoritative schema\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_invalid_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_invalid_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-invalid.txt",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App invalid raw failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App invalid raw must fail closed on schema drift"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,7 +113,10 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
-CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ENGINE = "codex-app-review"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
+AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
@@ -444,9 +447,32 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--reviewer", help="Reviewer identity")
     review.add_argument("--fallback-to", choices=("admission", "build", "merge"))
     review.add_argument("--findings-file", help="Optional findings JSON path relative to the target root")
-    review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
+    review.add_argument(
+        "--engine-adapter",
+        choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
+        help=(
+            "Optional authoritative review engine adapter for review run/record. "
+            "Default review run remains loom/default-codex."
+        ),
+    )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument(
+        "--codex-app-review-app-server",
+        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-thread-id",
+        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-cwd",
+        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-raw-file",
+        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+    )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
@@ -7034,11 +7060,14 @@ def resolve_review_engine_profile(
     context: dict[str, Any],
     review_kind: str,
     *,
+    adapter: str = DEFAULT_REVIEW_ADAPTER,
     requested_profile: str | None = None,
     requested_model: str | None = None,
     requested_reasoning: str | None = None,
     override_reason: str | None = None,
 ) -> tuple[dict[str, Any] | None, list[str]]:
+    if adapter not in AUTHORITATIVE_REVIEW_ADAPTERS:
+        return None, [f"unsupported authoritative review adapter: {adapter}"]
     selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
     if requested_profile:
         selected_profile = requested_profile
@@ -7061,8 +7090,8 @@ def resolve_review_engine_profile(
     resolved = {
         "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
         "profile_id": base_profile["profile_id"],
-        "adapter": DEFAULT_REVIEW_ADAPTER,
-        "engine": DEFAULT_REVIEW_ENGINE,
+        "adapter": adapter,
+        "engine": CODEX_APP_REVIEW_ENGINE if adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
         "model": base_profile["model"],
         "reasoning_effort": base_profile["reasoning_effort"],
         "timeout_seconds": int(base_profile["timeout_seconds"]),
@@ -7158,6 +7187,20 @@ def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[di
             }
         ],
     }, []
+
+
+def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App authoritative review output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, [f"Codex App authoritative review output `{relative}` must be normalized JSON: {exc}"]
+    normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+    if errors or normalized is None:
+        return None, errors
+    return normalized, []
 
 
 def shadow_adapter_slug(adapter: str) -> str:
@@ -7345,6 +7388,232 @@ def run_codex_app_review_shadow_adapter(
         "evidence": evidence,
         "decision": normalized["decision"],
         "parity_diff": parity_diff,
+    }
+
+
+def run_codex_app_review_authoritative_adapter(
+    context: dict[str, Any],
+    build_payload: dict[str, Any],
+    review_path: str,
+    engine_profile: dict[str, Any],
+    *,
+    review_kind: str,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    raw_path = runtime_root / "engine-result.json"
+    findings_path = runtime_root / "normalized-findings.json"
+    metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
+    instructions_path = runtime_root / "prompt.txt"
+    context_pack = build_review_context_pack(context, review_path)
+    evidence = {
+        "runtime_root": relative_to_root(runtime_root, context["target_root"]),
+        "prompt": relative_to_root(instructions_path, context["target_root"]),
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+    }
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
+    instructions_path.write_text(
+        build_default_review_prompt(
+            context=context,
+            build_payload=build_payload,
+            runtime_fields=runtime_evidence_from_report(context["report"])[0],
+            review_path=review_path,
+            context_pack=context_pack,
+        ),
+        encoding="utf-8",
+    )
+
+    missing_inputs: list[str] = []
+    for label, value in (
+        ("--codex-app-review-app-server", app_server),
+        ("--codex-app-review-thread-id", thread_id),
+        ("--codex-app-review-cwd", thread_cwd),
+        ("--codex-app-review-raw-file", raw_file),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(label)
+
+    cwd_relative: str | None = None
+    if isinstance(thread_cwd, str) and thread_cwd.strip():
+        try:
+            cwd_path = Path(thread_cwd).expanduser().resolve()
+        except OSError as exc:
+            missing_inputs.append(f"Codex App review cwd could not be resolved: {exc}")
+        else:
+            if cwd_path != context["target_root"]:
+                missing_inputs.append(
+                    f"Codex App review cwd `{cwd_path}` does not match target root `{context['target_root']}`"
+                )
+            else:
+                cwd_relative = relative_to_root(cwd_path, context["target_root"])
+
+    source_path: Path | None = None
+    source_relative: str | None = None
+    if isinstance(raw_file, str) and raw_file.strip():
+        source_path, source_errors = resolve_repo_relative_path(
+            context["target_root"],
+            raw_file,
+            label="Codex App authoritative review raw file",
+        )
+        missing_inputs.extend(source_errors)
+        if source_path is not None:
+            source_relative = relative_to_root(source_path, context["target_root"])
+
+    if missing_inputs:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "summary": "Codex App authoritative review adapter is missing required live binding proof.",
+                "missing_inputs": missing_inputs,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review adapter failed closed before a formal review record could be authored.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+                "raw_source": source_relative,
+            },
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
+    except OSError as exc:
+        raw_text = ""
+        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+        normalized = None
+    else:
+        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+            raw_text,
+            relative=source_relative or str(raw_file),
+        )
+
+    if normalization_errors or normalized is None:
+        if raw_text:
+            raw_path.write_text(raw_text, encoding="utf-8")
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "summary": "Codex App authoritative review output did not satisfy the Loom review result schema.",
+                "errors": normalization_errors,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        }
+
+    raw_path.write_text(raw_text, encoding="utf-8")
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    metadata = {
+        "schema_version": "loom-review-engine-metadata/v1",
+        "engine": CODEX_APP_REVIEW_ENGINE,
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "profile": engine_profile,
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+        "result": "pass",
+        "reviewed_head": reviewed_head,
+        "decision": normalized["decision"],
+        "summary": normalized["summary"],
+        "kind": review_kind,
+        "validation_summary": context["latest_validation_summary"],
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_relative,
+        "raw_source": source_relative,
+        "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
+    }
+    write_json_file(metadata_path, metadata)
+    return {
+        "result": "pass",
+        "summary": "Codex App authoritative review adapter produced a Loom-normalized formal review draft.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "engine": {
+            "engine": CODEX_APP_REVIEW_ENGINE,
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "profile": engine_profile,
+            "result": "pass",
+            "failure_reason": None,
+            "reviewed_head": reviewed_head,
+            "evidence": evidence,
+        },
+        "engine_metadata": metadata,
+        "review_record_input": {
+            "decision": normalized["decision"],
+            "summary": normalized["summary"],
+            "reviewer": CODEX_APP_REVIEW_ADAPTER,
+            "kind": review_kind,
+            "findings_file": relative_to_root(findings_path, context["target_root"]),
+            "engine_adapter": CODEX_APP_REVIEW_ADAPTER,
+            "engine_evidence": relative_to_root(raw_path, context["target_root"]),
+            "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
+        },
     }
 
 
@@ -11523,9 +11792,11 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
+            adapter=requested_engine_adapter,
             requested_profile=args.engine_profile,
             requested_model=args.engine_model,
             requested_reasoning=args.engine_reasoning,
@@ -11548,8 +11819,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "missing_inputs": engine_profile_errors,
                     "fallback_to": None,
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
@@ -11588,8 +11859,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                     "current_checkpoint": flow_payload.get("current_checkpoint"),
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
@@ -11601,13 +11872,26 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(
-            context,
-            build_payload,
-            review_path,
-            engine_profile,
-            review_kind=review_kind,
-        )
+        if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER:
+            engine_payload = run_codex_app_review_authoritative_adapter(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+                app_server=args.codex_app_review_app_server,
+                thread_id=args.codex_app_review_thread_id,
+                thread_cwd=args.codex_app_review_cwd,
+                raw_file=args.codex_app_review_raw_file,
+            )
+        else:
+            engine_payload = run_default_review_engine(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+            )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,
             adapter=args.shadow_engine_adapter,
@@ -11630,7 +11914,7 @@ def handle_review(args: argparse.Namespace) -> int:
         summary = (
             engine_payload["summary"]
             if result == "pass"
-            else "default review engine failed closed; record any formal review conclusion through the single review record."
+            else f"{requested_engine_adapter} review engine failed closed; record any formal review conclusion through the single review record."
         )
         return emit(
             {
@@ -11652,6 +11936,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"engine_metadata": engine_payload["engine_metadata"]} if isinstance(engine_payload.get("engine_metadata"), dict) else {}),
                 **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),

--- a/skills/loom-review/SKILL.md
+++ b/skills/loom-review/SKILL.md
@@ -42,7 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+
+默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -52,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 

--- a/skills/loom-spec-review/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-review/SKILL.md
@@ -42,7 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+
+默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -52,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 

--- a/skills/loom-spec-review/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，生成 Loom-normalized spec findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,6 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/review-execution.md
@@ -47,15 +47,15 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 Codex。
+默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+Codex App review adapter 有两种显式入口，默认均不启用：
 
 - 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
 - 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
@@ -63,17 +63,22 @@ Loom 把 review 分成四层：
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
+- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
+- authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract
 
-`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+`review run` 在调用 Codex-backed reviewer 或 Codex App authoritative adapter 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: 当前固定为 `loom/default-codex`
-- `engine`: 当前固定为 `codex`
+- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
+- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -757,6 +757,13 @@ output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
 sys.exit(0)
 """
+    elif mode == "fail_if_called":
+        body = """#!/usr/bin/env python3
+import sys
+
+sys.stderr.write("codex exec must not be called for explicit Codex App review adapter\\n")
+sys.exit(41)
+"""
     else:
         raise ValueError(f"unknown fake codex mode: {mode}")
     path.write_text(body, encoding="utf-8")
@@ -3005,10 +3012,12 @@ def require_review_run_payload(
     engine = payload.get("engine")
     if not isinstance(engine, dict):
         return
-    if engine.get("engine") != "codex":
-        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
-    if engine.get("adapter") != "loom/default-codex":
-        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    engine_adapter = engine.get("adapter")
+    if engine_adapter not in {"loom/default-codex", "loom/codex-app-review"}:
+        failures.append(Failure(category, f"{context} adapter must be a supported authoritative review adapter"))
+    expected_engine = "codex-app-review" if engine_adapter == "loom/codex-app-review" else "codex"
+    if engine.get("engine") != expected_engine:
+        failures.append(Failure(category, f"{context} engine must match the selected authoritative adapter"))
     profile = engine.get("profile")
     if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
         pass
@@ -3017,8 +3026,8 @@ def require_review_run_payload(
     else:
         if profile.get("schema_version") != "loom-review-engine-profile/v1":
             failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
-        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
-            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("adapter") != engine_adapter or profile.get("engine") != expected_engine:
+            failures.append(Failure(category, f"{context} engine profile must bind the selected adapter explicitly"))
         if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
             failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
         for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
@@ -3077,8 +3086,10 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
-            if review_record_input.get("reviewer") != "loom/default-codex":
-                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+            if review_record_input.get("reviewer") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input reviewer must match the selected adapter"))
+            if review_record_input.get("engine_adapter") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input engine_adapter must match the selected adapter"))
     shadow_engine = payload.get("shadow_engine")
     if shadow_engine is not None:
         if not isinstance(shadow_engine, dict):
@@ -5709,6 +5720,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex" or engine.get("adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep the default codex exec adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex" or review_record_input.get("reviewer") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep default review_record_input adapter"))
                 evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
                 context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
                 prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
@@ -5844,6 +5861,154 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
+        prepare_review_target(app_authoritative_target, "review run Codex App authoritative")
+        app_raw = app_authoritative_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App authoritative reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-warn-1",
+                            "summary": "Codex App authoritative review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_authoritative_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_authoritative_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App authoritative failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App authoritative",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must author app adapter review_record_input"))
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must not call codex exec"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("thread_id") != "thread-stage2-live-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must expose live thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_authoritative_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume raw Codex App authoritative evidence before review record is authored"))
+
+        app_missing_target = Path(tmp) / "review-run-codex-app-missing-proof"
+        prepare_review_target(app_missing_target, "review run Codex App missing proof")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_missing_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App missing proof failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App missing proof must fail closed"))
+
+        app_invalid_target = Path(tmp) / "review-run-codex-app-invalid-raw"
+        prepare_review_target(app_invalid_target, "review run Codex App invalid raw")
+        invalid_raw = app_invalid_target / ".loom/runtime/tmp/codex-app-review-invalid.txt"
+        invalid_raw.parent.mkdir(parents=True, exist_ok=True)
+        invalid_raw.write_text("plain review text is not authoritative schema\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_invalid_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_invalid_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-invalid.txt",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App invalid raw failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App invalid raw must fail closed on schema drift"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,7 +113,10 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
-CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ENGINE = "codex-app-review"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
+AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
@@ -444,9 +447,32 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--reviewer", help="Reviewer identity")
     review.add_argument("--fallback-to", choices=("admission", "build", "merge"))
     review.add_argument("--findings-file", help="Optional findings JSON path relative to the target root")
-    review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
+    review.add_argument(
+        "--engine-adapter",
+        choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
+        help=(
+            "Optional authoritative review engine adapter for review run/record. "
+            "Default review run remains loom/default-codex."
+        ),
+    )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument(
+        "--codex-app-review-app-server",
+        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-thread-id",
+        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-cwd",
+        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-raw-file",
+        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+    )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
@@ -7034,11 +7060,14 @@ def resolve_review_engine_profile(
     context: dict[str, Any],
     review_kind: str,
     *,
+    adapter: str = DEFAULT_REVIEW_ADAPTER,
     requested_profile: str | None = None,
     requested_model: str | None = None,
     requested_reasoning: str | None = None,
     override_reason: str | None = None,
 ) -> tuple[dict[str, Any] | None, list[str]]:
+    if adapter not in AUTHORITATIVE_REVIEW_ADAPTERS:
+        return None, [f"unsupported authoritative review adapter: {adapter}"]
     selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
     if requested_profile:
         selected_profile = requested_profile
@@ -7061,8 +7090,8 @@ def resolve_review_engine_profile(
     resolved = {
         "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
         "profile_id": base_profile["profile_id"],
-        "adapter": DEFAULT_REVIEW_ADAPTER,
-        "engine": DEFAULT_REVIEW_ENGINE,
+        "adapter": adapter,
+        "engine": CODEX_APP_REVIEW_ENGINE if adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
         "model": base_profile["model"],
         "reasoning_effort": base_profile["reasoning_effort"],
         "timeout_seconds": int(base_profile["timeout_seconds"]),
@@ -7158,6 +7187,20 @@ def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[di
             }
         ],
     }, []
+
+
+def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App authoritative review output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, [f"Codex App authoritative review output `{relative}` must be normalized JSON: {exc}"]
+    normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+    if errors or normalized is None:
+        return None, errors
+    return normalized, []
 
 
 def shadow_adapter_slug(adapter: str) -> str:
@@ -7345,6 +7388,232 @@ def run_codex_app_review_shadow_adapter(
         "evidence": evidence,
         "decision": normalized["decision"],
         "parity_diff": parity_diff,
+    }
+
+
+def run_codex_app_review_authoritative_adapter(
+    context: dict[str, Any],
+    build_payload: dict[str, Any],
+    review_path: str,
+    engine_profile: dict[str, Any],
+    *,
+    review_kind: str,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    raw_path = runtime_root / "engine-result.json"
+    findings_path = runtime_root / "normalized-findings.json"
+    metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
+    instructions_path = runtime_root / "prompt.txt"
+    context_pack = build_review_context_pack(context, review_path)
+    evidence = {
+        "runtime_root": relative_to_root(runtime_root, context["target_root"]),
+        "prompt": relative_to_root(instructions_path, context["target_root"]),
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+    }
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
+    instructions_path.write_text(
+        build_default_review_prompt(
+            context=context,
+            build_payload=build_payload,
+            runtime_fields=runtime_evidence_from_report(context["report"])[0],
+            review_path=review_path,
+            context_pack=context_pack,
+        ),
+        encoding="utf-8",
+    )
+
+    missing_inputs: list[str] = []
+    for label, value in (
+        ("--codex-app-review-app-server", app_server),
+        ("--codex-app-review-thread-id", thread_id),
+        ("--codex-app-review-cwd", thread_cwd),
+        ("--codex-app-review-raw-file", raw_file),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(label)
+
+    cwd_relative: str | None = None
+    if isinstance(thread_cwd, str) and thread_cwd.strip():
+        try:
+            cwd_path = Path(thread_cwd).expanduser().resolve()
+        except OSError as exc:
+            missing_inputs.append(f"Codex App review cwd could not be resolved: {exc}")
+        else:
+            if cwd_path != context["target_root"]:
+                missing_inputs.append(
+                    f"Codex App review cwd `{cwd_path}` does not match target root `{context['target_root']}`"
+                )
+            else:
+                cwd_relative = relative_to_root(cwd_path, context["target_root"])
+
+    source_path: Path | None = None
+    source_relative: str | None = None
+    if isinstance(raw_file, str) and raw_file.strip():
+        source_path, source_errors = resolve_repo_relative_path(
+            context["target_root"],
+            raw_file,
+            label="Codex App authoritative review raw file",
+        )
+        missing_inputs.extend(source_errors)
+        if source_path is not None:
+            source_relative = relative_to_root(source_path, context["target_root"])
+
+    if missing_inputs:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "summary": "Codex App authoritative review adapter is missing required live binding proof.",
+                "missing_inputs": missing_inputs,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review adapter failed closed before a formal review record could be authored.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+                "raw_source": source_relative,
+            },
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
+    except OSError as exc:
+        raw_text = ""
+        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+        normalized = None
+    else:
+        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+            raw_text,
+            relative=source_relative or str(raw_file),
+        )
+
+    if normalization_errors or normalized is None:
+        if raw_text:
+            raw_path.write_text(raw_text, encoding="utf-8")
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "summary": "Codex App authoritative review output did not satisfy the Loom review result schema.",
+                "errors": normalization_errors,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        }
+
+    raw_path.write_text(raw_text, encoding="utf-8")
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    metadata = {
+        "schema_version": "loom-review-engine-metadata/v1",
+        "engine": CODEX_APP_REVIEW_ENGINE,
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "profile": engine_profile,
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+        "result": "pass",
+        "reviewed_head": reviewed_head,
+        "decision": normalized["decision"],
+        "summary": normalized["summary"],
+        "kind": review_kind,
+        "validation_summary": context["latest_validation_summary"],
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_relative,
+        "raw_source": source_relative,
+        "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
+    }
+    write_json_file(metadata_path, metadata)
+    return {
+        "result": "pass",
+        "summary": "Codex App authoritative review adapter produced a Loom-normalized formal review draft.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "engine": {
+            "engine": CODEX_APP_REVIEW_ENGINE,
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "profile": engine_profile,
+            "result": "pass",
+            "failure_reason": None,
+            "reviewed_head": reviewed_head,
+            "evidence": evidence,
+        },
+        "engine_metadata": metadata,
+        "review_record_input": {
+            "decision": normalized["decision"],
+            "summary": normalized["summary"],
+            "reviewer": CODEX_APP_REVIEW_ADAPTER,
+            "kind": review_kind,
+            "findings_file": relative_to_root(findings_path, context["target_root"]),
+            "engine_adapter": CODEX_APP_REVIEW_ADAPTER,
+            "engine_evidence": relative_to_root(raw_path, context["target_root"]),
+            "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
+        },
     }
 
 
@@ -11523,9 +11792,11 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
+            adapter=requested_engine_adapter,
             requested_profile=args.engine_profile,
             requested_model=args.engine_model,
             requested_reasoning=args.engine_reasoning,
@@ -11548,8 +11819,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "missing_inputs": engine_profile_errors,
                     "fallback_to": None,
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
@@ -11588,8 +11859,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                     "current_checkpoint": flow_payload.get("current_checkpoint"),
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
@@ -11601,13 +11872,26 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(
-            context,
-            build_payload,
-            review_path,
-            engine_profile,
-            review_kind=review_kind,
-        )
+        if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER:
+            engine_payload = run_codex_app_review_authoritative_adapter(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+                app_server=args.codex_app_review_app_server,
+                thread_id=args.codex_app_review_thread_id,
+                thread_cwd=args.codex_app_review_cwd,
+                raw_file=args.codex_app_review_raw_file,
+            )
+        else:
+            engine_payload = run_default_review_engine(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+            )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,
             adapter=args.shadow_engine_adapter,
@@ -11630,7 +11914,7 @@ def handle_review(args: argparse.Namespace) -> int:
         summary = (
             engine_payload["summary"]
             if result == "pass"
-            else "default review engine failed closed; record any formal review conclusion through the single review record."
+            else f"{requested_engine_adapter} review engine failed closed; record any formal review conclusion through the single review record."
         )
         return emit(
             {
@@ -11652,6 +11936,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"engine_metadata": engine_payload["engine_metadata"]} if isinstance(engine_payload.get("engine_metadata"), dict) else {}),
                 **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),

--- a/skills/loom-spec-review/SKILL.md
+++ b/skills/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，生成 Loom-normalized spec findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,6 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-story/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-story/.loom-runtime/loom-review/SKILL.md
@@ -42,7 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+
+默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -52,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 

--- a/skills/loom-story/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-story/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，生成 Loom-normalized spec findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,6 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-story/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-story/.loom-runtime/shared/references/harness/review-execution.md
@@ -47,15 +47,15 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 Codex。
+默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+Codex App review adapter 有两种显式入口，默认均不启用：
 
 - 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
 - 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
@@ -63,17 +63,22 @@ Loom 把 review 分成四层：
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
+- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
+- authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract
 
-`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+`review run` 在调用 Codex-backed reviewer 或 Codex App authoritative adapter 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: 当前固定为 `loom/default-codex`
-- `engine`: 当前固定为 `codex`
+- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
+- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
@@ -757,6 +757,13 @@ output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
 sys.exit(0)
 """
+    elif mode == "fail_if_called":
+        body = """#!/usr/bin/env python3
+import sys
+
+sys.stderr.write("codex exec must not be called for explicit Codex App review adapter\\n")
+sys.exit(41)
+"""
     else:
         raise ValueError(f"unknown fake codex mode: {mode}")
     path.write_text(body, encoding="utf-8")
@@ -3005,10 +3012,12 @@ def require_review_run_payload(
     engine = payload.get("engine")
     if not isinstance(engine, dict):
         return
-    if engine.get("engine") != "codex":
-        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
-    if engine.get("adapter") != "loom/default-codex":
-        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    engine_adapter = engine.get("adapter")
+    if engine_adapter not in {"loom/default-codex", "loom/codex-app-review"}:
+        failures.append(Failure(category, f"{context} adapter must be a supported authoritative review adapter"))
+    expected_engine = "codex-app-review" if engine_adapter == "loom/codex-app-review" else "codex"
+    if engine.get("engine") != expected_engine:
+        failures.append(Failure(category, f"{context} engine must match the selected authoritative adapter"))
     profile = engine.get("profile")
     if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
         pass
@@ -3017,8 +3026,8 @@ def require_review_run_payload(
     else:
         if profile.get("schema_version") != "loom-review-engine-profile/v1":
             failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
-        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
-            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("adapter") != engine_adapter or profile.get("engine") != expected_engine:
+            failures.append(Failure(category, f"{context} engine profile must bind the selected adapter explicitly"))
         if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
             failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
         for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
@@ -3077,8 +3086,10 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
-            if review_record_input.get("reviewer") != "loom/default-codex":
-                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+            if review_record_input.get("reviewer") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input reviewer must match the selected adapter"))
+            if review_record_input.get("engine_adapter") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input engine_adapter must match the selected adapter"))
     shadow_engine = payload.get("shadow_engine")
     if shadow_engine is not None:
         if not isinstance(shadow_engine, dict):
@@ -5709,6 +5720,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex" or engine.get("adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep the default codex exec adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex" or review_record_input.get("reviewer") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep default review_record_input adapter"))
                 evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
                 context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
                 prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
@@ -5844,6 +5861,154 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
+        prepare_review_target(app_authoritative_target, "review run Codex App authoritative")
+        app_raw = app_authoritative_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App authoritative reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-warn-1",
+                            "summary": "Codex App authoritative review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_authoritative_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_authoritative_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App authoritative failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App authoritative",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must author app adapter review_record_input"))
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must not call codex exec"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("thread_id") != "thread-stage2-live-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must expose live thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_authoritative_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume raw Codex App authoritative evidence before review record is authored"))
+
+        app_missing_target = Path(tmp) / "review-run-codex-app-missing-proof"
+        prepare_review_target(app_missing_target, "review run Codex App missing proof")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_missing_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App missing proof failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App missing proof must fail closed"))
+
+        app_invalid_target = Path(tmp) / "review-run-codex-app-invalid-raw"
+        prepare_review_target(app_invalid_target, "review run Codex App invalid raw")
+        invalid_raw = app_invalid_target / ".loom/runtime/tmp/codex-app-review-invalid.txt"
+        invalid_raw.parent.mkdir(parents=True, exist_ok=True)
+        invalid_raw.write_text("plain review text is not authoritative schema\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_invalid_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_invalid_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-invalid.txt",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App invalid raw failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App invalid raw must fail closed on schema drift"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,7 +113,10 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
-CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ENGINE = "codex-app-review"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
+AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
@@ -444,9 +447,32 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--reviewer", help="Reviewer identity")
     review.add_argument("--fallback-to", choices=("admission", "build", "merge"))
     review.add_argument("--findings-file", help="Optional findings JSON path relative to the target root")
-    review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
+    review.add_argument(
+        "--engine-adapter",
+        choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
+        help=(
+            "Optional authoritative review engine adapter for review run/record. "
+            "Default review run remains loom/default-codex."
+        ),
+    )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument(
+        "--codex-app-review-app-server",
+        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-thread-id",
+        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-cwd",
+        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-raw-file",
+        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+    )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
@@ -7034,11 +7060,14 @@ def resolve_review_engine_profile(
     context: dict[str, Any],
     review_kind: str,
     *,
+    adapter: str = DEFAULT_REVIEW_ADAPTER,
     requested_profile: str | None = None,
     requested_model: str | None = None,
     requested_reasoning: str | None = None,
     override_reason: str | None = None,
 ) -> tuple[dict[str, Any] | None, list[str]]:
+    if adapter not in AUTHORITATIVE_REVIEW_ADAPTERS:
+        return None, [f"unsupported authoritative review adapter: {adapter}"]
     selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
     if requested_profile:
         selected_profile = requested_profile
@@ -7061,8 +7090,8 @@ def resolve_review_engine_profile(
     resolved = {
         "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
         "profile_id": base_profile["profile_id"],
-        "adapter": DEFAULT_REVIEW_ADAPTER,
-        "engine": DEFAULT_REVIEW_ENGINE,
+        "adapter": adapter,
+        "engine": CODEX_APP_REVIEW_ENGINE if adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
         "model": base_profile["model"],
         "reasoning_effort": base_profile["reasoning_effort"],
         "timeout_seconds": int(base_profile["timeout_seconds"]),
@@ -7158,6 +7187,20 @@ def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[di
             }
         ],
     }, []
+
+
+def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App authoritative review output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, [f"Codex App authoritative review output `{relative}` must be normalized JSON: {exc}"]
+    normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+    if errors or normalized is None:
+        return None, errors
+    return normalized, []
 
 
 def shadow_adapter_slug(adapter: str) -> str:
@@ -7345,6 +7388,232 @@ def run_codex_app_review_shadow_adapter(
         "evidence": evidence,
         "decision": normalized["decision"],
         "parity_diff": parity_diff,
+    }
+
+
+def run_codex_app_review_authoritative_adapter(
+    context: dict[str, Any],
+    build_payload: dict[str, Any],
+    review_path: str,
+    engine_profile: dict[str, Any],
+    *,
+    review_kind: str,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    raw_path = runtime_root / "engine-result.json"
+    findings_path = runtime_root / "normalized-findings.json"
+    metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
+    instructions_path = runtime_root / "prompt.txt"
+    context_pack = build_review_context_pack(context, review_path)
+    evidence = {
+        "runtime_root": relative_to_root(runtime_root, context["target_root"]),
+        "prompt": relative_to_root(instructions_path, context["target_root"]),
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+    }
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
+    instructions_path.write_text(
+        build_default_review_prompt(
+            context=context,
+            build_payload=build_payload,
+            runtime_fields=runtime_evidence_from_report(context["report"])[0],
+            review_path=review_path,
+            context_pack=context_pack,
+        ),
+        encoding="utf-8",
+    )
+
+    missing_inputs: list[str] = []
+    for label, value in (
+        ("--codex-app-review-app-server", app_server),
+        ("--codex-app-review-thread-id", thread_id),
+        ("--codex-app-review-cwd", thread_cwd),
+        ("--codex-app-review-raw-file", raw_file),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(label)
+
+    cwd_relative: str | None = None
+    if isinstance(thread_cwd, str) and thread_cwd.strip():
+        try:
+            cwd_path = Path(thread_cwd).expanduser().resolve()
+        except OSError as exc:
+            missing_inputs.append(f"Codex App review cwd could not be resolved: {exc}")
+        else:
+            if cwd_path != context["target_root"]:
+                missing_inputs.append(
+                    f"Codex App review cwd `{cwd_path}` does not match target root `{context['target_root']}`"
+                )
+            else:
+                cwd_relative = relative_to_root(cwd_path, context["target_root"])
+
+    source_path: Path | None = None
+    source_relative: str | None = None
+    if isinstance(raw_file, str) and raw_file.strip():
+        source_path, source_errors = resolve_repo_relative_path(
+            context["target_root"],
+            raw_file,
+            label="Codex App authoritative review raw file",
+        )
+        missing_inputs.extend(source_errors)
+        if source_path is not None:
+            source_relative = relative_to_root(source_path, context["target_root"])
+
+    if missing_inputs:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "summary": "Codex App authoritative review adapter is missing required live binding proof.",
+                "missing_inputs": missing_inputs,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review adapter failed closed before a formal review record could be authored.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+                "raw_source": source_relative,
+            },
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
+    except OSError as exc:
+        raw_text = ""
+        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+        normalized = None
+    else:
+        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+            raw_text,
+            relative=source_relative or str(raw_file),
+        )
+
+    if normalization_errors or normalized is None:
+        if raw_text:
+            raw_path.write_text(raw_text, encoding="utf-8")
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "summary": "Codex App authoritative review output did not satisfy the Loom review result schema.",
+                "errors": normalization_errors,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        }
+
+    raw_path.write_text(raw_text, encoding="utf-8")
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    metadata = {
+        "schema_version": "loom-review-engine-metadata/v1",
+        "engine": CODEX_APP_REVIEW_ENGINE,
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "profile": engine_profile,
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+        "result": "pass",
+        "reviewed_head": reviewed_head,
+        "decision": normalized["decision"],
+        "summary": normalized["summary"],
+        "kind": review_kind,
+        "validation_summary": context["latest_validation_summary"],
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_relative,
+        "raw_source": source_relative,
+        "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
+    }
+    write_json_file(metadata_path, metadata)
+    return {
+        "result": "pass",
+        "summary": "Codex App authoritative review adapter produced a Loom-normalized formal review draft.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "engine": {
+            "engine": CODEX_APP_REVIEW_ENGINE,
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "profile": engine_profile,
+            "result": "pass",
+            "failure_reason": None,
+            "reviewed_head": reviewed_head,
+            "evidence": evidence,
+        },
+        "engine_metadata": metadata,
+        "review_record_input": {
+            "decision": normalized["decision"],
+            "summary": normalized["summary"],
+            "reviewer": CODEX_APP_REVIEW_ADAPTER,
+            "kind": review_kind,
+            "findings_file": relative_to_root(findings_path, context["target_root"]),
+            "engine_adapter": CODEX_APP_REVIEW_ADAPTER,
+            "engine_evidence": relative_to_root(raw_path, context["target_root"]),
+            "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
+        },
     }
 
 
@@ -11523,9 +11792,11 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
+            adapter=requested_engine_adapter,
             requested_profile=args.engine_profile,
             requested_model=args.engine_model,
             requested_reasoning=args.engine_reasoning,
@@ -11548,8 +11819,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "missing_inputs": engine_profile_errors,
                     "fallback_to": None,
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
@@ -11588,8 +11859,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                     "current_checkpoint": flow_payload.get("current_checkpoint"),
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
@@ -11601,13 +11872,26 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(
-            context,
-            build_payload,
-            review_path,
-            engine_profile,
-            review_kind=review_kind,
-        )
+        if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER:
+            engine_payload = run_codex_app_review_authoritative_adapter(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+                app_server=args.codex_app_review_app_server,
+                thread_id=args.codex_app_review_thread_id,
+                thread_cwd=args.codex_app_review_cwd,
+                raw_file=args.codex_app_review_raw_file,
+            )
+        else:
+            engine_payload = run_default_review_engine(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+            )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,
             adapter=args.shadow_engine_adapter,
@@ -11630,7 +11914,7 @@ def handle_review(args: argparse.Namespace) -> int:
         summary = (
             engine_payload["summary"]
             if result == "pass"
-            else "default review engine failed closed; record any formal review conclusion through the single review record."
+            else f"{requested_engine_adapter} review engine failed closed; record any formal review conclusion through the single review record."
         )
         return emit(
             {
@@ -11652,6 +11936,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"engine_metadata": engine_payload["engine_metadata"]} if isinstance(engine_payload.get("engine_metadata"), dict) else {}),
                 **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),

--- a/skills/shared/references/harness/review-execution.md
+++ b/skills/shared/references/harness/review-execution.md
@@ -47,15 +47,15 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 Codex。
+默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+Codex App review adapter 有两种显式入口，默认均不启用：
 
 - 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
 - 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
@@ -63,17 +63,22 @@ Loom 把 review 分成四层：
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
+- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
+- authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract
 
-`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+`review run` 在调用 Codex-backed reviewer 或 Codex App authoritative adapter 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: 当前固定为 `loom/default-codex`
-- `engine`: 当前固定为 `codex`
+- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
+- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -757,6 +757,13 @@ output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
 sys.exit(0)
 """
+    elif mode == "fail_if_called":
+        body = """#!/usr/bin/env python3
+import sys
+
+sys.stderr.write("codex exec must not be called for explicit Codex App review adapter\\n")
+sys.exit(41)
+"""
     else:
         raise ValueError(f"unknown fake codex mode: {mode}")
     path.write_text(body, encoding="utf-8")
@@ -3005,10 +3012,12 @@ def require_review_run_payload(
     engine = payload.get("engine")
     if not isinstance(engine, dict):
         return
-    if engine.get("engine") != "codex":
-        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
-    if engine.get("adapter") != "loom/default-codex":
-        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    engine_adapter = engine.get("adapter")
+    if engine_adapter not in {"loom/default-codex", "loom/codex-app-review"}:
+        failures.append(Failure(category, f"{context} adapter must be a supported authoritative review adapter"))
+    expected_engine = "codex-app-review" if engine_adapter == "loom/codex-app-review" else "codex"
+    if engine.get("engine") != expected_engine:
+        failures.append(Failure(category, f"{context} engine must match the selected authoritative adapter"))
     profile = engine.get("profile")
     if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
         pass
@@ -3017,8 +3026,8 @@ def require_review_run_payload(
     else:
         if profile.get("schema_version") != "loom-review-engine-profile/v1":
             failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
-        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
-            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("adapter") != engine_adapter or profile.get("engine") != expected_engine:
+            failures.append(Failure(category, f"{context} engine profile must bind the selected adapter explicitly"))
         if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
             failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
         for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
@@ -3077,8 +3086,10 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
-            if review_record_input.get("reviewer") != "loom/default-codex":
-                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+            if review_record_input.get("reviewer") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input reviewer must match the selected adapter"))
+            if review_record_input.get("engine_adapter") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input engine_adapter must match the selected adapter"))
     shadow_engine = payload.get("shadow_engine")
     if shadow_engine is not None:
         if not isinstance(shadow_engine, dict):
@@ -5709,6 +5720,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex" or engine.get("adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep the default codex exec adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex" or review_record_input.get("reviewer") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep default review_record_input adapter"))
                 evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
                 context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
                 prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
@@ -5844,6 +5861,154 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
+        prepare_review_target(app_authoritative_target, "review run Codex App authoritative")
+        app_raw = app_authoritative_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App authoritative reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-warn-1",
+                            "summary": "Codex App authoritative review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_authoritative_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_authoritative_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App authoritative failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App authoritative",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must author app adapter review_record_input"))
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must not call codex exec"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("thread_id") != "thread-stage2-live-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must expose live thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_authoritative_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume raw Codex App authoritative evidence before review record is authored"))
+
+        app_missing_target = Path(tmp) / "review-run-codex-app-missing-proof"
+        prepare_review_target(app_missing_target, "review run Codex App missing proof")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_missing_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App missing proof failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App missing proof must fail closed"))
+
+        app_invalid_target = Path(tmp) / "review-run-codex-app-invalid-raw"
+        prepare_review_target(app_invalid_target, "review run Codex App invalid raw")
+        invalid_raw = app_invalid_target / ".loom/runtime/tmp/codex-app-review-invalid.txt"
+        invalid_raw.parent.mkdir(parents=True, exist_ok=True)
+        invalid_raw.write_text("plain review text is not authoritative schema\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_invalid_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_invalid_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-invalid.txt",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App invalid raw failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App invalid raw must fail closed on schema drift"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -113,7 +113,10 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
-CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ENGINE = "codex-app-review"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
+AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
@@ -444,9 +447,32 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--reviewer", help="Reviewer identity")
     review.add_argument("--fallback-to", choices=("admission", "build", "merge"))
     review.add_argument("--findings-file", help="Optional findings JSON path relative to the target root")
-    review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
+    review.add_argument(
+        "--engine-adapter",
+        choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
+        help=(
+            "Optional authoritative review engine adapter for review run/record. "
+            "Default review run remains loom/default-codex."
+        ),
+    )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument(
+        "--codex-app-review-app-server",
+        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-thread-id",
+        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-cwd",
+        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-raw-file",
+        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+    )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
@@ -7034,11 +7060,14 @@ def resolve_review_engine_profile(
     context: dict[str, Any],
     review_kind: str,
     *,
+    adapter: str = DEFAULT_REVIEW_ADAPTER,
     requested_profile: str | None = None,
     requested_model: str | None = None,
     requested_reasoning: str | None = None,
     override_reason: str | None = None,
 ) -> tuple[dict[str, Any] | None, list[str]]:
+    if adapter not in AUTHORITATIVE_REVIEW_ADAPTERS:
+        return None, [f"unsupported authoritative review adapter: {adapter}"]
     selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
     if requested_profile:
         selected_profile = requested_profile
@@ -7061,8 +7090,8 @@ def resolve_review_engine_profile(
     resolved = {
         "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
         "profile_id": base_profile["profile_id"],
-        "adapter": DEFAULT_REVIEW_ADAPTER,
-        "engine": DEFAULT_REVIEW_ENGINE,
+        "adapter": adapter,
+        "engine": CODEX_APP_REVIEW_ENGINE if adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
         "model": base_profile["model"],
         "reasoning_effort": base_profile["reasoning_effort"],
         "timeout_seconds": int(base_profile["timeout_seconds"]),
@@ -7158,6 +7187,20 @@ def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[di
             }
         ],
     }, []
+
+
+def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App authoritative review output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, [f"Codex App authoritative review output `{relative}` must be normalized JSON: {exc}"]
+    normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+    if errors or normalized is None:
+        return None, errors
+    return normalized, []
 
 
 def shadow_adapter_slug(adapter: str) -> str:
@@ -7345,6 +7388,232 @@ def run_codex_app_review_shadow_adapter(
         "evidence": evidence,
         "decision": normalized["decision"],
         "parity_diff": parity_diff,
+    }
+
+
+def run_codex_app_review_authoritative_adapter(
+    context: dict[str, Any],
+    build_payload: dict[str, Any],
+    review_path: str,
+    engine_profile: dict[str, Any],
+    *,
+    review_kind: str,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    raw_path = runtime_root / "engine-result.json"
+    findings_path = runtime_root / "normalized-findings.json"
+    metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
+    instructions_path = runtime_root / "prompt.txt"
+    context_pack = build_review_context_pack(context, review_path)
+    evidence = {
+        "runtime_root": relative_to_root(runtime_root, context["target_root"]),
+        "prompt": relative_to_root(instructions_path, context["target_root"]),
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+    }
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
+    instructions_path.write_text(
+        build_default_review_prompt(
+            context=context,
+            build_payload=build_payload,
+            runtime_fields=runtime_evidence_from_report(context["report"])[0],
+            review_path=review_path,
+            context_pack=context_pack,
+        ),
+        encoding="utf-8",
+    )
+
+    missing_inputs: list[str] = []
+    for label, value in (
+        ("--codex-app-review-app-server", app_server),
+        ("--codex-app-review-thread-id", thread_id),
+        ("--codex-app-review-cwd", thread_cwd),
+        ("--codex-app-review-raw-file", raw_file),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(label)
+
+    cwd_relative: str | None = None
+    if isinstance(thread_cwd, str) and thread_cwd.strip():
+        try:
+            cwd_path = Path(thread_cwd).expanduser().resolve()
+        except OSError as exc:
+            missing_inputs.append(f"Codex App review cwd could not be resolved: {exc}")
+        else:
+            if cwd_path != context["target_root"]:
+                missing_inputs.append(
+                    f"Codex App review cwd `{cwd_path}` does not match target root `{context['target_root']}`"
+                )
+            else:
+                cwd_relative = relative_to_root(cwd_path, context["target_root"])
+
+    source_path: Path | None = None
+    source_relative: str | None = None
+    if isinstance(raw_file, str) and raw_file.strip():
+        source_path, source_errors = resolve_repo_relative_path(
+            context["target_root"],
+            raw_file,
+            label="Codex App authoritative review raw file",
+        )
+        missing_inputs.extend(source_errors)
+        if source_path is not None:
+            source_relative = relative_to_root(source_path, context["target_root"])
+
+    if missing_inputs:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "summary": "Codex App authoritative review adapter is missing required live binding proof.",
+                "missing_inputs": missing_inputs,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review adapter failed closed before a formal review record could be authored.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+                "raw_source": source_relative,
+            },
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
+    except OSError as exc:
+        raw_text = ""
+        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+        normalized = None
+    else:
+        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+            raw_text,
+            relative=source_relative or str(raw_file),
+        )
+
+    if normalization_errors or normalized is None:
+        if raw_text:
+            raw_path.write_text(raw_text, encoding="utf-8")
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "summary": "Codex App authoritative review output did not satisfy the Loom review result schema.",
+                "errors": normalization_errors,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        }
+
+    raw_path.write_text(raw_text, encoding="utf-8")
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    metadata = {
+        "schema_version": "loom-review-engine-metadata/v1",
+        "engine": CODEX_APP_REVIEW_ENGINE,
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "profile": engine_profile,
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+        "result": "pass",
+        "reviewed_head": reviewed_head,
+        "decision": normalized["decision"],
+        "summary": normalized["summary"],
+        "kind": review_kind,
+        "validation_summary": context["latest_validation_summary"],
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_relative,
+        "raw_source": source_relative,
+        "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
+    }
+    write_json_file(metadata_path, metadata)
+    return {
+        "result": "pass",
+        "summary": "Codex App authoritative review adapter produced a Loom-normalized formal review draft.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "engine": {
+            "engine": CODEX_APP_REVIEW_ENGINE,
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "profile": engine_profile,
+            "result": "pass",
+            "failure_reason": None,
+            "reviewed_head": reviewed_head,
+            "evidence": evidence,
+        },
+        "engine_metadata": metadata,
+        "review_record_input": {
+            "decision": normalized["decision"],
+            "summary": normalized["summary"],
+            "reviewer": CODEX_APP_REVIEW_ADAPTER,
+            "kind": review_kind,
+            "findings_file": relative_to_root(findings_path, context["target_root"]),
+            "engine_adapter": CODEX_APP_REVIEW_ADAPTER,
+            "engine_evidence": relative_to_root(raw_path, context["target_root"]),
+            "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
+        },
     }
 
 
@@ -11523,9 +11792,11 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
+            adapter=requested_engine_adapter,
             requested_profile=args.engine_profile,
             requested_model=args.engine_model,
             requested_reasoning=args.engine_reasoning,
@@ -11548,8 +11819,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "missing_inputs": engine_profile_errors,
                     "fallback_to": None,
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
@@ -11588,8 +11859,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                     "current_checkpoint": flow_payload.get("current_checkpoint"),
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
@@ -11601,13 +11872,26 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(
-            context,
-            build_payload,
-            review_path,
-            engine_profile,
-            review_kind=review_kind,
-        )
+        if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER:
+            engine_payload = run_codex_app_review_authoritative_adapter(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+                app_server=args.codex_app_review_app_server,
+                thread_id=args.codex_app_review_thread_id,
+                thread_cwd=args.codex_app_review_cwd,
+                raw_file=args.codex_app_review_raw_file,
+            )
+        else:
+            engine_payload = run_default_review_engine(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+            )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,
             adapter=args.shadow_engine_adapter,
@@ -11630,7 +11914,7 @@ def handle_review(args: argparse.Namespace) -> int:
         summary = (
             engine_payload["summary"]
             if result == "pass"
-            else "default review engine failed closed; record any formal review conclusion through the single review record."
+            else f"{requested_engine_adapter} review engine failed closed; record any formal review conclusion through the single review record."
         )
         return emit(
             {
@@ -11652,6 +11936,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"engine_metadata": engine_payload["engine_metadata"]} if isinstance(engine_payload.get("engine_metadata"), dict) else {}),
                 **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),

--- a/src/skills/loom-review/SKILL.md
+++ b/src/skills/loom-review/SKILL.md
@@ -42,7 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+
+默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -52,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 

--- a/src/skills/loom-spec-review/SKILL.md
+++ b/src/skills/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，生成 Loom-normalized spec findings
+3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,6 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/src/skills/shared/references/harness/review-execution.md
+++ b/src/skills/shared/references/harness/review-execution.md
@@ -47,15 +47,15 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 Codex。
+默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-阶段 1 的 Codex App review adapter 只能作为 shadow evidence producer 进入：
+Codex App review adapter 有两种显式入口，默认均不启用：
 
 - 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
 - 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
@@ -63,17 +63,22 @@ Loom 把 review 分成四层：
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
+- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
+- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
+- authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
 ### 2.1 Review engine profile contract
 
-`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+`review run` 在调用 Codex-backed reviewer 或 Codex App authoritative adapter 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: 当前固定为 `loom/default-codex`
-- `engine`: 当前固定为 `codex`
+- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
+- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -757,6 +757,13 @@ output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
 sys.exit(0)
 """
+    elif mode == "fail_if_called":
+        body = """#!/usr/bin/env python3
+import sys
+
+sys.stderr.write("codex exec must not be called for explicit Codex App review adapter\\n")
+sys.exit(41)
+"""
     else:
         raise ValueError(f"unknown fake codex mode: {mode}")
     path.write_text(body, encoding="utf-8")
@@ -3005,10 +3012,12 @@ def require_review_run_payload(
     engine = payload.get("engine")
     if not isinstance(engine, dict):
         return
-    if engine.get("engine") != "codex":
-        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
-    if engine.get("adapter") != "loom/default-codex":
-        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    engine_adapter = engine.get("adapter")
+    if engine_adapter not in {"loom/default-codex", "loom/codex-app-review"}:
+        failures.append(Failure(category, f"{context} adapter must be a supported authoritative review adapter"))
+    expected_engine = "codex-app-review" if engine_adapter == "loom/codex-app-review" else "codex"
+    if engine.get("engine") != expected_engine:
+        failures.append(Failure(category, f"{context} engine must match the selected authoritative adapter"))
     profile = engine.get("profile")
     if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
         pass
@@ -3017,8 +3026,8 @@ def require_review_run_payload(
     else:
         if profile.get("schema_version") != "loom-review-engine-profile/v1":
             failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
-        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
-            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("adapter") != engine_adapter or profile.get("engine") != expected_engine:
+            failures.append(Failure(category, f"{context} engine profile must bind the selected adapter explicitly"))
         if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
             failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
         for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
@@ -3077,8 +3086,10 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
-            if review_record_input.get("reviewer") != "loom/default-codex":
-                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+            if review_record_input.get("reviewer") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input reviewer must match the selected adapter"))
+            if review_record_input.get("engine_adapter") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input engine_adapter must match the selected adapter"))
     shadow_engine = payload.get("shadow_engine")
     if shadow_engine is not None:
         if not isinstance(shadow_engine, dict):
@@ -5709,6 +5720,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex" or engine.get("adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep the default codex exec adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex" or review_record_input.get("reviewer") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep default review_record_input adapter"))
                 evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
                 context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
                 prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
@@ -5844,6 +5861,154 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
+        prepare_review_target(app_authoritative_target, "review run Codex App authoritative")
+        app_raw = app_authoritative_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App authoritative reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-warn-1",
+                            "summary": "Codex App authoritative review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_authoritative_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_authoritative_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App authoritative failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App authoritative",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must author app adapter review_record_input"))
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must not call codex exec"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("thread_id") != "thread-stage2-live-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must expose live thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_authoritative_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume raw Codex App authoritative evidence before review record is authored"))
+
+        app_missing_target = Path(tmp) / "review-run-codex-app-missing-proof"
+        prepare_review_target(app_missing_target, "review run Codex App missing proof")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_missing_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App missing proof failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App missing proof must fail closed"))
+
+        app_invalid_target = Path(tmp) / "review-run-codex-app-invalid-raw"
+        prepare_review_target(app_invalid_target, "review run Codex App invalid raw")
+        invalid_raw = app_invalid_target / ".loom/runtime/tmp/codex-app-review-invalid.txt"
+        invalid_raw.parent.mkdir(parents=True, exist_ok=True)
+        invalid_raw.write_text("plain review text is not authoritative schema\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_invalid_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_invalid_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-invalid.txt",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App invalid raw failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App invalid raw must fail closed on schema drift"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -113,7 +113,10 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
-CODEX_APP_REVIEW_SHADOW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ENGINE = "codex-app-review"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
+AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
@@ -444,9 +447,32 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--reviewer", help="Reviewer identity")
     review.add_argument("--fallback-to", choices=("admission", "build", "merge"))
     review.add_argument("--findings-file", help="Optional findings JSON path relative to the target root")
-    review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
+    review.add_argument(
+        "--engine-adapter",
+        choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
+        help=(
+            "Optional authoritative review engine adapter for review run/record. "
+            "Default review run remains loom/default-codex."
+        ),
+    )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument(
+        "--codex-app-review-app-server",
+        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-thread-id",
+        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-cwd",
+        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+    )
+    review.add_argument(
+        "--codex-app-review-raw-file",
+        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+    )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
@@ -7034,11 +7060,14 @@ def resolve_review_engine_profile(
     context: dict[str, Any],
     review_kind: str,
     *,
+    adapter: str = DEFAULT_REVIEW_ADAPTER,
     requested_profile: str | None = None,
     requested_model: str | None = None,
     requested_reasoning: str | None = None,
     override_reason: str | None = None,
 ) -> tuple[dict[str, Any] | None, list[str]]:
+    if adapter not in AUTHORITATIVE_REVIEW_ADAPTERS:
+        return None, [f"unsupported authoritative review adapter: {adapter}"]
     selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
     if requested_profile:
         selected_profile = requested_profile
@@ -7061,8 +7090,8 @@ def resolve_review_engine_profile(
     resolved = {
         "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
         "profile_id": base_profile["profile_id"],
-        "adapter": DEFAULT_REVIEW_ADAPTER,
-        "engine": DEFAULT_REVIEW_ENGINE,
+        "adapter": adapter,
+        "engine": CODEX_APP_REVIEW_ENGINE if adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
         "model": base_profile["model"],
         "reasoning_effort": base_profile["reasoning_effort"],
         "timeout_seconds": int(base_profile["timeout_seconds"]),
@@ -7158,6 +7187,20 @@ def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[di
             }
         ],
     }, []
+
+
+def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App authoritative review output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, [f"Codex App authoritative review output `{relative}` must be normalized JSON: {exc}"]
+    normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+    if errors or normalized is None:
+        return None, errors
+    return normalized, []
 
 
 def shadow_adapter_slug(adapter: str) -> str:
@@ -7345,6 +7388,232 @@ def run_codex_app_review_shadow_adapter(
         "evidence": evidence,
         "decision": normalized["decision"],
         "parity_diff": parity_diff,
+    }
+
+
+def run_codex_app_review_authoritative_adapter(
+    context: dict[str, Any],
+    build_payload: dict[str, Any],
+    review_path: str,
+    engine_profile: dict[str, Any],
+    *,
+    review_kind: str,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    raw_path = runtime_root / "engine-result.json"
+    findings_path = runtime_root / "normalized-findings.json"
+    metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
+    instructions_path = runtime_root / "prompt.txt"
+    context_pack = build_review_context_pack(context, review_path)
+    evidence = {
+        "runtime_root": relative_to_root(runtime_root, context["target_root"]),
+        "prompt": relative_to_root(instructions_path, context["target_root"]),
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+    }
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
+    instructions_path.write_text(
+        build_default_review_prompt(
+            context=context,
+            build_payload=build_payload,
+            runtime_fields=runtime_evidence_from_report(context["report"])[0],
+            review_path=review_path,
+            context_pack=context_pack,
+        ),
+        encoding="utf-8",
+    )
+
+    missing_inputs: list[str] = []
+    for label, value in (
+        ("--codex-app-review-app-server", app_server),
+        ("--codex-app-review-thread-id", thread_id),
+        ("--codex-app-review-cwd", thread_cwd),
+        ("--codex-app-review-raw-file", raw_file),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(label)
+
+    cwd_relative: str | None = None
+    if isinstance(thread_cwd, str) and thread_cwd.strip():
+        try:
+            cwd_path = Path(thread_cwd).expanduser().resolve()
+        except OSError as exc:
+            missing_inputs.append(f"Codex App review cwd could not be resolved: {exc}")
+        else:
+            if cwd_path != context["target_root"]:
+                missing_inputs.append(
+                    f"Codex App review cwd `{cwd_path}` does not match target root `{context['target_root']}`"
+                )
+            else:
+                cwd_relative = relative_to_root(cwd_path, context["target_root"])
+
+    source_path: Path | None = None
+    source_relative: str | None = None
+    if isinstance(raw_file, str) and raw_file.strip():
+        source_path, source_errors = resolve_repo_relative_path(
+            context["target_root"],
+            raw_file,
+            label="Codex App authoritative review raw file",
+        )
+        missing_inputs.extend(source_errors)
+        if source_path is not None:
+            source_relative = relative_to_root(source_path, context["target_root"])
+
+    if missing_inputs:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "summary": "Codex App authoritative review adapter is missing required live binding proof.",
+                "missing_inputs": missing_inputs,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review adapter failed closed before a formal review record could be authored.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+                "raw_source": source_relative,
+            },
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
+    except OSError as exc:
+        raw_text = ""
+        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+        normalized = None
+    else:
+        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+            raw_text,
+            relative=source_relative or str(raw_file),
+        )
+
+    if normalization_errors or normalized is None:
+        if raw_text:
+            raw_path.write_text(raw_text, encoding="utf-8")
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "summary": "Codex App authoritative review output did not satisfy the Loom review result schema.",
+                "errors": normalization_errors,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+            },
+        }
+
+    raw_path.write_text(raw_text, encoding="utf-8")
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    metadata = {
+        "schema_version": "loom-review-engine-metadata/v1",
+        "engine": CODEX_APP_REVIEW_ENGINE,
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "profile": engine_profile,
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+        "result": "pass",
+        "reviewed_head": reviewed_head,
+        "decision": normalized["decision"],
+        "summary": normalized["summary"],
+        "kind": review_kind,
+        "validation_summary": context["latest_validation_summary"],
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_relative,
+        "raw_source": source_relative,
+        "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
+    }
+    write_json_file(metadata_path, metadata)
+    return {
+        "result": "pass",
+        "summary": "Codex App authoritative review adapter produced a Loom-normalized formal review draft.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "engine": {
+            "engine": CODEX_APP_REVIEW_ENGINE,
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "profile": engine_profile,
+            "result": "pass",
+            "failure_reason": None,
+            "reviewed_head": reviewed_head,
+            "evidence": evidence,
+        },
+        "engine_metadata": metadata,
+        "review_record_input": {
+            "decision": normalized["decision"],
+            "summary": normalized["summary"],
+            "reviewer": CODEX_APP_REVIEW_ADAPTER,
+            "kind": review_kind,
+            "findings_file": relative_to_root(findings_path, context["target_root"]),
+            "engine_adapter": CODEX_APP_REVIEW_ADAPTER,
+            "engine_evidence": relative_to_root(raw_path, context["target_root"]),
+            "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
+        },
     }
 
 
@@ -11523,9 +11792,11 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
+            adapter=requested_engine_adapter,
             requested_profile=args.engine_profile,
             requested_model=args.engine_model,
             requested_reasoning=args.engine_reasoning,
@@ -11548,8 +11819,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "missing_inputs": engine_profile_errors,
                     "fallback_to": None,
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
@@ -11588,8 +11859,8 @@ def handle_review(args: argparse.Namespace) -> int:
                     "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                     "current_checkpoint": flow_payload.get("current_checkpoint"),
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
@@ -11601,13 +11872,26 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(
-            context,
-            build_payload,
-            review_path,
-            engine_profile,
-            review_kind=review_kind,
-        )
+        if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER:
+            engine_payload = run_codex_app_review_authoritative_adapter(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+                app_server=args.codex_app_review_app_server,
+                thread_id=args.codex_app_review_thread_id,
+                thread_cwd=args.codex_app_review_cwd,
+                raw_file=args.codex_app_review_raw_file,
+            )
+        else:
+            engine_payload = run_default_review_engine(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+            )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,
             adapter=args.shadow_engine_adapter,
@@ -11630,7 +11914,7 @@ def handle_review(args: argparse.Namespace) -> int:
         summary = (
             engine_payload["summary"]
             if result == "pass"
-            else "default review engine failed closed; record any formal review conclusion through the single review record."
+            else f"{requested_engine_adapter} review engine failed closed; record any formal review conclusion through the single review record."
         )
         return emit(
             {
@@ -11652,6 +11936,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"engine_metadata": engine_payload["engine_metadata"]} if isinstance(engine_payload.get("engine_metadata"), dict) else {}),
                 **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),


### PR DESCRIPTION
## Summary

- Adds explicit authoritative review run selection with --engine-adapter loom/codex-app-review while preserving default loom/default-codex plus codex exec --output-schema.
- Requires app-server/session locator, thread id, cwd proof, and normalized raw review output for Codex App authoritative runs.
- Normalizes App review output into the existing Loom review result and review_record_input contract; raw App output remains runtime evidence only.
- Fails closed for missing proof, cwd mismatch, unsafe/unreadable raw output, invalid JSON, and schema drift.
- Keeps merge-ready consumption bound to the authored review_entry record, not raw App evidence or shadow artifacts.
- Updates docs and regenerated skills surfaces.

## Live Proof

- Local runtime remains codex-cli 0.120.0.
- app-server stdio initialize returned Codex Desktop/0.120.0.
- Escalated local stdio thread/start created ephemeral thread 019e2bb0-4fe7-74f3-94ee-a6f5ed070ef2 bound to /Users/claw/dev/Loom.
- inline review/start returned reviewThreadId equal to the original thread id and emitted enteredReviewMode plus exitedReviewMode.review.
- Live App review found a P1 issue in the first implementation attempt: authoritative normalized findings were under an unscanned authoritative/<adapter>/ subdir. This PR fixes that by retaining authoritative files at .loom/runtime/review/<item>/<head>/normalized-findings.json and sibling engine files.

## Validation

- PYTHONPYCACHEPREFIX=/tmp/loom-pycache python3 -m py_compile tools/loom_flow.py tools/loom_check.py skills/shared/scripts/loom_flow.py skills/shared/scripts/loom_check.py src/skills/shared/scripts/loom_flow.py src/skills/shared/scripts/loom_check.py
- python3 tools/loom_flow.py review run --help
- python3 tools/skills_surface.py generate
- make skills-check
- python3 tools/skills_surface.py check
- git diff --check
- Focused check_daily_execution_cli run exercised Stage 2 fixtures; only failures were unrelated GitHub host-binding REST availability checks.

## Issue State

- Advances #749
- Parent truth #746
- Updates #757
- Updates #760
- Updates #758
- Updates #761
- Updates #759

## Boundaries

- Does not make Codex App review the default engine.
- Does not let raw App review output become authored truth.
- Does not let merge-ready consume raw App output or shadow artifacts.
- Does not remove headless / CI codex exec fallback.
- Does not begin Stage 3 default switching.
