### PR TITLE
feat: 切换 Codex App review 默认适配器

### DIFF
--- a/.loom/bootstrap/init-result.json
+++ b/.loom/bootstrap/init-result.json
@@ -74,9 +74,9 @@
     "mode": "work-item + recovery-entry + derived status-surface",
     "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
     "entry_points": {
-      "current_item_id": "WI-763",
-      "work_item": ".loom/work-items/WI-763.md",
-      "recovery_entry": ".loom/progress/WI-763.md",
+      "current_item_id": "WI-750",
+      "work_item": ".loom/work-items/WI-750.md",
+      "recovery_entry": ".loom/progress/WI-750.md",
       "status_surface": ".loom/status/current.md"
     }
   },

--- a/.loom/progress/WI-750.md
+++ b/.loom/progress/WI-750.md
@@ -1,0 +1,21 @@
+# WI-750 Progress
+
+## Dynamic Facts
+
+- Item ID: WI-750
+- Current Checkpoint: merge checkpoint
+- Current Stop: Implementation, documentation, generated surfaces, installer version bump, and local validation are complete on branch work/750-codex-app-default-review-adapter; fresh review records are being recorded for PR #770.
+- Next Step: Commit the WI-750 fact chain, record spec and implementation review records against the reviewed heads, update PR #770 body with the Loom Work Item binding, push, and confirm PR gates.
+- Blockers: None recorded.
+- Latest Validation Summary: pending final validation refresh for WI-750 after fact-chain and installer version updates.
+- Recovery Boundary: Branch work/750-codex-app-default-review-adapter; issue #750 phase 3; PR #770; raw Codex App review evidence remains runtime evidence only and never approval truth.
+- Current Lane: #750 phase 3 / Codex App default review adapter
+
+## Execution Ledger
+
+- Ledger Binding: recovery_entry
+- Plan Locator: .loom/specs/WI-750/plan.md
+- Acceptance Locator: .loom/specs/WI-750/spec.md
+- Validation Evidence Locator: python3 -m py_compile tools/loom_flow.py tools/loom_check.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py && python3 tools/loom_check.py && make check
+- Handoff Notes Locator: not_applicable
+- Evidence Freshness: current

--- a/.loom/progress/WI-750.md
+++ b/.loom/progress/WI-750.md
@@ -4,10 +4,10 @@
 
 - Item ID: WI-750
 - Current Checkpoint: merge checkpoint
-- Current Stop: Implementation, documentation, generated surfaces, installer version bump, and local validation are complete on branch work/750-codex-app-default-review-adapter; fresh review records are being recorded for PR #770.
-- Next Step: Commit the WI-750 fact chain, record spec and implementation review records against the reviewed heads, update PR #770 body with the Loom Work Item binding, push, and confirm PR gates.
+- Current Stop: Implementation, documentation, generated surfaces, installer version bump, local validation refresh, and fresh review records are complete on branch work/750-codex-app-default-review-adapter.
+- Next Step: Update PR #770 body with the Loom Work Item binding, push, and confirm PR gates.
 - Blockers: None recorded.
-- Latest Validation Summary: pending final validation refresh for WI-750 after fact-chain and installer version updates.
+- Latest Validation Summary: 2026-05-17 validation for WI-750: python3 -m py_compile tools/loom_flow.py tools/loom_check.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py -> OK; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main -> OK (0.1.107 -> 0.1.108); python3 tools/version_surface_check.py -> OK; python3 tools/loom_flow.py fact-chain --target . --item WI-750 -> pass; python3 tools/loom_check.py -> OK; make check -> OK; git diff --check -> OK.
 - Recovery Boundary: Branch work/750-codex-app-default-review-adapter; issue #750 phase 3; PR #770; raw Codex App review evidence remains runtime evidence only and never approval truth.
 - Current Lane: #750 phase 3 / Codex App default review adapter
 

--- a/.loom/progress/WI-763.md
+++ b/.loom/progress/WI-763.md
@@ -3,7 +3,7 @@
 ## Dynamic Facts
 
 - Item ID: WI-763
-- Current Checkpoint: merge checkpoint
+- Current Checkpoint: retired
 - Current Stop: Local implementation, ruleset fixture support, installer package version bump, vendored .loom/bin runtime refresh, validation refresh, and default loom/default-codex review evidence are complete on branch harden-pr-semantic-review-gate.
 - Next Step: Record the refreshed authored implementation review for the vendored runtime refresh, push PR #769, prove live PR-head checks and host readback, then merge through controlled-merge.
 - Blockers: None recorded.

--- a/.loom/reviews/WI-750.json
+++ b/.loom/reviews/WI-750.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-750",
+  "decision": "allow",
+  "kind": "code_review",
+  "summary": "#750 phase 3 is approved: review runs now default to the Codex App review adapter only with complete host proof, CI/headless/missing or unavailable App host paths fall back to default-codex, proof conflicts fail closed, metadata records the selected adapter and evidence locators, generated surfaces are synchronized, and raw App evidence remains outside merge approval truth.",
+  "reviewer": "codex",
+  "reviewed_head": "5ab3ab64bf09e56cec4e309aa58efecfe8f91098",
+  "reviewed_validation_summary": "2026-05-17 validation for WI-750: python3 -m py_compile tools/loom_flow.py tools/loom_check.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py -> OK; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main -> OK (0.1.107 -> 0.1.108); python3 tools/version_surface_check.py -> OK; python3 tools/loom_flow.py fact-chain --target . --item WI-750 -> pass; python3 tools/loom_check.py -> OK; make check -> OK; git diff --check -> OK.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-750.md",
+    "recovery_entry": ".loom/progress/WI-750.md",
+    "status_surface": ".loom/status/current.md",
+    "build_checkpoint": "pass",
+    "engine_adapter": null,
+    "engine_evidence": null,
+    "normalized_findings": null
+  }
+}

--- a/.loom/reviews/WI-750.json
+++ b/.loom/reviews/WI-750.json
@@ -5,7 +5,7 @@
   "kind": "code_review",
   "summary": "#750 phase 3 is approved: review runs now default to the Codex App review adapter only with complete host proof, CI/headless/missing or unavailable App host paths fall back to default-codex, proof conflicts fail closed, metadata records the selected adapter and evidence locators, generated surfaces are synchronized, and raw App evidence remains outside merge approval truth.",
   "reviewer": "codex",
-  "reviewed_head": "5ab3ab64bf09e56cec4e309aa58efecfe8f91098",
+  "reviewed_head": "2c26de8148571b706f470a1562b48149fae1d254",
   "reviewed_validation_summary": "2026-05-17 validation for WI-750: python3 -m py_compile tools/loom_flow.py tools/loom_check.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py -> OK; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main -> OK (0.1.107 -> 0.1.108); python3 tools/version_surface_check.py -> OK; python3 tools/loom_flow.py fact-chain --target . --item WI-750 -> pass; python3 tools/loom_check.py -> OK; make check -> OK; git diff --check -> OK.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-750.spec.json
+++ b/.loom/reviews/WI-750.spec.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-750",
+  "decision": "allow",
+  "kind": "spec_review",
+  "summary": "WI-750 spec suite matches #750 phase 3: default Codex App review is limited to verified App host proof, fallback/fail-closed behavior remains explicit, raw App evidence stays outside approval truth, and validation covers implementation, generated surfaces, installer version truth, and PR gates.",
+  "reviewer": "codex",
+  "reviewed_head": "daec659a377cb855acebc44faab2638722d7a556",
+  "reviewed_validation_summary": "Spec review covers .loom/specs/WI-750/spec.md, plan.md, and implementation-contract.md at daec659a377cb855acebc44faab2638722d7a556 before implementation review record authoring.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-750.md",
+    "recovery_entry": ".loom/progress/WI-750.md",
+    "status_surface": ".loom/status/current.md",
+    "formal_spec_path": ".loom/specs/WI-750/spec.md",
+    "plan_path": ".loom/specs/WI-750/plan.md",
+    "implementation_contract": ".loom/specs/WI-750/implementation-contract.md"
+  }
+}

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "ef507d8a3e77b576cf42d0a27c5de5cb08b6a827686192933673958958647f46"
+    ".loom/status/current.md": "e7900535450b73a5c2cd5aa3e9def40134b4730e90242101479716199811a20c"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "ef507d8a3e77b576cf42d0a27c5de5cb08b6a827686192933673958958647f46"
+    ".loom/status/current.md": "e7900535450b73a5c2cd5aa3e9def40134b4730e90242101479716199811a20c"
   }
 }

--- a/.loom/specs/WI-750/implementation-contract.md
+++ b/.loom/specs/WI-750/implementation-contract.md
@@ -1,0 +1,35 @@
+# WI-750 Implementation Contract
+
+## Owned Paths
+
+- `skills/shared/scripts/loom_flow.py`
+- `src/skills/shared/scripts/loom_flow.py`
+- `skills/shared/scripts/loom_check.py`
+- `src/skills/shared/scripts/loom_check.py`
+- `docs/methodology/harness/review-execution.md`
+- `skills/shared/references/harness/review-execution.md`
+- `src/skills/shared/references/harness/review-execution.md`
+- `skills/loom-review/SKILL.md`
+- `src/skills/loom-review/SKILL.md`
+- `skills/loom-spec-review/SKILL.md`
+- `src/skills/loom-spec-review/SKILL.md`
+- `skills/*/.loom-runtime/**`
+- `examples/new-project/.loom/**`
+- `examples/new-project/.github/PULL_REQUEST_TEMPLATE.md`
+- `packages/loom-installer/package.json`
+- `packages/loom-installer/package-lock.json`
+- `.loom/work-items/WI-750.md`
+- `.loom/progress/WI-750.md`
+- `.loom/reviews/WI-750.json`
+- `.loom/reviews/WI-750.spec.json`
+- `.loom/status/current.md`
+- `.loom/bootstrap/init-result.json`
+- `.loom/specs/WI-750/**`
+
+## Invariants
+
+- Do not remove Stage 1/2 shadow or opt-in compatibility interfaces.
+- Do not let raw Codex App evidence become merge-ready approval truth.
+- Do not change Loom review record consumption semantics outside the #750 adapter selection and metadata scope.
+- Do not make Codex App default in CI, headless, missing proof, or unavailable app-server contexts.
+- Fail closed on proof conflicts or target/head/schema binding failures.

--- a/.loom/specs/WI-750/plan.md
+++ b/.loom/specs/WI-750/plan.md
@@ -1,0 +1,11 @@
+# WI-750 Plan
+
+1. Read #750 phase 3 scope, review execution docs, adapter selection code, and daily execution fixtures.
+2. Implement the default adapter selector in `loom_flow.py`, preserving explicit adapter behavior and CI/headless fallback.
+3. Extend Codex App authoritative review handling with live app-server proof, binding checks, output normalization, and fail-closed behavior.
+4. Update `loom_check.py` fixtures for App default selection, CI fallback, unavailable endpoint fallback, proof conflicts, invalid schema, missing reviewed head, and raw-evidence merge-ready blocking.
+5. Synchronize `skills/` and `src/skills/` mirrors plus generated `.loom-runtime` and demo bootstrap surfaces.
+6. Update review execution and review skill documentation to describe the new default and fallback semantics.
+7. Bump the installer package version because distributed skill behavior changed.
+8. Run py_compile, `tools/loom_check.py`, installer version checks, version surface checks, and `make check`.
+9. Record fresh spec and implementation review records, push PR #770, and confirm PR gates.

--- a/.loom/specs/WI-750/spec.md
+++ b/.loom/specs/WI-750/spec.md
@@ -1,0 +1,28 @@
+# WI-750 Spec
+
+## Objective
+
+Switch Loom review runs to use `loom/codex-app-review` by default only inside a verified Codex App interactive host, while preserving `loom/default-codex` as the safe default for CI, headless, missing proof, and unavailable app-server paths.
+
+## Acceptance Criteria
+
+- Explicit `--engine-adapter` continues to take precedence over automatic selection.
+- Non-CI runs with complete App proof select `loom/codex-app-review` by default.
+- CI or `CODEX_CI` runs select `loom/default-codex` even when thread identifiers are present.
+- Missing or unavailable App host proof falls back to `loom/default-codex` and records the fallback reason.
+- Conflicting App proof, mismatched cwd/root, unverifiable reviewed head, target binding failure, or normalization failure fail closed.
+- App proof includes endpoint, thread id, thread cwd proof, target root, and reviewed head; `thread_cwd` must equal `target_root`.
+- Live app-server review starts against the current thread and consumes only `exitedReviewMode.review`; normalization uses the same app-server thread's `turn/start.outputSchema`.
+- Raw App review evidence remains runtime evidence only and cannot satisfy merge-ready approval without the authored review record.
+- `engine_metadata` records selected adapter, selection source, fallback reason, app-server endpoint, thread id, thread cwd, target root, reviewed head, review thread id, raw review locator, normalized findings locator, and context pack locator.
+- `review_record_input.engine_adapter` and reviewer match the selected adapter.
+- `skills/` and `src/skills/` generated and source surfaces stay synchronized.
+- Installer behavior version truth is bumped because distributed skill behavior changed.
+
+## Validation
+
+- `python3 -m py_compile tools/loom_flow.py tools/loom_check.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py`
+- `python3 tools/loom_check.py`
+- `make check`
+- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
+- `python3 tools/version_surface_check.py`

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -12,10 +12,10 @@
 - Validation Entry: python3 -m py_compile tools/loom_flow.py tools/loom_check.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py && python3 tools/loom_check.py && make check
 - Closing Condition: PR #770 contains the #750 phase 3 implementation and docs; generated surfaces are synchronized; installer version behavior truth is bumped; py_compile, loom_check, make check, and PR gates pass; the branch is pushed with fresh authored spec and implementation review records.
 - Current Checkpoint: merge checkpoint
-- Current Stop: Implementation, documentation, generated surfaces, installer version bump, and local validation are complete on branch work/750-codex-app-default-review-adapter; fresh review records are being recorded for PR #770.
-- Next Step: Commit the WI-750 fact chain, record spec and implementation review records against the reviewed heads, update PR #770 body with the Loom Work Item binding, push, and confirm PR gates.
+- Current Stop: Implementation, documentation, generated surfaces, installer version bump, local validation refresh, and fresh review records are complete on branch work/750-codex-app-default-review-adapter.
+- Next Step: Update PR #770 body with the Loom Work Item binding, push, and confirm PR gates.
 - Blockers: None recorded.
-- Latest Validation Summary: pending final validation refresh for WI-750 after fact-chain and installer version updates.
+- Latest Validation Summary: 2026-05-17 validation for WI-750: python3 -m py_compile tools/loom_flow.py tools/loom_check.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py -> OK; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main -> OK (0.1.107 -> 0.1.108); python3 tools/version_surface_check.py -> OK; python3 tools/loom_flow.py fact-chain --target . --item WI-750 -> pass; python3 tools/loom_check.py -> OK; make check -> OK; git diff --check -> OK.
 - Recovery Boundary: Branch work/750-codex-app-default-review-adapter; issue #750 phase 3; PR #770; raw Codex App review evidence remains runtime evidence only and never approval truth.
 - Current Lane: #750 phase 3 / Codex App default review adapter
 

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -2,22 +2,22 @@
 
 ## Derived Fact Chain View
 
-- Item ID: WI-763
-- Goal: Host-enforce Loom semantic review approval before PR merge
-- Scope: Add a PR-specific merge gate, host workflow, controlled merge wrapper, PR #762 regression evidence, generated skill surfaces, and validation proving raw review evidence cannot satisfy approval.
-- Execution Path: self-governance/pr-semantic-review-gate/763
+- Item ID: WI-750
+- Goal: Switch Codex App host review runs to the Codex App review adapter by default when verified host proof is complete.
+- Scope: Update review adapter selection, Codex App live runner behavior, review metadata, fallback/fail-closed semantics, generated skill surfaces, and review execution documentation for #750 phase 3.
+- Execution Path: phase/codex-app-review-default/750
 - Workspace Entry: .
-- Recovery Entry: .loom/progress/WI-763.md
-- Review Entry: .loom/reviews/WI-763.json
-- Validation Entry: python3 tools/loom_check.py . && make skills-check && git diff --check
-- Closing Condition: PR gate is implemented and required by host branch protection or ruleset; this branch has a fresh authored review record for the PR head; controlled merge consumes only the authored Loom review record and required-check readback; #763 and child issues contain proof; implementation is merged; main readback proves loom-pr-merge-gate is required.
+- Recovery Entry: .loom/progress/WI-750.md
+- Review Entry: .loom/reviews/WI-750.json
+- Validation Entry: python3 -m py_compile tools/loom_flow.py tools/loom_check.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py && python3 tools/loom_check.py && make check
+- Closing Condition: PR #770 contains the #750 phase 3 implementation and docs; generated surfaces are synchronized; installer version behavior truth is bumped; py_compile, loom_check, make check, and PR gates pass; the branch is pushed with fresh authored spec and implementation review records.
 - Current Checkpoint: merge checkpoint
-- Current Stop: Local implementation, ruleset fixture support, installer package version bump, vendored .loom/bin runtime refresh, validation refresh, and default loom/default-codex review evidence are complete on branch harden-pr-semantic-review-gate.
-- Next Step: Record the refreshed authored implementation review for the vendored runtime refresh, push PR #769, prove live PR-head checks and host readback, then merge through controlled-merge.
+- Current Stop: Implementation, documentation, generated surfaces, installer version bump, and local validation are complete on branch work/750-codex-app-default-review-adapter; fresh review records are being recorded for PR #770.
+- Next Step: Commit the WI-750 fact chain, record spec and implementation review records against the reviewed heads, update PR #770 body with the Loom Work Item binding, push, and confirm PR gates.
 - Blockers: None recorded.
-- Latest Validation Summary: 2026-05-16 validation refresh for WI-763 at 8aef9fa: PYTHONPYCACHEPREFIX=/tmp/loom-pycache python3 -m py_compile .loom/bin/*.py src/skills/shared/scripts/loom_flow.py src/skills/shared/scripts/loom_check.py tools/loom_flow.py tools/loom_check.py -> OK; python3 .loom/bin/loom_init.py verify --target . -> OK; python3 .loom/bin/loom_flow.py carrier refresh --target . --dry-run -> blocks only because refreshed review is still pending for vendored runtime implementation drift, with no refresh_needed drift; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main -> OK; make skills-check -> OK; python3 tools/loom_flow.py adopt verify --target . --item WI-763 -> pass; python3 tools/loom_flow.py shadow-parity --target . -> pass; MISE_NO_CONFIG=1 LOOM_INSTALLER_TEST_PYTHON_BIN=/Users/claw/.local/share/mise/installs/python/3.12.13/bin/python3.12 python3 tools/loom_check.py . -> OK (36 surfaces); git diff --check -> OK.
-- Recovery Boundary: Branch harden-pr-semantic-review-gate; parent issue #763; active Work Item WI-763; raw review evidence remains runtime evidence only and never approval truth.
-- Current Lane: self-governance / #763 semantic review host enforcement
+- Latest Validation Summary: pending final validation refresh for WI-750 after fact-chain and installer version updates.
+- Recovery Boundary: Branch work/750-codex-app-default-review-adapter; issue #750 phase 3; PR #770; raw Codex App review evidence remains runtime evidence only and never approval truth.
+- Current Lane: #750 phase 3 / Codex App default review adapter
 
 ## Runtime Evidence
 
@@ -29,7 +29,7 @@
 
 ## Sources
 
-- Static Truth: .loom/work-items/WI-763.md
-- Dynamic Truth: .loom/progress/WI-763.md
+- Static Truth: .loom/work-items/WI-750.md
+- Dynamic Truth: .loom/progress/WI-750.md
 - Locator Truth: .loom/bootstrap/init-result.json
 - Fact Chain CLI: python3 .loom/bin/loom_init.py fact-chain --target .

--- a/.loom/work-items/WI-750.md
+++ b/.loom/work-items/WI-750.md
@@ -1,0 +1,39 @@
+# WI-750
+
+## Static Facts
+
+- Item ID: WI-750
+- Goal: Switch Codex App host review runs to the Codex App review adapter by default when verified host proof is complete.
+- Scope: Update review adapter selection, Codex App live runner behavior, review metadata, fallback/fail-closed semantics, generated skill surfaces, and review execution documentation for #750 phase 3.
+- Execution Path: phase/codex-app-review-default/750
+- Workspace Entry: .
+- Recovery Entry: .loom/progress/WI-750.md
+- Review Entry: .loom/reviews/WI-750.json
+- Validation Entry: python3 -m py_compile tools/loom_flow.py tools/loom_check.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py && python3 tools/loom_check.py && make check
+- Closing Condition: PR #770 contains the #750 phase 3 implementation and docs; generated surfaces are synchronized; installer version behavior truth is bumped; py_compile, loom_check, make check, and PR gates pass; the branch is pushed with fresh authored spec and implementation review records.
+
+## Associated Artifacts
+
+- `.loom/work-items/WI-750.md`
+- `.loom/progress/WI-750.md`
+- `.loom/reviews/WI-750.json`
+- `.loom/reviews/WI-750.spec.json`
+- `.loom/status/current.md`
+- `.loom/specs/WI-750/spec.md`
+- `.loom/specs/WI-750/plan.md`
+- `.loom/specs/WI-750/implementation-contract.md`
+- `skills/shared/scripts/loom_flow.py`
+- `src/skills/shared/scripts/loom_flow.py`
+- `skills/shared/scripts/loom_check.py`
+- `src/skills/shared/scripts/loom_check.py`
+- `docs/methodology/harness/review-execution.md`
+- `skills/shared/references/harness/review-execution.md`
+- `src/skills/shared/references/harness/review-execution.md`
+- `skills/loom-review/SKILL.md`
+- `src/skills/loom-review/SKILL.md`
+- `skills/loom-spec-review/SKILL.md`
+- `src/skills/loom-spec-review/SKILL.md`
+- `packages/loom-installer/package.json`
+- `packages/loom-installer/package-lock.json`
+- `#750`
+- `#770`

--- a/docs/methodology/harness/review-execution.md
+++ b/docs/methodology/harness/review-execution.md
@@ -19,7 +19,7 @@ Loom 把 review 分成三层：
 1. `flow review`
    - 只读基线；确认是否具备进入 formal review 的条件
 2. `review run`
-   - 调用默认 Codex-backed reviewer，产出结构化 review evidence 与 Loom-normalized findings
+   - 按宿主 proof 选择 authoritative adapter，产出结构化 review evidence 与 Loom-normalized findings
 3. `review record`
    - 把 formal review 结论写入单一 authored review record
 
@@ -45,27 +45,33 @@ Loom 把 review 分成三层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责选择安全的 authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
+默认 engine 按宿主 proof 选择：
+
+- 已验证 Codex App host context 默认选择 `loom/codex-app-review`，不启动嵌套 `codex exec`
+- `CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex`，能力来源仍是 `codex exec --output-schema`
+- 显式 `--engine-adapter` 优先级最高，继续保留 Stage 2 authoritative opt-in / fallback 调试入口
+
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 checkpoint fallback。
 
-Codex App review adapter 有两种显式入口，默认均不启用：
+Codex App review adapter 有三种入口：
 
-- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
-- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- verified host default：不传 `--engine-adapter`，但必须能证明 app-server/session locator、thread id、thread cwd、target root 与 reviewed head 绑定一致
+- explicit authoritative：显式选择 `review run --engine-adapter loom/codex-app-review`，用于调试或非默认宿主
+- shadow comparison：显式选择 `review run --shadow-engine-adapter loom/codex-app-review`
 - shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
-- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
-- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
-- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof；live app-server unavailable 时默认 fallback 到 `loom/default-codex`
+- thread cwd proof 必须等于 target root；cwd / target / reviewed head 绑定冲突或 schema proof 失败时必须 fail closed
 - authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
 - authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
+- `engine_metadata` 必须记录 selected adapter、selection source、fallback reason、thread/target binding summary、reviewed head 与 evidence locators
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
@@ -75,8 +81,8 @@ Codex App review adapter 有两种显式入口，默认均不启用：
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
-- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
+- `adapter`: `loom/default-codex` 或 verified/explicit `loom/codex-app-review`
+- `engine`: `codex` 或 verified/explicit `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/examples/new-project/.github/PULL_REQUEST_TEMPLATE.md
+++ b/examples/new-project/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,4 +19,5 @@ Validation details:
 ## Related Work
 
 - Issue:
+- Loom Work Item:
 - Spec / plan:

--- a/examples/new-project/.loom/bin/governance_surface.py
+++ b/examples/new-project/.loom/bin/governance_surface.py
@@ -350,6 +350,7 @@ REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
     "context_schema",
     "dynamic_tool_locators",
     "policy_locators",
+    "hook_locators",
     "release_targets",
 }
 DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
@@ -364,6 +365,25 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
     "invalid_declaration",
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
+HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_LOCATOR_FALLBACKS = {
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+    "handoff",
+    "merge",
+}
+HOOK_SAFETY_PATH_CONTAINMENT = {"repo_relative"}
+HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocking_decision_only"}
+HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
+HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
+HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
+HOOK_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -395,7 +415,7 @@ RELEASE_TARGET_DELIVERY_STATUSES = {
 }
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
-REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
+REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"}
 REPO_INTEROP_COLLECTION_SURFACES = {
     "admission",
     "pre_review",
@@ -403,6 +423,13 @@ REPO_INTEROP_COLLECTION_SURFACES = {
     "build",
     "merge_ready",
     "closeout",
+}
+EXTERNAL_ORCHESTRATOR_OPERATIONS = {
+    "work_item_read",
+    "workspace_attach",
+    "recovery_writeback",
+    "status_read",
+    "gate_read",
 }
 REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 GOVERNANCE_CONTROL_VERSION = "loom-governance-control/v1"
@@ -1123,6 +1150,209 @@ def validate_dynamic_tool_locator(
         else:
             blocking.append(locator_error)
     return blocking, optional
+
+
+def validate_hook_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"hook_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "lifecycle", "owner", "requirement", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    lifecycle = entry.get("lifecycle")
+    if lifecycle not in HOOK_LOCATOR_LIFECYCLES:
+        blocking.append(f"{prefix} lifecycle must be `before-run`, `after-run`, or `cleanup`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(
+            f"{prefix} owner must be one of `repo`, `repo-companion`, `host`, `host-adapter`, `platform`, `external-tool`"
+        )
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    fallback_to = entry.get("fallback_to")
+    if fallback_to not in HOOK_LOCATOR_FALLBACKS:
+        blocking.append(f"{prefix} fallback_to must point to a Loom surface or manual repair path")
+
+    forbidden_fields = sorted(
+        set(entry)
+        & {
+            "runtime_state",
+            "execution_result",
+            "authored_progress",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+            "current_checkpoint",
+            "current_lane",
+            "recovery_boundary",
+            "closing_condition",
+            "review_verdict",
+            "review_summary",
+            "validation_status",
+            "host_action_result",
+            "closeout_basis",
+        }
+    )
+    if forbidden_fields:
+        blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
+    safety = entry.get("safety")
+    safety_errors: list[str] = []
+    if not isinstance(safety, dict):
+        safety_errors.append(f"{prefix} missing `safety` declaration")
+    else:
+        path_containment = safety.get("path_containment")
+        truth_boundary = safety.get("truth_boundary")
+        cleanup_scope = safety.get("cleanup_scope")
+        host_trust = safety.get("host_trust")
+        permission_risk = safety.get("permission_risk")
+        if path_containment not in HOOK_SAFETY_PATH_CONTAINMENT:
+            safety_errors.append(f"{prefix} safety.path_containment must be `repo_relative`")
+        if truth_boundary not in HOOK_SAFETY_TRUTH_BOUNDARIES:
+            safety_errors.append(
+                f"{prefix} safety.truth_boundary must be `runtime_evidence_only`, `context_only`, or `blocking_decision_only`"
+            )
+        if cleanup_scope not in HOOK_SAFETY_CLEANUP_SCOPES:
+            safety_errors.append(f"{prefix} safety.cleanup_scope must be `not_applicable` or `loom_owned_only`")
+        if lifecycle == "cleanup" and cleanup_scope != "loom_owned_only":
+            safety_errors.append(f"{prefix} cleanup hooks must declare safety.cleanup_scope `loom_owned_only`")
+        if lifecycle != "cleanup" and cleanup_scope == "loom_owned_only":
+            safety_errors.append(f"{prefix} non-cleanup hooks must declare safety.cleanup_scope `not_applicable`")
+        if host_trust not in HOOK_SAFETY_HOST_TRUST:
+            safety_errors.append(f"{prefix} safety.host_trust must be `trusted`, `requires_review`, or `untrusted`")
+        elif host_trust == "untrusted":
+            safety_errors.append(f"{prefix} untrusted hook declarations are unsafe and must fail closed")
+        if permission_risk not in HOOK_SAFETY_PERMISSION_RISKS:
+            safety_errors.append(
+                f"{prefix} safety.permission_risk must be `none`, `approval_required`, `sandbox_required`, or `unknown`"
+            )
+        elif permission_risk == "unknown":
+            safety_errors.append(f"{prefix} unknown hook permission risk is unsafe and must fail closed")
+    if safety_errors:
+        if requirement in {"optional", "advisory"}:
+            optional.extend(safety_errors)
+        else:
+            blocking.extend(safety_errors)
+
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
+def empty_hook_extension_profile() -> dict[str, Any]:
+    return {
+        "schema_version": HOOK_EXTENSION_PROFILE_SCHEMA,
+        "profile_id": "orchestration-extension/hooks",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "hooks extension profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+    }
+
+
+def hook_extension_profile_payload(root: Path, hook_locators: object) -> dict[str, Any]:
+    payload = empty_hook_extension_profile()
+    if hook_locators is None:
+        return payload
+    payload.update(
+        {
+            "enabled": True,
+            "status": "present",
+            "summary": "hooks extension profile is enabled and hook declarations are readable.",
+        }
+    )
+    if not isinstance(hook_locators, list):
+        return {
+            **payload,
+            "result": "block",
+            "status": "invalid_declaration",
+            "summary": "hooks extension profile is enabled but hook_locators is not a list.",
+            "missing_inputs": ["hook_locators must be a list"],
+            "checks": [],
+        }
+
+    checks: list[dict[str, Any]] = []
+    missing_inputs: list[str] = []
+    missing_optional: list[str] = []
+    for index, entry in enumerate(hook_locators):
+        blocking, optional = validate_hook_locator(root=root, entry=entry, index=index)
+        if isinstance(entry, dict):
+            hook_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"hook-{index}"
+            lifecycle = entry.get("lifecycle") if isinstance(entry.get("lifecycle"), str) else "unknown"
+            requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+            locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+            fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "manual_repair"
+        else:
+            hook_id = f"invalid-{index}"
+            lifecycle = "unknown"
+            requirement = "required"
+            locator = ""
+            fallback_to = "manual_repair"
+        result = "block" if blocking else "warn" if optional else "pass"
+        checks.append(
+            {
+                "id": hook_id,
+                "lifecycle": lifecycle,
+                "requirement": requirement,
+                "locator": locator,
+                "result": result,
+                "summary": "hook declaration is safe for extension consumption."
+                if result == "pass"
+                else "hook declaration has profile-local warnings."
+                if result == "warn"
+                else "hook declaration is unsafe for the configured hooks extension path.",
+                "missing_inputs": blocking,
+                "missing_optional": optional,
+                "fallback_to": fallback_to if result == "block" else None,
+            }
+        )
+        missing_inputs.extend(message for message in blocking if message not in missing_inputs)
+        missing_optional.extend(message for message in optional if message not in missing_optional)
+
+    result = "block" if missing_inputs else "warn" if missing_optional else "pass"
+    summary = "hooks extension profile is enabled and hook declarations are safe."
+    if result == "warn":
+        summary = "hooks extension profile is enabled with profile-local advisory gaps."
+    if result == "block":
+        summary = "hooks extension profile is enabled and unsafe hook declarations block the configured path."
+    return {
+        **payload,
+        "result": result,
+        "summary": summary,
+        "missing_inputs": missing_inputs,
+        "missing_optional": missing_optional,
+        "checks": checks,
+    }
 
 
 def validate_policy_locator(
@@ -1873,6 +2103,33 @@ def validate_repo_interop_collection_entry(
     return missing_inputs, missing_optional
 
 
+def validate_external_orchestrator_entry(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    missing_inputs, missing_optional = validate_repo_interop_collection_entry(
+        root=root,
+        collection="external_orchestrators",
+        entry=entry,
+        index=index,
+    )
+    if not isinstance(entry, dict):
+        return missing_inputs, missing_optional
+    prefix = f"external_orchestrators[{index}]"
+    operations = entry.get("operations")
+    if not isinstance(operations, list) or not operations:
+        missing_inputs.append(f"{prefix} must include `operations` as a non-empty list")
+    else:
+        for operation_index, operation in enumerate(operations):
+            if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS:
+                missing_inputs.append(
+                    f"{prefix}.operations[{operation_index}] must be one of `work_item_read`, `workspace_attach`, `recovery_writeback`, `status_read`, `gate_read`"
+                )
+    return missing_inputs, missing_optional
+
+
 def validate_shadow_surface(
     *,
     root: Path,
@@ -1908,9 +2165,11 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
         "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "policy_locators": carrier_entry("missing", "unknown", "repo companion interface"),
+        "hook_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
+        "hook_profile": empty_hook_extension_profile(),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2100,6 +2359,17 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             )
                             missing_inputs.extend(blocking)
                             missing_optional.extend(optional)
+                hook_locators = interface_payload.get("hook_locators")
+                if hook_locators is not None:
+                    repo_interface_surface["hook_profile"] = hook_extension_profile_payload(
+                        root,
+                        hook_locators,
+                    )
+                    repo_interface_surface["hook_locators"] = carrier_entry(
+                        "present",
+                        ".loom/companion/repo-interface.json",
+                        "repo companion interface",
+                    )
                 release_targets = interface_payload.get("release_targets")
                 if release_targets is not None:
                     blocking_inputs = validate_release_targets(root=root, entry=release_targets)
@@ -2176,6 +2446,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "host_adapters": carrier_entry("missing", "unknown", "repo interop contract"),
         "repo_native_carriers": carrier_entry("missing", "unknown", "repo interop contract"),
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
+        "external_orchestrators": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2204,7 +2475,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 + ", ".join(extra_keys)
             )
 
-        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
             repo_interop_surface[key] = carrier_entry(
                 "present",
                 ".loom/companion/interop.json",
@@ -2233,6 +2504,19 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
                 blocking, optional = validate_repo_interop_collection_entry(
                     root=root,
                     collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
+                )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
+
+        external_orchestrators = interop_payload.get("external_orchestrators", [])
+        if not isinstance(external_orchestrators, list):
+            missing_inputs.append("repo interop contract must include `external_orchestrators` as a list")
+        else:
+            for index, entry in enumerate(external_orchestrators):
+                blocking, optional = validate_external_orchestrator_entry(
+                    root=root,
                     entry=entry,
                     index=index,
                 )
@@ -2269,7 +2553,7 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = (
             "repo interop contract is readable with optional locator advisories."
             if missing_optional
-            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+            else "repo interop contract is readable for host adapters, repo-native carriers, shadow parity, and external orchestrator locators."
         )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
     repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))

--- a/examples/new-project/.loom/bin/loom_check.py
+++ b/examples/new-project/.loom/bin/loom_check.py
@@ -25,8 +25,8 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
-DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
-ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 30.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 120.0
 
 TOP_LEVEL_DIRS = (
     "docs",
@@ -78,6 +78,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/external-orchestrator-interop.md",
     "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
@@ -99,6 +100,7 @@ CORE_DOCS = (
     "docs/methodology/harness/closeout-gate.md",
     "docs/methodology/harness/gate-chain.md",
     "docs/methodology/harness/controlled-merge.md",
+    "docs/methodology/harness/pr-merge-gate.md",
     "docs/methodology/harness/governance-failure-taxonomy.md",
     "docs/methodology/harness/workspace-and-purity.md",
     "docs/methodology/templates/spec-suite.md",
@@ -308,6 +310,24 @@ EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA = "loom-external-orchestrator-interop-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA = "loom-external-orchestrator-conformance-fixtures/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -559,6 +579,20 @@ def command_timeout_seconds(args: list[str], requested_timeout_seconds: float | 
     return DEFAULT_COMMAND_TIMEOUT_SECONDS
 
 
+def host_executable(name: str) -> str:
+    """Resolve a host executable while avoiding shims that depend on HOME."""
+    found = shutil.which(name)
+    if found and "/mise/shims/" not in found:
+        return found
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        if not directory or "/mise/shims" in directory:
+            continue
+        candidate = Path(directory) / name
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return found or name
+
+
 def load_command_json(
     root: Path,
     args: list[str],
@@ -737,6 +771,13 @@ payload = {{
 output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
 sys.exit(0)
+"""
+    elif mode == "fail_if_called":
+        body = """#!/usr/bin/env python3
+import sys
+
+sys.stderr.write("codex exec must not be called for explicit Codex App review adapter\\n")
+sys.exit(41)
 """
     else:
         raise ValueError(f"unknown fake codex mode: {mode}")
@@ -1232,7 +1273,14 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators", "policy_locators"):
+    for key in (
+        "companion_entry",
+        "repo_specific_requirements",
+        "specialized_gates",
+        "dynamic_tool_locators",
+        "policy_locators",
+        "hook_locators",
+    ):
         require_locator_entry(
             failures,
             category=category,
@@ -1263,6 +1311,12 @@ def require_repo_interface_payload(
         category=category,
         context=f"{context}.policy_readiness",
         payload=payload.get("policy_readiness"),
+    )
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hook_profile",
+        payload=payload.get("hook_profile"),
     )
 
 
@@ -1423,6 +1477,126 @@ def require_policy_readiness_payload(
         failures.append(Failure(category, f"{context} missing_inputs must be a list"))
 
 
+def require_hook_profile_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("profile_id") != "orchestration-extension/hooks":
+        failures.append(Failure(category, f"{context} profile_id must be `orchestration-extension/hooks`"))
+    if not isinstance(payload.get("enabled"), bool):
+        failures.append(Failure(category, f"{context} enabled must be a boolean"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if payload.get("status") not in {
+        "not_applicable",
+        "present",
+        "invalid_declaration",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} status is outside the stable hooks extension vocabulary"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    for field in ("missing_inputs", "missing_optional", "checks"):
+        if not isinstance(payload.get(field), list):
+            failures.append(Failure(category, f"{context}.{field} must be a list"))
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context}.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "lifecycle", "requirement", "result", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context}.checks[{index}] missing `{field}`"))
+        if not isinstance(check.get("locator"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] locator must be a string"))
+        if check.get("lifecycle") not in {"before-run", "after-run", "cleanup", "unknown"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] lifecycle is outside the stable vocabulary"))
+        if check.get("requirement") not in {"required", "optional", "advisory"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] requirement must be `required`, `optional`, or `advisory`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] result must stay within `pass | warn | block`"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_inputs must be a list"))
+        if not isinstance(check.get("missing_optional"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
+        if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
+
+
+def require_external_orchestrator_conformance_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "external-orchestrator-interop":
+        failures.append(Failure(category, f"{context} must report `operation: external-orchestrator-interop`"))
+    if payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within pass/warn/block"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include summary"))
+    if payload.get("fallback_to") not in {None, "live-smoke-config-repair", "live-smoke-retry-or-record-unavailable"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay profile-local"))
+    for field in ("runtime_state", "target", "profile_check", "core_profile", "external_orchestrator"):
+        if not isinstance(payload.get(field), dict):
+            failures.append(Failure(category, f"{context} must include `{field}` object"))
+    if not isinstance(payload.get("command_plan"), list) or not payload.get("command_plan"):
+        failures.append(Failure(category, f"{context} must include command_plan"))
+    if not isinstance(payload.get("reports"), list):
+        failures.append(Failure(category, f"{context} must include reports"))
+    conformance = payload.get("external_orchestrator")
+    if isinstance(conformance, dict):
+        if conformance.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, f"{context}.external_orchestrator must use conformance schema"))
+        if conformance.get("profile_id") != "orchestration-extension/external-orchestrator":
+            failures.append(Failure(category, f"{context}.external_orchestrator profile_id must be external-orchestrator"))
+        if conformance.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.external_orchestrator result must stay stable"))
+        if conformance.get("status") not in {
+            "not_applicable",
+            "present",
+            "runtime-blocked",
+            "target-unavailable",
+            "missing-target",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context}.external_orchestrator status is outside the stable vocabulary"))
+        for field in ("missing_inputs", "missing_optional", "checks"):
+            if not isinstance(conformance.get(field), list):
+                failures.append(Failure(category, f"{context}.external_orchestrator.{field} must be a list"))
+        non_goals = conformance.get("non_goals")
+        if not isinstance(non_goals, dict):
+            failures.append(Failure(category, f"{context}.external_orchestrator must include non_goals"))
+        else:
+            for key in ("daemon", "scheduler_state_machine", "tracker_polling_product", "second_status_surface", "host_lifecycle_ownership"):
+                if non_goals.get(key) is not False:
+                    failures.append(Failure(category, f"{context}.external_orchestrator non_goal `{key}` must remain false"))
+    core_profile = payload.get("core_profile")
+    if isinstance(core_profile, dict) and core_profile.get("result") != "pass":
+        failures.append(Failure(category, f"{context}.core_profile.result must remain pass"))
+
+
 def require_repo_interop_payload(
     failures: list[Failure],
     *,
@@ -1442,7 +1616,7 @@ def require_repo_interop_payload(
         payload=payload.get("contract"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces", "external_orchestrators"):
         require_locator_entry(
             failures,
             category=category,
@@ -2244,6 +2418,209 @@ def require_dynamic_tool_live_availability_payload(
     )
 
 
+def require_hook_envelope_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hook-envelope":
+        failures.append(Failure(category, f"{context} must report `operation: hook-envelope`"))
+    if payload.get("schema_version") != "loom-hook-envelope-check/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-hook-envelope-check/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hook envelope check contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hook-envelope":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hook-envelope`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    hook_envelope = payload.get("hook_envelope")
+    if not isinstance(hook_envelope, dict):
+        failures.append(Failure(category, f"{context} must include `hook_envelope`"))
+        return
+    if hook_envelope.get("availability") not in {
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+        "missing-envelope",
+        "invalid-declaration",
+    }:
+        failures.append(Failure(category, f"{context} hook_envelope.availability is outside the stable vocabulary"))
+    if hook_envelope.get("requirement") not in {"required", "optional", "advisory"}:
+        failures.append(Failure(category, f"{context} hook_envelope.requirement must be `required`, `optional`, or `advisory`"))
+    checks = hook_envelope.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} hook_envelope.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "requirement", "locator", "result", "classification", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "invalid_envelope",
+            "missing_required_input",
+            "unsupported",
+            "not_applicable",
+            "permission_unavailable",
+            "unsafe",
+            "host_mapping_failed",
+        }:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
+
+
+def require_hooks_extension_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hooks-extension":
+        failures.append(Failure(category, f"{context} must report `operation: hooks-extension`"))
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hooks extension contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hooks-extension":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hooks-extension`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    core_profile = payload.get("core_profile")
+    if not isinstance(core_profile, dict):
+        failures.append(Failure(category, f"{context} must include `core_profile`"))
+    else:
+        if core_profile.get("id") != "orchestration-core":
+            failures.append(Failure(category, f"{context} core_profile.id must be `orchestration-core`"))
+        if core_profile.get("hook_enforcement") != "not_applicable":
+            failures.append(Failure(category, f"{context} core_profile.hook_enforcement must be `not_applicable`"))
+        if core_profile.get("result") != "pass":
+            failures.append(Failure(category, f"{context} core_profile.result must remain `pass`"))
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hooks_extension",
+        payload=payload.get("hooks_extension"),
+    )
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -2650,10 +3027,12 @@ def require_review_run_payload(
     engine = payload.get("engine")
     if not isinstance(engine, dict):
         return
-    if engine.get("engine") != "codex":
-        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
-    if engine.get("adapter") != "loom/default-codex":
-        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    engine_adapter = engine.get("adapter")
+    if engine_adapter not in {"loom/default-codex", "loom/codex-app-review"}:
+        failures.append(Failure(category, f"{context} adapter must be a supported authoritative review adapter"))
+    expected_engine = "codex-app-review" if engine_adapter == "loom/codex-app-review" else "codex"
+    if engine.get("engine") != expected_engine:
+        failures.append(Failure(category, f"{context} engine must match the selected authoritative adapter"))
     profile = engine.get("profile")
     if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
         pass
@@ -2662,8 +3041,8 @@ def require_review_run_payload(
     else:
         if profile.get("schema_version") != "loom-review-engine-profile/v1":
             failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
-        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
-            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("adapter") != engine_adapter or profile.get("engine") != expected_engine:
+            failures.append(Failure(category, f"{context} engine profile must bind the selected adapter explicitly"))
         if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
             failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
         for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
@@ -2671,8 +3050,9 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} engine profile must include non-empty `{key}`"))
         if profile.get("reasoning_effort") not in {"low", "medium", "high", "xhigh"}:
             failures.append(Failure(category, f"{context} engine profile reasoning effort must stay within the stable vocabulary"))
-        if not isinstance(profile.get("timeout_seconds"), int) or profile.get("timeout_seconds") <= 0:
-            failures.append(Failure(category, f"{context} engine profile must include a positive `timeout_seconds`"))
+        timeout_seconds = profile.get("timeout_seconds")
+        if timeout_seconds is not None and (not isinstance(timeout_seconds, int) or timeout_seconds <= 0):
+            failures.append(Failure(category, f"{context} engine profile timeout must be null or a positive integer"))
         if "override" in profile:
             override = profile.get("override")
             if not isinstance(override, dict):
@@ -2722,8 +3102,43 @@ def require_review_run_payload(
                 failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
-            if review_record_input.get("reviewer") != "loom/default-codex":
-                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
+            if review_record_input.get("reviewer") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input reviewer must match the selected adapter"))
+            if review_record_input.get("engine_adapter") != engine_adapter:
+                failures.append(Failure(category, f"{context} review_record_input engine_adapter must match the selected adapter"))
+    shadow_engine = payload.get("shadow_engine")
+    if shadow_engine is not None:
+        if not isinstance(shadow_engine, dict):
+            failures.append(Failure(category, f"{context} shadow_engine must be an object when present"))
+        else:
+            if shadow_engine.get("adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} shadow_engine adapter must stay shadow-only `loom/codex-app-review`"))
+            if shadow_engine.get("result") not in {"pass", "block", "unavailable"}:
+                failures.append(Failure(category, f"{context} shadow_engine result must stay within the stable shadow contract"))
+            if shadow_engine.get("authoritative") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must declare authoritative=false"))
+            if shadow_engine.get("blocking") is not False:
+                failures.append(Failure(category, f"{context} shadow_engine must not block review or merge-ready"))
+            evidence = shadow_engine.get("evidence")
+            if not isinstance(evidence, dict):
+                failures.append(Failure(category, f"{context} shadow_engine must include runtime evidence locators"))
+            else:
+                for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    if not isinstance(evidence.get(key), str) or not evidence.get(key):
+                        failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
+    engine_metadata = payload.get("engine_metadata")
+    if engine_adapter == "loom/codex-app-review" and engine.get("result") == "pass":
+        if not isinstance(engine_metadata, dict):
+            failures.append(Failure(category, f"{context} app review pass must expose `engine_metadata`"))
+        else:
+            for key in ("selected_adapter", "selection_source", "app_server", "thread_id", "thread_cwd", "raw_result", "normalized_findings", "context_pack", "reviewed_head"):
+                value = engine_metadata.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} app review metadata must include non-empty `{key}`"))
+            if engine_metadata.get("selected_adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} app review metadata must bind the selected adapter"))
+            if "normalized review_record_input only" not in str(engine_metadata.get("authority_boundary", "")):
+                failures.append(Failure(category, f"{context} app review metadata must keep raw App output outside merge-ready truth"))
 
 
 def require_runtime_state_payload(
@@ -3785,6 +4200,13 @@ def check_root_self_plugin_install(root: Path) -> list[Failure]:
     if not package_json.exists():
         failures.append(Failure("root-self-plugin", "installer package must exist for downstream plugin verification"))
         return failures
+    npm_bin = host_executable("npm")
+    node_bin = host_executable("node")
+    python_bin = (
+        os.environ.get("LOOM_INSTALLER_PYTHON_BIN")
+        or os.environ.get("LOOM_INSTALLER_TEST_PYTHON_BIN")
+        or host_executable("python3")
+    )
     with tempfile.TemporaryDirectory(prefix="loom-root-self-plugin-") as tmp:
         tmp_root = Path(tmp)
         target = tmp_root / "target"
@@ -3795,13 +4217,22 @@ def check_root_self_plugin_install(root: Path) -> list[Failure]:
             "HOME": str(home),
             "CODEX_HOME": str(home / ".codex"),
             "LOOM_INSTALLER_BUILD_TIMESTAMP": "2026-01-01T00:00:00.000Z",
+            "LOOM_INSTALLER_PYTHON_BIN": python_bin,
         }
+        clean_path_entries = [
+            entry
+            for entry in os.environ.get("PATH", "").split(os.pathsep)
+            if entry and "/mise/shims" not in entry
+        ]
+        env["PATH"] = os.pathsep.join(
+            [str(Path(python_bin).parent), str(Path(node_bin).parent), str(Path(npm_bin).parent), *clean_path_entries]
+        )
         commands: list[tuple[str, list[str], Path]] = []
         if not (package_root / "node_modules/.bin/tsc").exists():
             commands.append(
                 (
                     "install self-plugin build dependencies",
-                    ["npm", "ci", "--prefix", str(package_root)],
+                    [npm_bin, "ci", "--prefix", str(package_root)],
                     root,
                 )
             )
@@ -3809,13 +4240,13 @@ def check_root_self_plugin_install(root: Path) -> list[Failure]:
             (
                 (
                     "build downstream plugin installer",
-                    ["npm", "--prefix", str(package_root), "run", "build"],
+                    [npm_bin, "--prefix", str(package_root), "run", "build"],
                     root,
                 ),
                 (
                     "install downstream plugin payload",
                     [
-                        "node",
+                        node_bin,
                         str(cli_entry),
                         "add",
                         "plugin",
@@ -4374,6 +4805,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 classifications = governance_status.get("classifications")
                 if not isinstance(classifications, list):
                     failures.append(Failure("daily-execution-cli", "`loom_status` governance_status must include classifications"))
+            external_orchestrator = payload.get("external_orchestrator")
+            if not isinstance(external_orchestrator, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `external_orchestrator` consumer view"))
+            else:
+                if external_orchestrator.get("schema_version") != "loom-governance-status/v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse governance status schema v2"))
+                if external_orchestrator.get("view") != "external_orchestrator_consumer":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator view must be consumer-only"))
+                if external_orchestrator.get("result") not in {"pass", "block"}:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator result must be `pass` or `block`"))
+                if external_orchestrator.get("allowed_operations") != ["status_read", "gate_read"]:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must expose only read operations"))
+                if not isinstance(external_orchestrator.get("gate_chain"), list):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must reuse gate_chain"))
+                source_policy = external_orchestrator.get("source_policy")
+                if not isinstance(source_policy, dict):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must include source_policy"))
+                elif source_policy.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator fallback must point to Loom checkpoint"))
+                elif source_policy.get("status_source") != "derived_from_status_control_plane_v2":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read status from status control plane v2"))
+                elif source_policy.get("gate_source") != "derived_from_governance_gate_chain":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must read gates from the governance gate chain"))
+                external_provenance = external_orchestrator.get("provenance")
+                if not (
+                    isinstance(external_provenance, dict)
+                    or (isinstance(external_provenance, list) and external_provenance)
+                ):
+                    failures.append(Failure("daily-execution-cli", "`loom_status` external_orchestrator must carry provenance"))
             closeout = payload.get("closeout")
             if not isinstance(closeout, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `closeout`"))
@@ -5189,7 +5649,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         review_target = Path(tmp) / "new-project"
         fake_bin = Path(tmp) / "bin"
         fake_bin.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
         def prepare_review_target(target: Path, label: str) -> bool:
             shutil.copytree(source_snapshot, target)
@@ -5278,7 +5738,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
 
         prepare_review_target(review_target, "review run positive chain")
         write_fake_codex(fake_bin / "codex", mode="success")
-        success_env = prepend_path_env(fake_bin)
+        success_env = prepend_path_env(fake_bin, {"CI": "", "CODEX_CI": ""})
 
         payload, error = load_command_json(
             root,
@@ -5305,6 +5765,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex" or engine.get("adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep the default codex exec adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex" or review_record_input.get("reviewer") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must keep default review_record_input adapter"))
                 evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
                 context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
                 prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
@@ -5332,6 +5798,473 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        shadow_target = Path(tmp) / "review-run-shadow"
+        prepare_review_target(shadow_target, "review run shadow adapter")
+        shadow_raw = shadow_target / ".loom/runtime/tmp/codex-app-review-raw.json"
+        shadow_raw.parent.mkdir(parents=True, exist_ok=True)
+        shadow_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "fallback",
+                    "summary": "Codex App reviewer produced shadow-only findings.",
+                    "findings": [
+                        {
+                            "id": "shadow-warn-1",
+                            "summary": "Codex App shadow review noted a comparison-only issue.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "deferred",
+                                "summary": "Shadow evidence must not author the formal review record.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+                "--shadow-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-raw.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow adapter",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/default-codex":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must not replace default review_record_input engine adapter"))
+                shadow_engine = payload.get("shadow_engine") if isinstance(payload.get("shadow_engine"), dict) else {}
+                if shadow_engine.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must pass when raw review evidence is provided"))
+                evidence = shadow_engine.get("evidence") if isinstance(shadow_engine.get("evidence"), dict) else {}
+                for key in ("raw_review", "normalized_findings", "metadata", "parity_diff"):
+                    value = evidence.get(key)
+                    if not isinstance(value, str) or not (shadow_target / value).exists():
+                        failures.append(Failure("daily-execution-cli", f"`review run` shadow adapter must write {key} evidence"))
+                if shadow_engine.get("authoritative") is not False or shadow_engine.get("blocking") is not False:
+                    failures.append(Failure("daily-execution-cli", "`review run` shadow adapter must stay non-authoritative and non-blocking"))
+
+        shadow_unavailable_target = Path(tmp) / "review-run-shadow-unavailable"
+        prepare_review_target(shadow_unavailable_target, "review run shadow unavailable")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(shadow_unavailable_target),
+                "--item",
+                "INIT-0001",
+                "--shadow-engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` shadow unavailable failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` shadow unavailable",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            shadow_engine = payload.get("shadow_engine") if isinstance(payload, dict) and isinstance(payload.get("shadow_engine"), dict) else {}
+            if shadow_engine.get("result") != "unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must not block the default review path"))
+            review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
+            if review_record_input.get("engine_adapter") != "loom/default-codex":
+                failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_default_target = Path(tmp) / "review-run-codex-app-default"
+        prepare_review_target(app_default_target, "review run Codex App host default")
+        app_default_raw = app_default_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_default_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_default_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App default reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-default-warn-1",
+                            "summary": "Codex App default review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_default_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-default-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-default-proof",
+                "--codex-app-review-cwd",
+                str(app_default_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App host default failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App host default",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("adapter") != "loom/codex-app-review" or engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must select the app adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review" or review_record_input.get("reviewer") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must author app adapter review_record_input"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("selection_source") != "codex-app-host-default" or metadata.get("thread_id") != "thread-stage3-default-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must expose selected adapter and thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_default_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored default app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume default Codex App raw evidence before review record is authored"))
+
+        app_ci_fallback_target = Path(tmp) / "review-run-codex-app-ci-fallback"
+        prepare_review_target(app_ci_fallback_target, "review run Codex App CI fallback")
+        app_ci_raw = app_ci_fallback_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_ci_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_ci_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_ci_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-ci-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-ci-proof",
+                "--codex-app-review-cwd",
+                str(app_ci_fallback_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=prepend_path_env(fake_bin, {"CODEX_CI": "1"}),
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App CI fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App CI fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "ci-or-codex-ci":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App CI fallback must keep the default codex exec adapter"))
+
+        app_unavailable_fallback_target = Path(tmp) / "review-run-codex-app-unavailable-fallback"
+        prepare_review_target(app_unavailable_fallback_target, "review run Codex App unavailable fallback")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_unavailable_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                f"unix://{tmp}/missing-codex-app.sock",
+                "--codex-app-review-thread-id",
+                "thread-stage3-missing-endpoint",
+                "--codex-app-review-cwd",
+                str(app_unavailable_fallback_target),
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App unavailable fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App unavailable fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "app-server-unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App unavailable fallback must record default adapter fallback"))
+
+        app_conflict_target = Path(tmp) / "review-run-codex-app-proof-conflict"
+        prepare_review_target(app_conflict_target, "review run Codex App proof conflict")
+        app_conflict_raw = app_conflict_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_conflict_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_conflict_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_conflict_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-conflict-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-conflict-proof",
+                "--codex-app-review-cwd",
+                str(Path(tmp) / "different-cwd"),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App proof conflict failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must fail closed"))
+        else:
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            if engine.get("adapter") != "loom/codex-app-review" or engine.get("failure_reason") != "runtime_conflict":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not fallback to default codex"))
+            if "does not match target root" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must expose cwd mismatch"))
+            if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not emit review_record_input"))
+
+        app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
+        prepare_review_target(app_authoritative_target, "review run Codex App authoritative")
+        app_raw = app_authoritative_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App authoritative reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-warn-1",
+                            "summary": "Codex App authoritative review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_authoritative_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_authoritative_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App authoritative failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App authoritative",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must author app adapter review_record_input"))
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must not call codex exec"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("thread_id") != "thread-stage2-live-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App authoritative must expose live thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_authoritative_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume raw Codex App authoritative evidence before review record is authored"))
+
+        app_missing_target = Path(tmp) / "review-run-codex-app-missing-proof"
+        prepare_review_target(app_missing_target, "review run Codex App missing proof")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_missing_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App missing proof failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App missing proof must fail closed"))
+
+        app_invalid_target = Path(tmp) / "review-run-codex-app-invalid-raw"
+        prepare_review_target(app_invalid_target, "review run Codex App invalid raw")
+        invalid_raw = app_invalid_target / ".loom/runtime/tmp/codex-app-review-invalid.txt"
+        invalid_raw.parent.mkdir(parents=True, exist_ok=True)
+        invalid_raw.write_text("plain review text is not authoritative schema\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_invalid_target),
+                "--item",
+                "INIT-0001",
+                "--engine-adapter",
+                "loom/codex-app-review",
+                "--codex-app-review-app-server",
+                "stdio://stage2-live-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage2-live-proof",
+                "--codex-app-review-cwd",
+                str(app_invalid_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-invalid.txt",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App invalid raw failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App invalid raw must fail closed on schema drift"))
 
         repeated_target = Path(tmp) / "repeated-blocker-context"
         prepare_review_target(repeated_target, "review run repeated blocker context")
@@ -6289,7 +7222,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             write_fake_codex(fake_bin / "codex", mode="success")
             installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
-            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__", ".agents"))
 
             def prepare_target(target: Path) -> tuple[str | None, list[str]]:
                 errors: list[str] = []
@@ -6867,6 +7800,321 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         detail = git_commit.stderr.strip() or git_commit.stdout.strip() or "git commit failed"
                         failures.append(Failure("daily-execution-cli", f"`installed pre-merge carrier commit` failed: {detail}"))
 
+                def current_head(target: Path) -> str:
+                    result = run_command(root, ["git", "rev-parse", "HEAD"], cwd=target)
+                    return result.stdout.strip()
+
+                def write_json_fixture(target: Path, relative: str, payload: object) -> str:
+                    path = target / relative
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+                    return relative
+
+                def pr_gate_fixture(target: Path, *, number: int = 1) -> str:
+                    return write_json_fixture(
+                        target,
+                        ".loom/tmp/pr-gate/pr.json",
+                        {
+                            "number": number,
+                            "state": "OPEN",
+                            "isDraft": False,
+                            "headRefName": "feature/pr-gate",
+                            "baseRefName": "main",
+                            "headRefOid": current_head(target),
+                            "body": "## Related Work\n\n- Loom Work Item: INIT-0001\n",
+                            "url": f"https://github.example/owner/repo/pull/{number}",
+                        },
+                    )
+
+                pr_fixture = pr_gate_fixture(positive_target)
+                pr_gate_payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                        "pr-gate",
+                        "check",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                        "--pr",
+                        "1",
+                        "--pr-payload-file",
+                        pr_fixture,
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed pr-gate` positive failed: {error}"))
+                elif pr_gate_payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed pr-gate` must pass for fresh authored review approval"))
+                else:
+                    if pr_gate_payload.get("schema_version") != "loom-pr-merge-gate/v1":
+                        failures.append(Failure("daily-execution-cli", "`installed pr-gate` must expose the stable schema"))
+                    approval_boundary = pr_gate_payload.get("approval_boundary")
+                    if not isinstance(approval_boundary, dict) or approval_boundary.get("raw_review_evidence_satisfies_approval") is not False:
+                        failures.append(Failure("daily-execution-cli", "`installed pr-gate` must reject raw review evidence as approval truth"))
+                    review_approval = pr_gate_payload.get("review_approval")
+                    if not isinstance(review_approval, dict) or review_approval.get("decision") != "allow":
+                        failures.append(Failure("daily-execution-cli", "`installed pr-gate` must read the authored allow review record"))
+
+                protection_fixture = write_json_fixture(
+                    positive_target,
+                    ".loom/tmp/pr-gate/branch-protection.json",
+                    {
+                        "required_status_checks": {
+                            "contexts": ["py-compile", "loom-check", "loom-pr-merge-gate"],
+                        },
+                    },
+                )
+                status_fixture = write_json_fixture(
+                    positive_target,
+                    ".loom/tmp/pr-gate/status-checks.json",
+                    {
+                        "statusCheckRollup": [
+                            {"name": "py-compile", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                            {"name": "loom-check", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                            {"name": "loom-pr-merge-gate", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                        ],
+                    },
+                )
+                controlled_payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                        "controlled-merge",
+                        "check",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                        "--pr",
+                        "1",
+                        "--pr-payload-file",
+                        pr_fixture,
+                        "--branch-protection-file",
+                        protection_fixture,
+                        "--status-checks-file",
+                        status_fixture,
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed controlled-merge` positive failed: {error}"))
+                elif controlled_payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed controlled-merge` check must pass when pr-gate and required checks pass"))
+                else:
+                    host_enforcement = controlled_payload.get("host_enforcement")
+                    merge = controlled_payload.get("merge")
+                    if not isinstance(host_enforcement, dict) or host_enforcement.get("required") is not True:
+                        failures.append(Failure("daily-execution-cli", "`installed controlled-merge` must prove loom-pr-merge-gate is required"))
+                    if not isinstance(merge, dict) or merge.get("attempted") is not False or merge.get("dry_run") is not True:
+                        failures.append(Failure("daily-execution-cli", "`installed controlled-merge check` must not call gh pr merge"))
+
+                missing_gate_protection = write_json_fixture(
+                    positive_target,
+                    ".loom/tmp/pr-gate/branch-protection-missing-pr-gate.json",
+                    {
+                        "required_status_checks": {
+                            "contexts": ["py-compile", "loom-check"],
+                        },
+                    },
+                )
+                controlled_missing_payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                        "controlled-merge",
+                        "check",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                        "--pr",
+                        "1",
+                        "--pr-payload-file",
+                        pr_fixture,
+                        "--branch-protection-file",
+                        missing_gate_protection,
+                        "--status-checks-file",
+                        status_fixture,
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed controlled-merge` missing required gate failed: {error}"))
+                elif controlled_missing_payload.get("result") != "block":
+                    failures.append(Failure("daily-execution-cli", "`installed controlled-merge` must block when loom-pr-merge-gate is not required"))
+
+                ruleset_fixture = write_json_fixture(
+                    positive_target,
+                    ".loom/tmp/pr-gate/branch-ruleset.json",
+                    [
+                        {
+                            "type": "required_status_checks",
+                            "parameters": {
+                                "required_status_checks": [
+                                    {"context": "loom-pr-merge-gate"},
+                                ],
+                            },
+                        },
+                    ],
+                )
+                controlled_ruleset_payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                        "controlled-merge",
+                        "check",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                        "--pr",
+                        "1",
+                        "--pr-payload-file",
+                        pr_fixture,
+                        "--branch-protection-file",
+                        missing_gate_protection,
+                        "--ruleset-file",
+                        ruleset_fixture,
+                        "--status-checks-file",
+                        status_fixture,
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed controlled-merge` ruleset required gate failed: {error}"))
+                elif controlled_ruleset_payload.get("result") != "pass":
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`installed controlled-merge` must pass when an active ruleset requires "
+                            f"loom-pr-merge-gate; got result={controlled_ruleset_payload.get('result')} "
+                            f"missing={controlled_ruleset_payload.get('missing_inputs')} "
+                            f"host_enforcement={controlled_ruleset_payload.get('host_enforcement')}",
+                        )
+                    )
+                else:
+                    host_enforcement = controlled_ruleset_payload.get("host_enforcement")
+                    if not isinstance(host_enforcement, dict) or "loom-pr-merge-gate" not in host_enforcement.get("ruleset_required_contexts", []):
+                        failures.append(Failure("daily-execution-cli", "`installed controlled-merge` must expose ruleset required contexts"))
+
+                missing_review_target = tmp_root / "pr-gate-missing-review"
+                shutil.copytree(positive_target, missing_review_target)
+                review_path = missing_review_target / ".loom/reviews/INIT-0001.json"
+                if review_path.exists():
+                    review_path.unlink()
+                git_add = run_command(root, ["git", "add", "-u", ".loom/reviews/INIT-0001.json"], cwd=missing_review_target)
+                git_commit = run_command(root, ["git", "commit", "-m", "remove authored review for pr gate fixture"], cwd=missing_review_target)
+                if git_add.returncode != 0 or git_commit.returncode != 0:
+                    failures.append(Failure("daily-execution-cli", "`installed pr-gate` missing review fixture setup failed"))
+                else:
+                    missing_pr_fixture = pr_gate_fixture(missing_review_target, number=2)
+                    missing_review_payload, error = load_command_json(
+                        root,
+                        [
+                            "python3",
+                            str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                            "pr-gate",
+                            "check",
+                            "--target",
+                            str(missing_review_target),
+                            "--item",
+                            "INIT-0001",
+                            "--pr",
+                            "2",
+                            "--pr-payload-file",
+                            missing_pr_fixture,
+                        ],
+                    )
+                    taxonomy = missing_review_payload.get("failure_taxonomy") if isinstance(missing_review_payload, dict) else []
+                    if error:
+                        failures.append(Failure("daily-execution-cli", f"`installed pr-gate` missing review failed: {error}"))
+                    elif missing_review_payload.get("result") != "block" or "review_missing" not in taxonomy:
+                        failures.append(Failure("daily-execution-cli", "`installed pr-gate` must block when authored review is missing"))
+
+                raw_only_target = tmp_root / "pr-gate-raw-only"
+                shutil.copytree(positive_target, raw_only_target)
+                raw_review_path = raw_only_target / ".loom/reviews/INIT-0001.json"
+                if raw_review_path.exists():
+                    raw_review_path.unlink()
+                write_json_fixture(
+                    raw_only_target,
+                    ".loom/runtime/review/INIT-0001/raw-only-head/engine-result.json",
+                    {"decision": "allow", "summary": "Raw evidence must not satisfy the PR gate.", "findings": []},
+                )
+                git_add = run_command(root, ["git", "add", "-f", "-A", ".loom/reviews/INIT-0001.json", ".loom/runtime/review"], cwd=raw_only_target)
+                git_commit = run_command(root, ["git", "commit", "-m", "leave only raw review evidence for pr gate fixture"], cwd=raw_only_target)
+                if git_add.returncode != 0 or git_commit.returncode != 0:
+                    detail = git_add.stderr.strip() or git_add.stdout.strip() or git_commit.stderr.strip() or git_commit.stdout.strip() or "git fixture setup failed"
+                    failures.append(Failure("daily-execution-cli", f"`installed pr-gate` raw evidence fixture setup failed: {detail}"))
+                else:
+                    raw_pr_fixture = pr_gate_fixture(raw_only_target, number=3)
+                    raw_only_payload, error = load_command_json(
+                        root,
+                        [
+                            "python3",
+                            str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                            "pr-gate",
+                            "check",
+                            "--target",
+                            str(raw_only_target),
+                            "--item",
+                            "INIT-0001",
+                            "--pr",
+                            "3",
+                            "--pr-payload-file",
+                            raw_pr_fixture,
+                        ],
+                    )
+                    taxonomy = raw_only_payload.get("failure_taxonomy") if isinstance(raw_only_payload, dict) else []
+                    if error:
+                        failures.append(Failure("daily-execution-cli", f"`installed pr-gate` raw evidence bypass failed: {error}"))
+                    elif raw_only_payload.get("result") != "block" or "raw_evidence_bypass" not in taxonomy:
+                        failures.append(Failure("daily-execution-cli", "`installed pr-gate` must block raw-evidence-only approval bypass"))
+
+                block_decision_target = tmp_root / "pr-gate-block-decision"
+                shutil.copytree(positive_target, block_decision_target)
+                block_review_path = block_decision_target / ".loom/reviews/INIT-0001.json"
+                try:
+                    block_review = json.loads(block_review_path.read_text(encoding="utf-8"))
+                except (OSError, json.JSONDecodeError):
+                    block_review = {}
+                if isinstance(block_review, dict):
+                    block_review["decision"] = "block"
+                    block_review["summary"] = "Fixture review blocks merge."
+                    block_review_path.write_text(json.dumps(block_review, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+                git_add = run_command(root, ["git", "add", "-f", ".loom/reviews/INIT-0001.json"], cwd=block_decision_target)
+                git_commit = run_command(root, ["git", "commit", "-m", "author blocking review fixture"], cwd=block_decision_target)
+                if git_add.returncode != 0 or git_commit.returncode != 0:
+                    detail = git_add.stderr.strip() or git_add.stdout.strip() or git_commit.stderr.strip() or git_commit.stdout.strip() or "git fixture setup failed"
+                    failures.append(Failure("daily-execution-cli", f"`installed pr-gate` block decision fixture setup failed: {detail}"))
+                else:
+                    block_pr_fixture = pr_gate_fixture(block_decision_target, number=4)
+                    block_decision_payload, error = load_command_json(
+                        root,
+                        [
+                            "python3",
+                            str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                            "pr-gate",
+                            "check",
+                            "--target",
+                            str(block_decision_target),
+                            "--item",
+                            "INIT-0001",
+                            "--pr",
+                            "4",
+                            "--pr-payload-file",
+                            block_pr_fixture,
+                        ],
+                    )
+                    taxonomy = block_decision_payload.get("failure_taxonomy") if isinstance(block_decision_payload, dict) else []
+                    if error:
+                        failures.append(Failure("daily-execution-cli", f"`installed pr-gate` block decision failed: {error}"))
+                    elif block_decision_payload.get("result") != "block" or "review_not_approved" not in taxonomy:
+                        failures.append(Failure("daily-execution-cli", "`installed pr-gate` must block non-allow authored review decisions"))
+
                 payload, error = load_command_json(
                     root,
                     [
@@ -7155,6 +8403,30 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     if git_commit.returncode != 0:
                         detail = git_commit.stderr.strip() or git_commit.stdout.strip() or "git commit failed"
                         failures.append(Failure("daily-execution-cli", f"`installed merge-ready drift` commit failed: {detail}"))
+
+                stale_pr_fixture = pr_gate_fixture(positive_target, number=5)
+                stale_pr_payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                        "pr-gate",
+                        "check",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                        "--pr",
+                        "5",
+                        "--pr-payload-file",
+                        stale_pr_fixture,
+                    ],
+                )
+                taxonomy = stale_pr_payload.get("failure_taxonomy") if isinstance(stale_pr_payload, dict) else []
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed pr-gate` stale review failed: {error}"))
+                elif stale_pr_payload.get("result") != "block" or "review_stale" not in taxonomy:
+                    failures.append(Failure("daily-execution-cli", "`installed pr-gate` must block stale authored review approval"))
 
                 payload, error = load_command_json(
                     root,
@@ -7760,6 +9032,9 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             "checkpoints.md",
             "metadata-contract.md",
             "context-schema.md",
+            "hooks/before-run.md",
+            "hooks/after-run.md",
+            "hooks/cleanup.md",
             "review-instructions/spec.md",
             "review-instructions/implementation.md",
         ):
@@ -7971,6 +9246,55 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "fallback_to": "merge",
             },
         ],
+        "hook_locators": [
+            {
+                "id": "before-run-hook",
+                "summary": "Declare a lifecycle hook locator without executing it.",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "trusted",
+                    "permission_risk": "approval_required",
+                },
+            },
+            {
+                "id": "optional-after-run-hook",
+                "summary": "Declare an optional after-run hook locator.",
+                "lifecycle": "after-run",
+                "locator": ".loom/companion/hooks/missing-after-run.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "handoff",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "sandbox_required",
+                },
+            },
+            {
+                "id": "advisory-cleanup-hook",
+                "summary": "Declare an advisory cleanup hook without requiring host-native support.",
+                "lifecycle": "cleanup",
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "workspace cleanup|retire",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "loom_owned_only",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
+            },
+        ],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",
@@ -8160,6 +9484,246 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
+        invalid_hook_escape_target = base / "invalid-hook-escape"
+        shutil.copytree(example_target, invalid_hook_escape_target)
+        install_companion(
+            invalid_hook_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        hook_escape_interface_path = invalid_hook_escape_target / ".loom" / "companion" / "repo-interface.json"
+        hook_escape_payload = json.loads(hook_escape_interface_path.read_text(encoding="utf-8"))
+        hook_escape_payload["hook_locators"] = [
+            {
+                "id": "escaped-hook",
+                "summary": "Optional hook locator must still respect repository path boundaries.",
+                "lifecycle": "before-run",
+                "locator": "../outside-hook.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
+            }
+        ]
+        write_json(hook_escape_interface_path, hook_escape_payload)
+        invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
+        invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
+        invalid_hook_escape_profile = (
+            invalid_hook_escape_interface.get("hook_profile") if isinstance(invalid_hook_escape_interface, dict) else None
+        )
+        invalid_hook_escape_missing = json.dumps(
+            invalid_hook_escape_profile.get("missing_inputs", []) if isinstance(invalid_hook_escape_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_escape_profile, dict) or invalid_hook_escape_profile.get("result") != "block":
+            failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
+        elif "outside-hook.md" not in invalid_hook_escape_missing:
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in hook_profile missing_inputs"))
+
+        invalid_hook_truth_target = base / "invalid-hook-truth"
+        shutil.copytree(example_target, invalid_hook_truth_target)
+        install_companion(
+            invalid_hook_truth_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "truth-polluting-hook",
+                        "summary": "Hook declarations must not carry authored or runtime truth.",
+                        "lifecycle": "after-run",
+                        "locator": ".loom/companion/hooks/after-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "handoff",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "none",
+                        },
+                        "validation_status": "pass",
+                    }
+                ],
+            },
+        )
+        invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
+        invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
+        invalid_hook_truth_profile = (
+            invalid_hook_truth_interface.get("hook_profile") if isinstance(invalid_hook_truth_interface, dict) else None
+        )
+        invalid_hook_truth_missing = json.dumps(
+            invalid_hook_truth_profile.get("missing_inputs", []) if isinstance(invalid_hook_truth_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_truth_profile, dict) or invalid_hook_truth_profile.get("result") != "block":
+            failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
+        elif "validation_status" not in invalid_hook_truth_missing:
+            failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
+
+        required_hook_missing_target = base / "required-hook-missing"
+        shutil.copytree(example_target, required_hook_missing_target)
+        install_companion(
+            required_hook_missing_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-missing-hook",
+                        "summary": "Required hook locator must block when missing.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/missing-required.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "approval_required",
+                        },
+                    }
+                ],
+            },
+        )
+        required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
+        required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
+        required_hook_missing_profile = (
+            required_hook_missing_interface.get("hook_profile") if isinstance(required_hook_missing_interface, dict) else None
+        )
+        required_hook_missing_inputs = json.dumps(
+            required_hook_missing_profile.get("missing_inputs", []) if isinstance(required_hook_missing_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(required_hook_missing_profile, dict) or required_hook_missing_profile.get("result") != "block":
+            failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
+        elif "missing-required.md" not in required_hook_missing_inputs:
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in hook_profile missing_inputs"))
+
+        required_hook_missing_safety_target = base / "required-hook-missing-safety"
+        shutil.copytree(example_target, required_hook_missing_safety_target)
+        install_companion(
+            required_hook_missing_safety_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-no-safety-hook",
+                        "summary": "Required hook safety declaration must fail closed when absent.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
+        required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        required_hook_missing_safety_profile = (
+            required_hook_missing_safety_interface.get("hook_profile")
+            if isinstance(required_hook_missing_safety_interface, dict)
+            else None
+        )
+        if (
+            not isinstance(required_hook_missing_safety_profile, dict)
+            or required_hook_missing_safety_profile.get("result") != "block"
+        ):
+            failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
+        elif "missing `safety` declaration" not in json.dumps(
+            required_hook_missing_safety_profile.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
+
+        unsafe_hook_target = base / "unsafe-hook-safety"
+        shutil.copytree(example_target, unsafe_hook_target)
+        install_companion(
+            unsafe_hook_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "untrusted-hook",
+                        "summary": "Untrusted hook declarations must fail closed.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "untrusted",
+                            "permission_risk": "unknown",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
+        unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_profile = unsafe_hook_interface.get("hook_profile") if isinstance(unsafe_hook_interface, dict) else None
+        unsafe_hook_missing = json.dumps(
+            unsafe_hook_profile.get("missing_inputs", []) if isinstance(unsafe_hook_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(unsafe_hook_profile, dict) or unsafe_hook_profile.get("result") != "block":
+            failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
+        elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
+            failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
+
+        unsafe_cleanup_target = base / "unsafe-cleanup-scope"
+        shutil.copytree(example_target, unsafe_cleanup_target)
+        install_companion(
+            unsafe_cleanup_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "unsafe-cleanup-hook",
+                        "summary": "Cleanup hooks must be constrained to Loom-owned residue.",
+                        "lifecycle": "cleanup",
+                        "locator": ".loom/companion/hooks/cleanup.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "workspace cleanup|retire",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "requires_review",
+                            "permission_risk": "approval_required",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
+        unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
+        unsafe_cleanup_profile = unsafe_cleanup_interface.get("hook_profile") if isinstance(unsafe_cleanup_interface, dict) else None
+        if not isinstance(unsafe_cleanup_profile, dict) or unsafe_cleanup_profile.get("result") != "block":
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
+        elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
+            unsafe_cleanup_profile.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
+
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
         install_companion(
@@ -8203,6 +9767,19 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
+        present_hook_profile = present_interface.get("hook_profile") if isinstance(present_interface, dict) else None
+        present_hook_optional = json.dumps(
+            present_hook_profile.get("missing_optional", []) if isinstance(present_hook_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if "missing-after-run.md" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in hook_profile missing_optional"))
+        if "advisory-cleanup-hook" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in hook_profile missing_optional"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must not pollute core missing_inputs"))
         if isinstance(present_interface, dict):
             availability = present_interface.get("tool_availability")
             require_tool_availability_payload(
@@ -8648,6 +10225,51 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         (target / "native" / "status").mkdir(parents=True, exist_ok=True)
         for relative, payload in {
             "host/guardian-review.json": {"verdict": "allow"},
+            "host/external-orchestrator-read.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "work_item_read",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/work-items/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
+            "host/external-orchestrator-attach.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "workspace_attach",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-writeback.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "recovery_writeback",
+                "entry_kind": "work_item",
+                "source_layer": "authored_truth",
+                "source_locator": ".loom/progress/INIT-0001.md",
+                "source_binding": {"item_id": "INIT-0001"},
+                "consumed_as": "locator",
+            },
+            "host/external-orchestrator-status.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "status_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "status_schema_version": "loom-governance-status/v2"},
+                "consumed_as": "summary",
+            },
+            "host/external-orchestrator-gate.json": {
+                "schema_version": "loom-external-orchestrator-read/v1",
+                "operation": "gate_read",
+                "entry_kind": "work_item",
+                "source_layer": "derived_surface",
+                "source_locator": ".loom/status/current.md",
+                "source_binding": {"item_id": "INIT-0001", "gate_chain": "status_control_plane_v2"},
+                "consumed_as": "summary",
+            },
             "native/status/admission.json": {"result": "pass"},
             "native/status/review.json": {"decision": "allow"},
             "native/status/merge-ready.json": {"status": "pass"},
@@ -8705,6 +10327,68 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "requirement": "required",
                 "fallback_to": "manual-reconciliation",
             }
+        ],
+        "external_orchestrators": [
+            {
+                "id": "fake-external-orchestrator",
+                "summary": "Read external orchestrator retained read evidence without making it a scheduler state.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/external-orchestrator-read.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-external-orchestrator",
+                "summary": "Optional external orchestrator evidence may be unavailable.",
+                "surfaces": ["admission"],
+                "operations": ["work_item_read"],
+                "locator": "host/missing-external-orchestrator.json",
+                "owner": "external-tool",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-attach",
+                "summary": "Read workspace attach evidence without owning host lifecycle.",
+                "surfaces": ["admission"],
+                "operations": ["workspace_attach"],
+                "locator": "host/external-orchestrator-attach.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "fake-external-orchestrator-writeback",
+                "summary": "Read recovery writeback evidence without authoring status truth.",
+                "surfaces": ["build"],
+                "operations": ["recovery_writeback"],
+                "locator": "host/external-orchestrator-writeback.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "build",
+            },
+            {
+                "id": "fake-external-orchestrator-status",
+                "summary": "Read status control plane v2 without defining a second status surface.",
+                "surfaces": ["merge_ready"],
+                "operations": ["status_read"],
+                "locator": "host/external-orchestrator-status.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "current_checkpoint",
+            },
+            {
+                "id": "fake-external-orchestrator-gate",
+                "summary": "Read the Loom gate chain without authoring a gate verdict.",
+                "surfaces": ["merge_ready"],
+                "operations": ["gate_read"],
+                "locator": "host/external-orchestrator-gate.json",
+                "owner": "external-tool",
+                "requirement": "required",
+                "fallback_to": "review_gate",
+            },
         ],
         "shadow_surfaces": {
             "admission": {
@@ -8765,6 +10449,7 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                     }
                 ],
                 "repo_native_carriers": [],
+                "external_orchestrators": [],
                 "shadow_surfaces": {
                     "admission": {
                         "summary": "Compare admission parity.",
@@ -8826,10 +10511,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
         elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        elif "missing-external-orchestrator.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must stay in missing_optional"))
         if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "missing-external-orchestrator.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional external orchestrator locator gaps must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -9029,6 +10718,349 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             reports = rogue_payload.get("reports")
             if not isinstance(reports, list) or not reports or reports[0].get("result") != "unreadable":
                 failures.append(Failure("repo-interop", "`shadow-parity` rogue evidence sample must report `unreadable`"))
+
+    return failures
+
+
+def check_external_orchestrator_interop_fixture_contract(root: Path) -> list[Failure]:
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-interop-fixtures.json"
+    category = "external-orchestrator-interop"
+    failures: list[Failure] = []
+    if not fixture_path.exists():
+        return [Failure(category, "`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` is missing")]
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [Failure(category, f"external orchestrator fixture JSON is invalid: {exc}")]
+
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/external-orchestrator-interop-fixtures.json` schema_version must be `{EXTERNAL_ORCHESTRATOR_FIXTURE_SCHEMA}`",
+            )
+        )
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator fixtures must include a non-empty `fixtures` list"))
+        return failures
+
+    seen_names: set[str] = set()
+    required_names = {
+        "work-item-read-present",
+        "pr-only-entry-block",
+        "truth-poisoning-block",
+        "optional-missing-warn",
+        "workspace-attach-present",
+        "recovery-writeback-present",
+        "direct-status-write-block",
+        "status-read-present",
+        "gate-read-present",
+        "scheduler-private-fallback-block",
+    }
+    allowed_operations = {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"}
+    loom_fallbacks = {
+        "work_item",
+        "admission",
+        "binding_repair",
+        "current_checkpoint",
+        "spec_gate",
+        "build_gate",
+        "review_gate",
+        "merge_gate",
+        "merge_ready",
+        "build",
+        "review",
+        "closeout",
+    }
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if not isinstance(name, str) or not name:
+            failures.append(Failure(category, f"fixtures[{index}] must include non-empty `name`"))
+        else:
+            seen_names.add(name)
+        expect = fixture.get("expect")
+        entry = fixture.get("entry")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+        else:
+            for field in ("id", "summary", "locator", "owner", "requirement", "fallback_to"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{name or index} entry missing `{field}`"))
+            if entry.get("owner") not in governance_surface_module.DECLARED_LOCATOR_OWNERS:
+                failures.append(Failure(category, f"{name or index} owner must stay within declared locator owners"))
+            if entry.get("requirement") not in governance_surface_module.DECLARED_LOCATOR_REQUIREMENTS:
+                failures.append(Failure(category, f"{name or index} requirement must be required/optional/advisory"))
+            surfaces = entry.get("surfaces")
+            if not isinstance(surfaces, list) or not surfaces:
+                failures.append(Failure(category, f"{name or index} entry must include non-empty `surfaces`"))
+            operations = entry.get("operations")
+            if not isinstance(operations, list) or not operations:
+                failures.append(Failure(category, f"{name or index} entry must declare at least one external orchestrator operation"))
+            elif any(operation not in allowed_operations for operation in operations):
+                failures.append(Failure(category, f"{name or index} entry declares an unsupported external orchestrator operation"))
+            fallback_to = entry.get("fallback_to")
+            if (
+                isinstance(fallback_to, str)
+                and fallback_to not in loom_fallbacks
+                and (not isinstance(expect, dict) or expect.get("result") != "block")
+            ):
+                failures.append(Failure(category, f"{name or index} fallback_to must point to a Loom checkpoint or gate repair surface"))
+        payload = fixture.get("payload")
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/warn/block"))
+        if payload is not None:
+            if not isinstance(payload, dict):
+                failures.append(Failure(category, f"{name or index} payload must be an object or null"))
+            else:
+                if payload.get("operation") not in allowed_operations:
+                    failures.append(Failure(category, f"{name or index} payload operation must be a supported external orchestrator operation"))
+                if payload.get("source_layer") not in {"authored_truth", "host_control_mirror", "retained_result", "derived_surface"}:
+                    failures.append(Failure(category, f"{name or index} payload source_layer must use fact-chain vocabulary"))
+                payload_fallback = payload.get("fallback_to")
+                if (
+                    isinstance(payload_fallback, str)
+                    and payload_fallback not in loom_fallbacks
+                    and (not isinstance(expect, dict) or expect.get("result") != "block")
+                ):
+                    failures.append(Failure(category, f"{name or index} payload fallback_to must point to a Loom checkpoint or gate repair surface"))
+                forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+                if forbidden and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} forbidden fields must only appear in blocking fixtures"))
+                if payload.get("entry_kind") != "work_item" and expect.get("result") != "block":
+                    failures.append(Failure(category, f"{name or index} non-Work Item entry must block"))
+                if payload.get("entry_kind") == "implementation_pr" and expect.get("fallback_to") != "work_item":
+                    failures.append(Failure(category, f"{name or index} PR-only fixture must fallback to `work_item`"))
+                if payload.get("operation") in {"status_read", "gate_read"}:
+                    if payload.get("source_layer") != "derived_surface":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must consume the derived status surface"))
+                    if payload.get("consumed_as") != "summary":
+                        failures.append(Failure(category, f"{name or index} status/gate reads must be consumed as summary, not authored truth"))
+                    if payload.get("operation") == "status_read":
+                        status_fields = payload.get("status_fields")
+                        required_status_fields = {"result", "current_gate", "classifications", "missing_inputs", "head_binding", "gate_chain", "provenance"}
+                        if not isinstance(status_fields, list) or not required_status_fields.issubset(set(status_fields)):
+                            failures.append(Failure(category, f"{name or index} status_read fixture must reuse status control plane v2 fields"))
+                    if payload.get("operation") == "gate_read":
+                        gate_fields = payload.get("gate_fields")
+                        required_gate_fields = {"name", "result", "classification", "missing_inputs", "fallback_to"}
+                        if expect.get("result") != "block" and (not isinstance(gate_fields, list) or not required_gate_fields.issubset(set(gate_fields))):
+                            failures.append(Failure(category, f"{name or index} gate_read fixture must reuse the existing gate chain fields"))
+                if name == "scheduler-private-fallback-block" and expect.get("fallback_to") != "current_checkpoint":
+                    failures.append(Failure(category, "scheduler-private fallback fixture must fallback to `current_checkpoint`"))
+                if name == "scheduler-private-fallback-block":
+                    entry_fallback = entry.get("fallback_to") if isinstance(entry, dict) else None
+                    if entry_fallback in loom_fallbacks or payload.get("fallback_to") in loom_fallbacks:
+                        failures.append(Failure(category, "scheduler-private fallback fixture must prove a private fallback is blocked"))
+
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator fixtures missing required cases: " + ", ".join(missing)))
+
+    return failures
+
+
+def check_external_orchestrator_conformance_contract(root: Path) -> list[Failure]:
+    category = "external-orchestrator-conformance"
+    failures: list[Failure] = []
+    required_docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/external-orchestrator",
+            "loom-external-orchestrator-conformance/v1",
+            "fake external orchestrator happy/drift fixtures",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "external-orchestrator-interop",
+            "loom-external-orchestrator-conformance/v1",
+            "does not execute",
+        ],
+        "docs/evidence/external-orchestrator-release-threshold.md": [
+            "v0.12.0",
+            "loom-external-orchestrator-conformance/v1",
+            "no daemon",
+            "fake external orchestrator fixtures are sufficient",
+        ],
+    }
+    for relative, anchors in required_docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure(category, f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure(category, f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/external-orchestrator-conformance-fixtures.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"external orchestrator conformance fixtures are unreadable: {exc}"))
+        return failures
+    if fixture_payload.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA:
+        failures.append(Failure(category, f"conformance fixture schema_version must be `{EXTERNAL_ORCHESTRATOR_CONFORMANCE_FIXTURE_SCHEMA}`"))
+    fixtures = fixture_payload.get("fixtures")
+    required_names = {
+        "fake-external-orchestrator-happy",
+        "fake-external-orchestrator-truth-drift",
+        "fake-external-orchestrator-private-fallback",
+        "fake-external-orchestrator-lifecycle-drift",
+    }
+    if not isinstance(fixtures, list) or not fixtures:
+        failures.append(Failure(category, "external orchestrator conformance fixtures must include fixtures"))
+        return failures
+    seen_names: set[str] = set()
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"fixtures[{index}] must be an object"))
+            continue
+        name = fixture.get("name")
+        if isinstance(name, str):
+            seen_names.add(name)
+        entry = fixture.get("entry")
+        payload = fixture.get("payload")
+        expect = fixture.get("expect")
+        if not isinstance(entry, dict):
+            failures.append(Failure(category, f"{name or index} entry must be an object"))
+            continue
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"{name or index} payload must be an object"))
+        if not isinstance(expect, dict) or expect.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{name or index} expect.result must be pass/block"))
+        operations = entry.get("operations")
+        if not isinstance(operations, list) or not operations:
+            failures.append(Failure(category, f"{name or index} entry.operations must be non-empty"))
+        elif any(operation not in {"work_item_read", "workspace_attach", "recovery_writeback", "status_read", "gate_read"} for operation in operations):
+            failures.append(Failure(category, f"{name or index} declares unsupported operation"))
+        if name == "fake-external-orchestrator-happy" and expect.get("schema_version") != EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA:
+            failures.append(Failure(category, "happy fixture must expect conformance schema v1"))
+        if name == "fake-external-orchestrator-truth-drift" and payload is not None:
+            forbidden = sorted(EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS.intersection(payload.keys()))
+            if not forbidden or expect.get("failure") != "truth_pollution":
+                failures.append(Failure(category, "truth drift fixture must prove forbidden authored/scheduler fields block"))
+        if name == "fake-external-orchestrator-private-fallback":
+            if entry.get("fallback_to") != "scheduler_retry_queue" or expect.get("fallback_to") != "current_checkpoint":
+                failures.append(Failure(category, "private fallback fixture must block back to current_checkpoint"))
+        if name == "fake-external-orchestrator-lifecycle-drift" and payload is not None:
+            if payload.get("host_lifecycle_ownership") != "loom" or payload.get("daemon") is not True:
+                failures.append(Failure(category, "lifecycle drift fixture must prove no-daemon/no-host-lifecycle boundary"))
+    missing = sorted(required_names - seen_names)
+    if missing:
+        failures.append(Failure(category, "external orchestrator conformance fixtures missing required cases: " + ", ".join(missing)))
+
+    example_target = root / "examples/new-project"
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(example_target)],
+    )
+    if error:
+        failures.append(Failure(category, f"`external-orchestrator-interop` not_applicable sample failed: {error}"))
+    else:
+        require_external_orchestrator_conformance_payload(
+            failures,
+            category=category,
+            context="not-applicable external orchestrator conformance",
+            payload=absent_payload,
+        )
+        external_profile = absent_payload.get("external_orchestrator") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must pass"))
+        elif not isinstance(external_profile, dict) or external_profile.get("status") != "not_applicable":
+            failures.append(Failure(category, "not-applicable external orchestrator conformance must expose not_applicable status"))
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def sha256_file_local(path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def write_shadow_evidence_local(target: Path, evidence: str, value_key: str, value: str, source: str) -> None:
+        source_path = target / source
+        if not source_path.exists():
+            write_json_local(source_path, {value_key: value})
+        write_json_local(
+            target / evidence,
+            {
+                value_key: value,
+                "source_files": [source],
+                "source_sha256": {source: sha256_file_local(source_path)},
+            },
+        )
+
+    def load_or_new_interop_local(target: Path) -> dict:
+        interop_path = target / ".loom/companion/interop.json"
+        if interop_path.exists():
+            interop = load_json_file(interop_path)
+            if isinstance(interop, dict):
+                return interop
+        return {
+            "schema_version": "loom-repo-interop/v1",
+            "host_adapters": [],
+            "repo_native_carriers": [],
+            "external_orchestrators": [],
+        }
+
+    with tempfile.TemporaryDirectory(prefix="loom-external-orchestrator-conformance-") as tmp:
+        base = Path(tmp)
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        happy_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-happy"), None)
+        if isinstance(happy_fixture, dict):
+            interop = load_or_new_interop_local(present_target)
+            interop["external_orchestrators"] = [happy_fixture["entry"]]
+            write_json_local(present_target / ".loom/companion/interop.json", interop)
+            write_json_local(present_target / happy_fixture["entry"]["locator"], happy_fixture["payload"])
+            present_payload, present_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(present_target)],
+            )
+            if present_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` happy sample failed: {present_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="happy external orchestrator conformance",
+                    payload=present_payload,
+                )
+                if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                    failures.append(Failure(category, "happy external orchestrator conformance must pass"))
+
+        drift_target = base / "drift"
+        shutil.copytree(example_target, drift_target)
+        drift_fixture = next((fixture for fixture in fixtures if isinstance(fixture, dict) and fixture.get("name") == "fake-external-orchestrator-truth-drift"), None)
+        if isinstance(drift_fixture, dict):
+            interop = load_or_new_interop_local(drift_target)
+            interop["external_orchestrators"] = [drift_fixture["entry"]]
+            write_json_local(drift_target / ".loom/companion/interop.json", interop)
+            write_json_local(drift_target / drift_fixture["entry"]["locator"], drift_fixture["payload"])
+            drift_payload, drift_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "live-smoke", "external-orchestrator-interop", "--target", str(drift_target)],
+            )
+            if drift_error:
+                failures.append(Failure(category, f"`external-orchestrator-interop` drift sample failed: {drift_error}"))
+            else:
+                require_external_orchestrator_conformance_payload(
+                    failures,
+                    category=category,
+                    context="drift external orchestrator conformance",
+                    payload=drift_payload,
+                )
+                core_profile = drift_payload.get("core_profile") if isinstance(drift_payload, dict) else None
+                if not isinstance(drift_payload, dict) or drift_payload.get("result") != "block":
+                    failures.append(Failure(category, "truth drift external orchestrator conformance must block"))
+                elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                    failures.append(Failure(category, "external orchestrator conformance drift must not rewrite core profile"))
 
     return failures
 
@@ -11362,12 +13394,592 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hook_envelope_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "loom-hook-envelope/v1",
+            "context_injection",
+            "blocking_decision",
+            "runtime_evidence",
+            "permission_unavailable",
+            "host_mapping_failed",
+            "must not carry",
+        ],
+        "docs/methodology/harness/README.md": [
+            "hook-envelope-contract.md",
+            "context injection / blocking decision / runtime evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hook-envelope", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hook-envelope", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    def valid_envelope(category: str) -> dict[str, object]:
+        return {
+            "schema_version": "loom-hook-envelope/v1",
+            "hook": {
+                "id": f"{category}-hook",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+            },
+            "input": {
+                "item_locator": ".loom/items/WI-617.md",
+                "workspace_locator": ".loom/workspaces/current.json",
+                "attempt_locator": ".loom/runtime/attempts/attempt-1.json",
+                "host_adapter_mapping": {
+                    "host": "codex",
+                    "event": "PreToolUse",
+                    "adapter_result": "supported",
+                },
+            },
+            "output": {
+                "category": category,
+                "summary": f"{category} output mapped into Loom envelope.",
+                "evidence": {"mapped": True},
+            },
+        }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hook-envelope-") as tmp:
+        base = Path(tmp)
+        valid_target = base / "valid"
+        shutil.copytree(example_target, valid_target)
+        for category in ("context_injection", "blocking_decision", "runtime_evidence"):
+            locator = f".loom/companion/hooks/{category}.json"
+            write_json_local(valid_target / locator, valid_envelope(category))
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_flow.py",
+                    "live-smoke",
+                    "hook-envelope",
+                    "--target",
+                    str(valid_target),
+                    "--envelope",
+                    locator,
+                ],
+            )
+            if error:
+                failures.append(Failure("hook-envelope", f"`hook-envelope` valid {category} sample failed: {error}"))
+            else:
+                require_hook_envelope_live_check_payload(
+                    failures,
+                    category="hook-envelope",
+                    context=f"valid-{category}-hook-envelope",
+                    payload=payload,
+                )
+                if not isinstance(payload, dict) or payload.get("result") != "pass":
+                    failures.append(Failure("hook-envelope", f"valid {category} hook envelope must pass"))
+
+        missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-required.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing required sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "required missing hook envelope must block"))
+
+        optional_missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-optional.json",
+                "--requirement",
+                "optional",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing optional sample failed: {error}"))
+        elif not isinstance(optional_missing_payload, dict) or optional_missing_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "optional missing hook envelope must warn"))
+
+        invalid_category_target = base / "invalid-category"
+        shutil.copytree(example_target, invalid_category_target)
+        invalid_category = valid_envelope("runtime_evidence")
+        invalid_category["output"] = {"category": "host_raw_output", "summary": "invalid category"}
+        write_json_local(invalid_category_target / ".loom/companion/hooks/invalid-category.json", invalid_category)
+        invalid_category_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(invalid_category_target),
+                "--envelope",
+                ".loom/companion/hooks/invalid-category.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` invalid category sample failed: {error}"))
+        elif not isinstance(invalid_category_payload, dict) or invalid_category_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "invalid hook envelope category must block"))
+
+        truth_target = base / "truth-pollution"
+        shutil.copytree(example_target, truth_target)
+        truth_polluting = valid_envelope("runtime_evidence")
+        truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "truth pollution must fail",
+            "authored_progress": "done",
+        }
+        write_json_local(truth_target / ".loom/companion/hooks/truth.json", truth_polluting)
+        truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(truth_target),
+                "--envelope",
+                ".loom/companion/hooks/truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` truth pollution sample failed: {error}"))
+        elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
+
+        status_truth_target = base / "status-truth-write"
+        shutil.copytree(example_target, status_truth_target)
+        status_truth_polluting = valid_envelope("runtime_evidence")
+        status_truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "status authored field write must fail",
+            "evidence": {
+                "latest_validation_summary": "hook tried to author status truth",
+            },
+        }
+        write_json_local(status_truth_target / ".loom/companion/hooks/status-truth.json", status_truth_polluting)
+        status_truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(status_truth_target),
+                "--envelope",
+                ".loom/companion/hooks/status-truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` status authored field sample failed: {error}"))
+        elif not isinstance(status_truth_payload, dict) or status_truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope status authored field write must block"))
+
+        cleanup_target = base / "cleanup-non-loom-owned"
+        shutil.copytree(example_target, cleanup_target)
+        cleanup_intent = valid_envelope("runtime_evidence")
+        cleanup_intent["hook"]["lifecycle"] = "cleanup"
+        cleanup_intent["output"] = {
+            "category": "runtime_evidence",
+            "summary": "cleanup intent must be constrained to Loom-owned residue.",
+            "evidence": {
+                "cleanup_targets": [
+                    {
+                        "locator": "README.md",
+                        "ownership": "repo_owned",
+                    }
+                ],
+            },
+        }
+        write_json_local(cleanup_target / ".loom/companion/hooks/cleanup-non-loom-owned.json", cleanup_intent)
+        cleanup_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(cleanup_target),
+                "--envelope",
+                ".loom/companion/hooks/cleanup-non-loom-owned.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` cleanup non-Loom-owned sample failed: {error}"))
+        elif not isinstance(cleanup_payload, dict) or cleanup_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope non-Loom-owned cleanup intent must block"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        permission_envelope = valid_envelope("blocking_decision")
+        permission_envelope["failure"] = {
+            "classification": "permission_unavailable",
+            "summary": "host permission is unavailable after adapter mapping.",
+            "fallback_to": "build",
+        }
+        write_json_local(permission_target / ".loom/companion/hooks/permission.json", permission_envelope)
+        permission_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(permission_target),
+                "--envelope",
+                ".loom/companion/hooks/permission.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` permission sample failed: {error}"))
+        elif not isinstance(permission_payload, dict) or permission_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "permission_unavailable hook envelope must block when required"))
+
+        advisory_unsafe_target = base / "advisory-unsafe"
+        shutil.copytree(example_target, advisory_unsafe_target)
+        unsafe_envelope = valid_envelope("blocking_decision")
+        unsafe_envelope["failure"] = {
+            "classification": "unsafe",
+            "summary": "host mapping reported unsafe.",
+            "fallback_to": "manual_repair",
+        }
+        write_json_local(advisory_unsafe_target / ".loom/companion/hooks/unsafe.json", unsafe_envelope)
+        advisory_unsafe_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(advisory_unsafe_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe.json",
+                "--requirement",
+                "advisory",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` advisory unsafe sample failed: {error}"))
+        elif not isinstance(advisory_unsafe_payload, dict) or advisory_unsafe_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "advisory unsafe hook envelope must warn"))
+
+        host_private_target = base / "host-private-fallback"
+        shutil.copytree(example_target, host_private_target)
+        host_private = valid_envelope("blocking_decision")
+        host_private["failure"] = {
+            "classification": "unsupported",
+            "summary": "fallback must not point to host-private action.",
+            "fallback_to": "Codex SessionEnd",
+        }
+        write_json_local(host_private_target / ".loom/companion/hooks/host-private.json", host_private)
+        host_private_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(host_private_target),
+                "--envelope",
+                ".loom/companion/hooks/host-private.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
+        elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+        unsafe_mapping_target = base / "unsafe-adapter-mapping"
+        shutil.copytree(example_target, unsafe_mapping_target)
+        unsafe_mapping = valid_envelope("blocking_decision")
+        unsafe_mapping["input"]["host_adapter_mapping"]["adapter_result"] = "unsafe"
+        write_json_local(unsafe_mapping_target / ".loom/companion/hooks/unsafe-adapter.json", unsafe_mapping)
+        unsafe_mapping_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(unsafe_mapping_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe-adapter.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` unsafe adapter mapping sample failed: {error}"))
+        elif not isinstance(unsafe_mapping_payload, dict) or unsafe_mapping_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "unsafe hook adapter mapping must block when required"))
+
+    return failures
+
+
+def check_hooks_extension_profile_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/hooks",
+            "not_applicable",
+            "profile-local `warn`",
+            "core profile remains pass",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-hooks-extension-profile/v1",
+            "hooks-extension",
+            "optional/advisory",
+            "does not execute hooks",
+        ],
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "hooks-extension",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/hook-locator-contract.md": [
+            "orchestration-extension/hooks",
+            "profile-local advisory evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hooks-extension-profile", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hooks-extension-profile", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-hooks-extension-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("hooks-extension-profile", f"`hooks-extension` absent interface sample failed: {error}"))
+    else:
+        require_hooks_extension_live_check_payload(
+            failures,
+            category="hooks-extension-profile",
+            context="absent-hooks-extension",
+            payload=absent_payload,
+        )
+        hooks_extension = absent_payload.get("hooks_extension") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must pass"))
+        elif not isinstance(hooks_extension, dict) or hooks_extension.get("status") != "not_applicable":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must be not_applicable"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "hook_locators": [],
+    }
+    safe_hook = {
+        "id": "before-run-context",
+        "summary": "Read Loom context before a host run.",
+        "lifecycle": "before-run",
+        "locator": ".loom/companion/hooks/before-run.md",
+        "owner": "host-adapter",
+        "requirement": "required",
+        "fallback_to": "build",
+        "safety": {
+            "path_containment": "repo_relative",
+            "truth_boundary": "context_only",
+            "cleanup_scope": "not_applicable",
+            "host_trust": "trusted",
+            "permission_risk": "none",
+        },
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hooks-extension-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        present_interface = json.loads(json.dumps(valid_interface))
+        present_interface["hook_locators"] = [safe_hook]
+        install_companion_local(present_target, repo_interface=present_interface)
+        (present_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (present_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` present sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="present-hooks-extension",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "safe hooks extension sample must pass"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_hook = json.loads(json.dumps(safe_hook))
+        optional_hook["id"] = "optional-after-run"
+        optional_hook["lifecycle"] = "after-run"
+        optional_hook["requirement"] = "optional"
+        optional_hook["locator"] = ".loom/companion/hooks/missing-optional.md"
+        optional_hook.pop("safety")
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["hook_locators"] = [optional_hook]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(optional_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` optional sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="optional-hooks-extension",
+                payload=optional_payload,
+            )
+            core_profile = optional_payload.get("core_profile") if isinstance(optional_payload, dict) else None
+            if not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must warn"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must not block core profile"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_hook = json.loads(json.dumps(safe_hook))
+        required_hook["id"] = "required-unsafe"
+        required_hook["safety"]["host_trust"] = "untrusted"
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["hook_locators"] = [required_hook]
+        install_companion_local(required_target, repo_interface=required_interface)
+        (required_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (required_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(required_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` required sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="required-hooks-extension",
+                payload=required_payload,
+            )
+            core_profile = required_payload.get("core_profile") if isinstance(required_payload, dict) else None
+            if not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must block the hooks extension profile"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must not rewrite core profile result"))
+        governance_surface = build_governance_surface(required_target)
+        repo_interface = governance_surface.get("repo_interface")
+        core_missing = repo_interface.get("missing_inputs", []) if isinstance(repo_interface, dict) else []
+        if any("hook_locators" in str(message) for message in core_missing):
+            failures.append(Failure("hooks-extension-profile", "hooks extension gaps must not pollute repo_interface core missing_inputs"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
     def write_json_local(path: Path, payload: object) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def sha256_file_local(path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def write_shadow_evidence_local(target: Path, evidence: str, value_key: str, value: str, source: str) -> None:
+        source_path = target / source
+        if not source_path.exists():
+            write_json_local(source_path, {value_key: value})
+        write_json_local(
+            target / evidence,
+            {
+                value_key: value,
+                "source_files": [source],
+                "source_sha256": {source: sha256_file_local(source_path)},
+            },
+        )
 
     docs = {
         "docs/evidence/v0.10.0-release-readiness.md": [
@@ -11457,6 +14069,7 @@ def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     with tempfile.TemporaryDirectory(prefix="loom-live-validation-guardrail-") as tmp:
         mismatch_target = Path(tmp) / "shadow-mismatch"
         shutil.copytree(example_target, mismatch_target)
+        write_shadow_evidence_local(mismatch_target, ".loom/shadow/review-repo.json", "decision", "allow", "native/status/review.json")
         shadow_payload = load_json_file(mismatch_target / ".loom/shadow/review-repo.json")
         if isinstance(shadow_payload, dict):
             shadow_payload["source_sha256"] = {"native/status/review.json": "0" * 64}
@@ -12933,6 +15546,8 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
+    failures.extend(check_external_orchestrator_interop_fixture_contract(root))
+    failures.extend(check_external_orchestrator_conformance_contract(root))
     failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_status_closeout_binding_contract(root))
     failures.extend(check_behavior_first_locator_contracts(root))
@@ -12945,6 +15560,8 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_hook_envelope_contract(root))
+    failures.extend(check_hooks_extension_profile_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
@@ -12959,7 +15576,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 33
+    categories_checked = 36
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/examples/new-project/.loom/bin/loom_flow.py
+++ b/examples/new-project/.loom/bin/loom_flow.py
@@ -34,6 +34,8 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    EXTERNAL_ORCHESTRATOR_OPERATIONS,
+    empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
     workspace_lifecycle_expectations,
@@ -111,16 +113,108 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
-DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
+CODEX_APP_REVIEW_ADAPTER = "loom/codex-app-review"
+CODEX_APP_REVIEW_ENGINE = "codex-app-review"
+CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
+AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
+SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
+CODEX_APP_REVIEW_ENDPOINT_ENV = "LOOM_CODEX_APP_REVIEW_ENDPOINT"
+CODEX_APP_REVIEW_THREAD_ID_ENV = "LOOM_CODEX_APP_REVIEW_THREAD_ID"
+CODEX_APP_REVIEW_CWD_ENV = "LOOM_CODEX_APP_REVIEW_CWD"
+CODEX_THREAD_ID_ENV = "CODEX_THREAD_ID"
+DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS: int | None = None
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+PR_MERGE_GATE_SCHEMA = "loom-pr-merge-gate/v1"
+CONTROLLED_MERGE_SCHEMA = "loom-controlled-merge/v1"
+PR_MERGE_GATE_CHECK_NAME = "loom-pr-merge-gate"
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
+HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
+HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
+HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
+EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA = "loom-external-orchestrator-conformance/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
+HOOK_ENVELOPE_CATEGORIES = {"context_injection", "blocking_decision", "runtime_evidence"}
+HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS = {
+    "invalid_envelope",
+    "missing_required_input",
+    "unsupported",
+    "not_applicable",
+    "permission_unavailable",
+    "unsafe",
+    "host_mapping_failed",
+}
+HOOK_ENVELOPE_FALLBACKS = {
+    None,
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+}
+HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
+    "authored_progress",
+    "recovery_truth",
+    "status_truth",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+    "current_stop",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "current_lane",
+    "recovery_boundary",
+    "closing_condition",
+}
+EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS = {
+    "scheduler_state",
+    "attempt_ownership",
+    "authored_progress",
+    "current_checkpoint",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "status_truth",
+    "gate_verdict",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+    "daemon",
+    "scheduler_queue",
+    "branch_ownership",
+    "pr_ownership",
+    "worktree_ownership",
+    "worker_lifecycle",
+}
+EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS = {
+    "work_item",
+    "admission",
+    "binding_repair",
+    "current_checkpoint",
+    "spec_gate",
+    "build_gate",
+    "review_gate",
+    "merge_gate",
+    "build",
+    "review",
+    "merge_ready",
+    "closeout",
+}
+HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
+HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -332,6 +426,43 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     host_binding.add_argument("--head-sha", help="Implementation head SHA to validate")
     host_binding.add_argument("--base-sha", help="Base SHA used for diff validation")
 
+    pr_gate = subparsers.add_parser("pr-gate", help="Evaluate PR-specific semantic approval before host merge")
+    pr_gate.add_argument("operation", choices=("check",))
+    pr_gate.add_argument("--target", required=True, help="Target repository root")
+    pr_gate.add_argument("--item", help="Expected Loom Work Item id; must match PR body when both are present")
+    pr_gate.add_argument(
+        "--output",
+        default=".loom/bootstrap/init-result.json",
+        help="Init-result path relative to the target root",
+    )
+    pr_gate.add_argument("--owner", help="GitHub owner; auto-detected from origin when omitted")
+    pr_gate.add_argument("--repo", dest="repo_name", help="GitHub repository name; auto-detected from origin when omitted")
+    pr_gate.add_argument("--pr", type=int, help="GitHub implementation PR number")
+    pr_gate.add_argument("--head-sha", help="Expected PR head SHA")
+    pr_gate.add_argument("--branch", help="Optional PR branch/ref used to infer a PR number")
+    pr_gate.add_argument("--pr-payload-file", help="Optional repo-relative PR payload JSON fixture")
+
+    controlled_merge = subparsers.add_parser("controlled-merge", help="Check or execute Loom-controlled PR merge")
+    controlled_merge.add_argument("operation", choices=("check", "merge"))
+    controlled_merge.add_argument("--target", required=True, help="Target repository root")
+    controlled_merge.add_argument("--item", help="Expected Loom Work Item id")
+    controlled_merge.add_argument(
+        "--output",
+        default=".loom/bootstrap/init-result.json",
+        help="Init-result path relative to the target root",
+    )
+    controlled_merge.add_argument("--owner", help="GitHub owner; auto-detected from origin when omitted")
+    controlled_merge.add_argument("--repo", dest="repo_name", help="GitHub repository name; auto-detected from origin when omitted")
+    controlled_merge.add_argument("--pr", type=int, required=True, help="GitHub implementation PR number")
+    controlled_merge.add_argument("--head-sha", help="Expected PR head SHA")
+    controlled_merge.add_argument("--merge-method", choices=("squash", "merge", "rebase"), default="squash")
+    controlled_merge.add_argument("--delete-branch", action="store_true", help="Delete branch after a successful host merge")
+    controlled_merge.add_argument("--execute", action="store_true", help="Actually delegate to gh pr merge when all gates pass")
+    controlled_merge.add_argument("--pr-payload-file", help="Optional repo-relative PR payload JSON fixture")
+    controlled_merge.add_argument("--status-checks-file", help="Optional repo-relative statusCheckRollup JSON fixture")
+    controlled_merge.add_argument("--branch-protection-file", help="Optional repo-relative branch protection JSON fixture")
+    controlled_merge.add_argument("--ruleset-file", help="Optional repo-relative branch rules/ruleset JSON fixture")
+
     state = subparsers.add_parser(
         "state-check",
         help="Check active-state consistency, checkpoint completeness, and scope overflow signals",
@@ -360,13 +491,45 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--reviewer", help="Reviewer identity")
     review.add_argument("--fallback-to", choices=("admission", "build", "merge"))
     review.add_argument("--findings-file", help="Optional findings JSON path relative to the target root")
-    review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
+    review.add_argument(
+        "--engine-adapter",
+        choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
+        help=(
+            "Optional authoritative review engine adapter for review run/record. "
+            "When omitted, verified Codex App sessions use loom/codex-app-review; headless/CI fallback remains loom/default-codex."
+        ),
+    )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument(
+        "--codex-app-review-app-server",
+        help=f"Codex App app-server/session locator. Defaults to ${CODEX_APP_REVIEW_ENDPOINT_ENV} when available.",
+    )
+    review.add_argument(
+        "--codex-app-review-thread-id",
+        help=f"Codex App thread id. Defaults to ${CODEX_APP_REVIEW_THREAD_ID_ENV}, or ${CODEX_THREAD_ID_ENV} when an endpoint is present.",
+    )
+    review.add_argument(
+        "--codex-app-review-cwd",
+        help=f"Codex App thread cwd proof. Defaults to ${CODEX_APP_REVIEW_CWD_ENV}.",
+    )
+    review.add_argument(
+        "--codex-app-review-raw-file",
+        help="Optional repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+    )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
     review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
     review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
+    review.add_argument(
+        "--shadow-engine-adapter",
+        choices=tuple(sorted(SHADOW_REVIEW_ADAPTERS)),
+        help="Optional shadow-only review adapter. Does not replace the default authoritative review engine.",
+    )
+    review.add_argument(
+        "--shadow-review-raw-file",
+        help="Optional repo-relative captured Codex App review text to normalize as shadow evidence.",
+    )
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -508,7 +671,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
+    live_smoke.add_argument(
+        "operation",
+        choices=(
+            "run",
+            "replay",
+            "host-adapter-drift",
+            "dynamic-tool-availability",
+            "hook-envelope",
+            "hooks-extension",
+            "external-orchestrator-interop",
+        ),
+    )
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -518,6 +692,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
         default="attempt_time",
         help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
+    live_smoke.add_argument("--envelope", help="Repo-relative Loom hook envelope path for live-smoke hook-envelope")
+    live_smoke.add_argument(
+        "--requirement",
+        choices=("required", "optional", "advisory"),
+        default="required",
+        help="Hook envelope requirement level; defaults to required",
     )
     live_smoke.add_argument(
         "--include-blocking-shadow",
@@ -741,6 +922,21 @@ def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -
     return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
 
 
+def hook_envelope_command(target_root: Path, *, envelope: str, requirement: str) -> str:
+    return live_smoke_command(
+        [
+            "live-smoke",
+            "hook-envelope",
+            "--target",
+            str(target_root),
+            "--envelope",
+            envelope,
+            "--requirement",
+            requirement,
+        ]
+    )
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -798,6 +994,290 @@ def dynamic_tool_live_availability_command_plan(
             }
         )
     return plan
+
+
+def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading the mapped hook envelope.",
+        },
+        {
+            "id": "hook-envelope",
+            "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
+            "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading hooks extension declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read hook_locators from repo companion without executing hooks or writing host state.",
+        },
+    ]
+
+
+def external_orchestrator_conformance_command_plan(
+    target_root: Path,
+    external_orchestrators: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading external orchestrator declarations.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'} external_orchestrators",
+            "description": "Read external orchestrator locator declarations without starting a scheduler or daemon.",
+        },
+        {
+            "id": "status-consumer-view",
+            "command": f"{shlex.quote(sys.executable)} tools/loom_status.py --target {shlex.quote(str(target_root))} --item INIT-0001",
+            "description": "Confirm status/gate consumption reuses Loom status control plane v2 and the existing gate chain.",
+        },
+    ]
+    for index, entry in enumerate(external_orchestrators or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"external-orchestrator-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read external orchestrator retained evidence without accepting scheduler-owned status or gate truth.",
+            }
+        )
+    return plan
+
+
+def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in HOOK_ENVELOPE_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def find_forbidden_external_orchestrator_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in EXTERNAL_ORCHESTRATOR_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_external_orchestrator_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def find_unsafe_hook_cleanup_targets(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        targets = value.get("cleanup_targets")
+        if isinstance(targets, list):
+            for index, target in enumerate(targets):
+                target_prefix = f"{prefix}.cleanup_targets[{index}]"
+                if not isinstance(target, dict):
+                    found.append(f"{target_prefix} must be an object")
+                    continue
+                ownership = target.get("ownership")
+                if ownership not in HOOK_CLEANUP_ALLOWED_OWNERSHIPS:
+                    found.append(f"{target_prefix}.ownership must be `loom_owned`")
+        for key_label, nested in value.items():
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}.{key_label}"))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
+    missing_inputs: list[str] = []
+    evidence: dict[str, Any] = {
+        "schema_status": "unknown",
+        "output_category": None,
+        "failure_classification": None,
+    }
+    if not isinstance(envelope, dict):
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope must be a JSON object.",
+            "missing_inputs": ["hook envelope must be a JSON object"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if envelope.get("schema_version") != HOOK_ENVELOPE_SCHEMA:
+        missing_inputs.append("schema_version must be `loom-hook-envelope/v1`")
+    else:
+        evidence["schema_status"] = "valid"
+
+    hook = envelope.get("hook")
+    if not isinstance(hook, dict):
+        missing_inputs.append("hook envelope missing `hook` object")
+    else:
+        for field in ("id", "locator"):
+            value = hook.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"hook missing `{field}`")
+        lifecycle = hook.get("lifecycle")
+        if lifecycle not in HOOK_LIFECYCLES:
+            missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
+
+    input_payload = envelope.get("input")
+    adapter_result = None
+    if not isinstance(input_payload, dict):
+        missing_inputs.append("hook envelope missing `input` object")
+    else:
+        for field in ("item_locator", "workspace_locator", "attempt_locator"):
+            value = input_payload.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"input missing `{field}`")
+        mapping = input_payload.get("host_adapter_mapping")
+        if not isinstance(mapping, dict):
+            missing_inputs.append("input missing `host_adapter_mapping` object")
+        else:
+            for field in ("host", "event"):
+                value = mapping.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    missing_inputs.append(f"host_adapter_mapping missing `{field}`")
+            if mapping.get("adapter_result") not in HOOK_ADAPTER_RESULTS:
+                missing_inputs.append(
+                    "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
+                )
+            else:
+                adapter_result = mapping.get("adapter_result")
+
+    output = envelope.get("output")
+    output_category = None
+    if not isinstance(output, dict):
+        missing_inputs.append("hook envelope missing `output` object")
+    else:
+        output_category = output.get("category")
+        evidence["output_category"] = output_category
+        if output_category not in HOOK_ENVELOPE_CATEGORIES:
+            missing_inputs.append("output.category must be `context_injection`, `blocking_decision`, or `runtime_evidence`")
+        summary = output.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            missing_inputs.append("output missing `summary`")
+
+    forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
+    if forbidden_fields:
+        missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+    unsafe_cleanup_targets = find_unsafe_hook_cleanup_targets(envelope)
+    if unsafe_cleanup_targets:
+        missing_inputs.append(
+            "hook envelope cleanup intent must target Loom-owned residue only: "
+            + ", ".join(unsafe_cleanup_targets)
+        )
+
+    failure = envelope.get("failure")
+    failure_classification = None
+    fallback_to = None
+    if failure is not None:
+        if not isinstance(failure, dict):
+            missing_inputs.append("failure must be an object when present")
+        else:
+            failure_classification = failure.get("classification")
+            evidence["failure_classification"] = failure_classification
+            if failure_classification not in HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS:
+                missing_inputs.append("failure.classification is outside the stable hook envelope vocabulary")
+            fallback_to = failure.get("fallback_to")
+            if fallback_to not in HOOK_ENVELOPE_FALLBACKS:
+                missing_inputs.append("failure.fallback_to must point to a Loom surface or manual repair path")
+            summary = failure.get("summary")
+            if failure_classification and (not isinstance(summary, str) or not summary.strip()):
+                missing_inputs.append("failure with classification must include `summary`")
+
+    if missing_inputs:
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope is invalid or truth-polluting.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if adapter_result == "unsafe":
+        return {
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook adapter mapping reports unsafe.",
+            "missing_inputs": ["host_adapter_mapping.adapter_result is unsafe"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+    if adapter_result == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook adapter mapping reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if adapter_result == "advisory":
+        return {
+            "result": "warn",
+            "classification": "unsupported",
+            "summary": "hook adapter mapping is advisory and remains profile-local evidence.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+
+    if failure_classification == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook envelope reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if failure_classification:
+        result = "block" if failure_classification in {"permission_unavailable", "unsafe", "host_mapping_failed"} else "warn"
+        return {
+            "result": result,
+            "classification": failure_classification,
+            "summary": str(failure.get("summary") if isinstance(failure, dict) else "hook envelope reports failure."),
+            "missing_inputs": [f"hook envelope reported {failure_classification}"] if result == "block" else [],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    return {
+        "result": "pass",
+        "classification": "none",
+        "summary": f"hook envelope maps output as `{output_category}`.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
 
 
 def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
@@ -1269,6 +1749,618 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
             },
+        }
+    )
+    return payload
+
+
+def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hook-envelope",
+        "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hook_envelope_command_plan(target_root, envelope=envelope),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if requirement not in {"required", "optional", "advisory"}:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check requires requirement to be required, optional, or advisory.",
+                "missing_inputs": ["--requirement must be `required`, `optional`, or `advisory`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "invalid-declaration",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "runtime-blocked",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hook envelope check recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "warn"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "target-unavailable",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    envelope_path, envelope_errors = resolve_repo_relative_path(target_root, envelope, label="hook envelope locator")
+    if envelope_errors:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook envelope locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": envelope_errors,
+            "fallback_to": "manual_repair",
+            "evidence": {"locator_status": "unsafe"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "unsafe",
+                "result": "block",
+                "summary": check["summary"],
+                "missing_inputs": envelope_errors,
+                "fallback_to": "manual_repair",
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check found an unsafe locator.",
+                "missing_inputs": live_smoke_missing_inputs(envelope_errors),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+    assert envelope_path is not None
+
+    if not envelope_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator points to missing path `{envelope}`"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "missing_required_input" if result == "block" else "not_applicable",
+            "summary": "hook envelope locator is missing.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "missing",
+                "result": result,
+                "summary": check["summary"],
+                "missing_inputs": missing_inputs,
+                "fallback_to": check["fallback_to"],
+            }
+        )
+        payload.update(
+            {
+                "result": result,
+                "summary": "hook envelope locator is missing.",
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs) if result == "block" else [],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+                "profile_check": {"id": "hook-envelope", "result": result},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+
+    try:
+        envelope_payload = load_json_file(envelope_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator is unreadable: {exc}"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "invalid_envelope",
+            "summary": "hook envelope locator is unreadable.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    else:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            **validate_hook_envelope_payload(envelope_payload),
+        }
+        check["evidence"] = {"locator_status": "readable", **dict(check.get("evidence", {}))}
+        if requirement in {"optional", "advisory"} and check["result"] == "block":
+            check["result"] = "warn"
+            check["fallback_to"] = None
+            check["missing_inputs"] = []
+
+    payload["reports"].append(
+        {
+            "id": "hook-envelope",
+            "attempted": True,
+            "command": f"read {envelope}",
+            "reported_command": "hook-envelope",
+            "reported_result": str(check["classification"]),
+            "result": str(check["result"]),
+            "summary": str(check["summary"]),
+            "missing_inputs": list(check.get("missing_inputs", [])),
+            "fallback_to": check.get("fallback_to"),
+        }
+    )
+    result = str(check["result"])
+    payload.update(
+        {
+            "result": result,
+            "summary": "hook envelope is valid." if result == "pass" else "hook envelope check produced warnings." if result == "warn" else "hook envelope check found blocking errors.",
+            "missing_inputs": live_smoke_missing_inputs(list(check.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hook-envelope", "result": result},
+            "hook_envelope": {
+                "contract_locator": envelope,
+                "availability": "present",
+                "requirement": requirement,
+                "checks": [check],
+            },
+        }
+    )
+    return payload
+
+
+def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hooks-extension",
+        "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hooks_extension_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hooks extension profile is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hooks-extension", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hooks extension profile recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hooks-extension", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    if not isinstance(repo_interface, dict):
+        hook_profile = empty_hook_extension_profile()
+    else:
+        hook_profile = repo_interface.get("hook_profile")
+        if not isinstance(hook_profile, dict):
+            hook_profile = empty_hook_extension_profile()
+
+    result = str(hook_profile.get("result") or "pass")
+    if result not in {"pass", "warn", "block"}:
+        result = "block"
+    payload["reports"].append(
+        {
+            "id": "hooks-extension",
+            "attempted": True,
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "reported_command": "repo-interface.hook_locators",
+            "reported_result": str(hook_profile.get("status") or "not_applicable"),
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": list(hook_profile.get("missing_inputs", [])) if result == "block" else [],
+            "fallback_to": "manual_repair" if result == "block" else None,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": live_smoke_missing_inputs(list(hook_profile.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hooks-extension", "result": result},
+            "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+            "hooks_extension": hook_profile,
+        }
+    )
+    return payload
+
+
+def empty_external_orchestrator_conformance() -> dict[str, Any]:
+    return {
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "profile_id": "orchestration-extension/external-orchestrator",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "external orchestrator interop profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+        "non_goals": {
+            "daemon": False,
+            "scheduler_state_machine": False,
+            "tracker_polling_product": False,
+            "second_status_surface": False,
+            "host_lifecycle_ownership": False,
+        },
+    }
+
+
+def external_orchestrator_conformance_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+) -> dict[str, Any]:
+    prefix = f"external_orchestrators[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "requirement": "required",
+            "operations": [],
+            "locator": "",
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            "evidence": {"locator_status": "invalid-declaration"},
+        }
+
+    entry_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"external-orchestrator-{index}"
+    requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+    locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "admission"
+    operations = entry.get("operations") if isinstance(entry.get("operations"), list) else []
+    blocking: list[str] = []
+    optional: list[str] = []
+
+    if requirement not in {"required", "optional", "advisory"}:
+        blocking.append(f"{prefix}.requirement must be required, optional, or advisory")
+        requirement = "required"
+    if not operations:
+        blocking.append(f"{prefix}.operations must be a non-empty list")
+    unsupported = [str(operation) for operation in operations if operation not in EXTERNAL_ORCHESTRATOR_OPERATIONS]
+    if unsupported:
+        blocking.append(f"{prefix}.operations contains unsupported operations: {', '.join(unsupported)}")
+    if isinstance(fallback_to, str) and fallback_to not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+        blocking.append(f"{prefix}.fallback_to must point back to a Loom checkpoint or gate repair surface")
+
+    locator_path, locator_errors = resolve_repo_relative_path(target_root, locator, label=f"{prefix} locator")
+    if locator_errors:
+        blocking.extend(locator_errors)
+    elif locator_path is None or not locator_path.exists() or locator_path.is_dir():
+        message = f"{prefix} locator points to missing or unreadable retained evidence `{locator}`"
+        if requirement in {"optional", "advisory"}:
+            optional.append(message)
+        else:
+            blocking.append(message)
+
+    payload: object = None
+    if locator_path is not None and locator_path.exists() and locator_path.is_file():
+        try:
+            payload = load_json_file(locator_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            blocking.append(f"{prefix} retained evidence is not readable JSON: {exc}")
+    if payload is not None and not isinstance(payload, dict):
+        blocking.append(f"{prefix} retained evidence must be a JSON object")
+    if isinstance(payload, dict):
+        forbidden = find_forbidden_external_orchestrator_fields(payload)
+        if forbidden:
+            blocking.append(f"{prefix} retained evidence contains forbidden authored/scheduler fields: {', '.join(forbidden)}")
+        payload_operation = payload.get("operation")
+        if isinstance(payload_operation, str) and operations and payload_operation not in operations:
+            blocking.append(f"{prefix} retained evidence operation is not declared by the locator")
+        if payload.get("operation") in {"status_read", "gate_read"}:
+            if payload.get("source_layer") != "derived_surface":
+                blocking.append(f"{prefix} status/gate reads must consume the derived status surface")
+            if payload.get("consumed_as") != "summary":
+                blocking.append(f"{prefix} status/gate reads must be consumed as summary")
+        if payload.get("host_lifecycle_ownership") not in {None, "host", "external"}:
+            blocking.append(f"{prefix} retained evidence must not claim Loom owns host lifecycle")
+        payload_fallback = payload.get("fallback_to")
+        if isinstance(payload_fallback, str) and payload_fallback not in EXTERNAL_ORCHESTRATOR_ALLOWED_FALLBACKS:
+            blocking.append(f"{prefix} retained evidence fallback_to must point back to Loom")
+
+    result = "block" if blocking else "warn" if optional else "pass"
+    if result == "warn" and requirement in {"required"}:
+        result = "block"
+    return {
+        "id": entry_id,
+        "requirement": requirement,
+        "operations": operations,
+        "locator": locator,
+        "result": result,
+        "classification": "truth_pollution" if blocking and isinstance(payload, dict) and find_forbidden_external_orchestrator_fields(payload) else "locator_or_contract",
+        "summary": (
+            "external orchestrator retained evidence is readable and respects Loom truth boundaries."
+            if result == "pass"
+            else "external orchestrator retained evidence has profile-local warnings."
+            if result == "warn"
+            else "external orchestrator retained evidence violates interop conformance boundaries."
+        ),
+        "missing_inputs": blocking if result == "block" else [],
+        "missing_optional": optional,
+        "fallback_to": fallback_to if result == "block" else None,
+        "evidence": {
+            "locator_status": "readable" if isinstance(payload, dict) else "missing_or_invalid",
+            "payload_schema_version": payload.get("schema_version") if isinstance(payload, dict) else None,
+            "payload_operation": payload.get("operation") if isinstance(payload, dict) else None,
+        },
+    }
+
+
+def external_orchestrator_conformance_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "external-orchestrator-interop",
+        "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": external_orchestrator_conformance_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "external orchestrator conformance is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "external orchestrator conformance recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    interop_path = target_root / ".loom" / "companion" / "interop.json"
+    if not interop_path.exists():
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop does not declare external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    try:
+        interop_payload = load_json_file(interop_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        conformance = empty_external_orchestrator_conformance()
+        conformance.update(
+            {
+                "enabled": True,
+                "result": "block",
+                "status": "invalid_declaration",
+                "summary": "repo interop contract is unreadable for external orchestrator conformance.",
+                "missing_inputs": [f"repo interop contract is unreadable: {exc}"],
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": conformance["summary"],
+                "missing_inputs": conformance["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+    external_orchestrators = interop_payload.get("external_orchestrators", []) if isinstance(interop_payload, dict) else []
+    if not isinstance(external_orchestrators, list) or not external_orchestrators:
+        conformance = empty_external_orchestrator_conformance()
+        payload["reports"].append(
+            {
+                "id": "external-orchestrator-interop",
+                "attempted": True,
+                "command": f"read {interop_path}",
+                "reported_command": "repo-interop.external_orchestrators",
+                "reported_result": "not_applicable",
+                "result": "pass",
+                "summary": "repo interop is readable but declares no external orchestrators.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": conformance["summary"],
+                "profile_check": {"id": "external-orchestrator-interop", "result": "pass"},
+                "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                "external_orchestrator": conformance,
+            }
+        )
+        return payload
+
+    checks = [
+        external_orchestrator_conformance_check(target_root, entry=entry, index=index)
+        for index, entry in enumerate(external_orchestrators)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "repo-interop.external_orchestrator",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    conformance = empty_external_orchestrator_conformance()
+    conformance.update(
+        {
+            "enabled": True,
+            "result": result,
+            "status": "present",
+            "summary": (
+                "external orchestrator conformance passed without introducing a daemon, scheduler state, or second status surface."
+                if result == "pass"
+                else "external orchestrator conformance produced profile-local warnings."
+                if result == "warn"
+                else "external orchestrator conformance found blocking interop drift."
+            ),
+            "missing_inputs": live_smoke_missing_inputs([message for check in checks for message in check.get("missing_inputs", [])]),
+            "missing_optional": [message for check in checks for message in check.get("missing_optional", [])],
+            "checks": checks,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": conformance["summary"],
+            "missing_inputs": conformance["missing_inputs"],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "external-orchestrator-interop", "result": result},
+            "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+            "external_orchestrator": conformance,
+            "command_plan": external_orchestrator_conformance_command_plan(target_root, external_orchestrators=external_orchestrators),
         }
     )
     return payload
@@ -2079,6 +3171,7 @@ def default_repo_interface() -> dict[str, Any]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",
@@ -3161,6 +4254,19 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def truthy_env(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def non_empty_str(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def execution_attempt_directory(target_root: Path, item_id: str) -> Path:
     return target_root / ".loom/runtime/attempts" / item_id
 
@@ -3760,6 +4866,8 @@ def cleanup_scratch_tree(target_root: Path, scratch_dir: Path) -> None:
 def gh_json(root: Path, args: list[str]) -> tuple[dict[str, Any] | None, list[str]]:
     try:
         result = run_process(["gh", *args], root, timeout_seconds=20)
+    except FileNotFoundError:
+        return None, ["gh command is unavailable in PATH"]
     except subprocess.TimeoutExpired:
         return None, [f"gh {' '.join(args)} timed out after 20s"]
     if result.returncode != 0:
@@ -3879,6 +4987,7 @@ def normalize_rest_pr(payload: dict[str, Any]) -> dict[str, Any]:
         "mergeCommit": {"oid": merge_commit_sha} if isinstance(merge_commit_sha, str) and merge_commit_sha else None,
         "mergeStateStatus": str(payload.get("mergeable_state")).upper() if payload.get("mergeable_state") else None,
         "headRefName": head.get("ref"),
+        "headRefOid": head.get("sha"),
         "baseRefName": base.get("ref"),
     }
 
@@ -4193,12 +5302,15 @@ def shadow_evidence_paths_for_sources(target_root: Path, source_paths: set[str])
 
 
 def allowed_post_review_carrier_paths(context: dict[str, Any], *review_paths: str) -> set[str]:
-    allowed = {
+    source_paths = {
         *review_paths,
         str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
         str(context["report"]["fact_chain"]["entry_points"]["status_surface"]),
     }
-    allowed.update(shadow_evidence_paths_for_sources(context["target_root"], set(review_paths)))
+    allowed = {
+        *source_paths,
+    }
+    allowed.update(shadow_evidence_paths_for_sources(context["target_root"], source_paths))
     review_shadow_root = context["target_root"] / ".loom/shadow"
     if review_shadow_root.exists():
         for evidence_path in sorted(review_shadow_root.glob("review-*.json")):
@@ -4208,6 +5320,13 @@ def allowed_post_review_carrier_paths(context: dict[str, Any], *review_paths: st
                 continue
             if isinstance(payload, dict):
                 allowed.add(evidence_path.relative_to(context["target_root"]).as_posix())
+    item_id = context.get("item_id")
+    if isinstance(item_id, str) and item_id.strip():
+        for runtime_root in OWNED_RUNTIME_EVIDENCE_ROOTS:
+            item_runtime_root = context["target_root"] / runtime_root / item_id
+            if item_runtime_root.exists():
+                for evidence_path in sorted(path for path in item_runtime_root.rglob("*") if path.is_file()):
+                    allowed.add(evidence_path.relative_to(context["target_root"]).as_posix())
     return allowed
 
 
@@ -5162,8 +6281,26 @@ def run_default_review_engine(
     engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "explicit-or-legacy-default",
+            "fallback_reason": None,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=None,
+                thread_id=None,
+                thread_cwd=None,
+                reviewed_head=reviewed_head,
+                raw_file=None,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     prompt_path = runtime_root / "prompt.txt"
     result_path = runtime_root / "engine-result.json"
@@ -5184,7 +6321,8 @@ def run_default_review_engine(
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
-    timeout_seconds = int(engine_profile["timeout_seconds"])
+    raw_timeout_seconds = engine_profile.get("timeout_seconds")
+    timeout_seconds = int(raw_timeout_seconds) if raw_timeout_seconds is not None else None
 
     before_fingerprint, fingerprint_errors = git_tracked_diff_fingerprint(context["target_root"])
     if fingerprint_errors:
@@ -5210,6 +6348,7 @@ def run_default_review_engine(
                     "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
+            "engine_metadata": selection_metadata,
         }
 
     scratch_dir.mkdir(parents=True, exist_ok=True)
@@ -5227,7 +6366,6 @@ def run_default_review_engine(
             [
                 DEFAULT_REVIEW_ENGINE,
                 "exec",
-                "--ignore-user-config",
                 "-C",
                 str(context["target_root"]),
                 "-m",
@@ -5255,9 +6393,7 @@ def run_default_review_engine(
         failure_detail = f"default review engine `{DEFAULT_REVIEW_ENGINE}` is unavailable in PATH"
     except subprocess.TimeoutExpired:
         failure_reason = "runtime_conflict"
-        failure_detail = (
-            f"default review engine timed out after {timeout_seconds}s"
-        )
+        failure_detail = f"default review engine timed out after {timeout_seconds}s"
     else:
         if completed.returncode != 0:
             failure_reason = "runtime_conflict"
@@ -5303,6 +6439,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
@@ -5324,6 +6461,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     if raw_payload is not None and not result_path.exists():
@@ -5340,6 +6478,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
@@ -5362,6 +6501,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     write_json_file(findings_path, {"findings": normalized_payload["findings"]})
@@ -5371,6 +6511,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
@@ -5394,6 +6535,13 @@ def run_default_review_engine(
             "failure_reason": None,
             "reviewed_head": reviewed_head,
             "evidence": engine_evidence,
+        },
+        "engine_metadata": {
+            **selection_metadata,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "raw_result": relative_to_root(result_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "metadata": relative_to_root(metadata_path, context["target_root"]),
         },
         "review_record_input": {
             "decision": normalized_payload["decision"],
@@ -6011,11 +7159,14 @@ def resolve_review_engine_profile(
     context: dict[str, Any],
     review_kind: str,
     *,
+    adapter: str = DEFAULT_REVIEW_ADAPTER,
     requested_profile: str | None = None,
     requested_model: str | None = None,
     requested_reasoning: str | None = None,
     override_reason: str | None = None,
 ) -> tuple[dict[str, Any] | None, list[str]]:
+    if adapter not in AUTHORITATIVE_REVIEW_ADAPTERS:
+        return None, [f"unsupported authoritative review adapter: {adapter}"]
     selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
     if requested_profile:
         selected_profile = requested_profile
@@ -6038,11 +7189,11 @@ def resolve_review_engine_profile(
     resolved = {
         "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
         "profile_id": base_profile["profile_id"],
-        "adapter": DEFAULT_REVIEW_ADAPTER,
-        "engine": DEFAULT_REVIEW_ENGINE,
+        "adapter": adapter,
+        "engine": CODEX_APP_REVIEW_ENGINE if adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
         "model": base_profile["model"],
         "reasoning_effort": base_profile["reasoning_effort"],
-        "timeout_seconds": int(base_profile["timeout_seconds"]),
+        "timeout_seconds": int(base_profile["timeout_seconds"]) if base_profile["timeout_seconds"] is not None else None,
         "context_policy": base_profile["context_policy"],
         "selection_reason": base_profile["selection_reason"],
         "override_reason": reason or None,
@@ -6101,6 +7252,822 @@ def normalize_engine_review_result(payload: Any, *, relative: str) -> tuple[dict
         "summary": summary.strip(),
         "findings": findings,
     }, []
+
+
+def normalize_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App review raw output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+        if normalized is not None and not errors:
+            return normalized, []
+
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+    summary = first_line[:240] if first_line else "Codex App review returned raw text."
+    return {
+        "decision": "fallback",
+        "summary": "Codex App review raw output was captured as shadow evidence and normalized for comparison only.",
+        "findings": [
+            {
+                "id": "codex-app-review-raw-output",
+                "summary": summary,
+                "severity": "warn",
+                "rebuttal": None,
+                "disposition": {
+                    "status": "deferred",
+                    "summary": "Shadow-only finding; formal disposition must still be authored through the single review record.",
+                },
+                "details": text[:4000],
+            }
+        ],
+    }, []
+
+
+def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: str) -> tuple[dict[str, Any] | None, list[str]]:
+    text = raw_text.strip()
+    if not text:
+        return None, [f"Codex App authoritative review output `{relative}` is empty"]
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, [f"Codex App authoritative review output `{relative}` must be normalized JSON: {exc}"]
+    normalized, errors = normalize_engine_review_result(parsed, relative=relative)
+    if errors or normalized is None:
+        return None, errors
+    return normalized, []
+
+
+def codex_app_endpoint_socket_path(app_server: str | None) -> Path | None:
+    endpoint = non_empty_str(app_server)
+    if endpoint is None:
+        return None
+    if endpoint.startswith("unix://"):
+        path_text = endpoint.removeprefix("unix://")
+    elif endpoint.startswith("/"):
+        path_text = endpoint
+    else:
+        return None
+    if not path_text:
+        return None
+    return Path(path_text).expanduser()
+
+
+def codex_app_endpoint_is_live_capable(app_server: str | None) -> bool:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    return socket_path is not None and socket_path.exists()
+
+
+def codex_app_review_bindings_from_args_env(args: argparse.Namespace) -> dict[str, str | None]:
+    app_server = non_empty_str(args.codex_app_review_app_server) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_ENDPOINT_ENV))
+    thread_id = (
+        non_empty_str(args.codex_app_review_thread_id)
+        or non_empty_str(os.environ.get(CODEX_APP_REVIEW_THREAD_ID_ENV))
+        or (non_empty_str(os.environ.get(CODEX_THREAD_ID_ENV)) if app_server else None)
+    )
+    thread_cwd = non_empty_str(args.codex_app_review_cwd) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_CWD_ENV))
+    raw_file = non_empty_str(args.codex_app_review_raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": thread_cwd,
+        "raw_file": raw_file,
+    }
+
+
+def codex_app_binding_summary(
+    target_root: Path,
+    *,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    reviewed_head: str,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    cwd_match: bool | None = None
+    cwd_summary: str | None = thread_cwd
+    if non_empty_str(thread_cwd):
+        try:
+            cwd_path = Path(str(thread_cwd)).expanduser().resolve()
+        except OSError:
+            cwd_match = False
+        else:
+            cwd_match = cwd_path == target_root
+            cwd_summary = str(cwd_path)
+    raw_source: str | None = None
+    if non_empty_str(raw_file):
+        raw_path, raw_errors = resolve_repo_relative_path(target_root, str(raw_file), label="Codex App authoritative review raw file")
+        if raw_path is not None and not raw_errors:
+            raw_source = relative_to_root(raw_path, target_root)
+        else:
+            raw_source = str(raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_summary,
+        "thread_cwd_matches_target_root": cwd_match,
+        "target_root": str(target_root),
+        "reviewed_head": reviewed_head,
+        "raw_source": raw_source,
+        "live_endpoint_capable": codex_app_endpoint_is_live_capable(app_server),
+    }
+
+
+def select_review_adapter(
+    args: argparse.Namespace,
+    target_root: Path,
+    *,
+    reviewed_head: str,
+) -> dict[str, Any]:
+    bindings = codex_app_review_bindings_from_args_env(args)
+    explicit_adapter = non_empty_str(args.engine_adapter)
+    if explicit_adapter:
+        return {
+            "adapter": explicit_adapter,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    if truthy_env("CI") or truthy_env("CODEX_CI"):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "headless-fallback",
+            "fallback_reason": "ci-or-codex-ci",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    app_server = bindings["app_server"]
+    thread_id = bindings["thread_id"]
+    thread_cwd = bindings["thread_cwd"]
+    raw_file = bindings["raw_file"]
+    if not app_server or not thread_id or not thread_cwd:
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "missing-codex-app-host-proof",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    if not raw_file and not codex_app_endpoint_is_live_capable(app_server):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "app-server-unavailable",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    return {
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "selection_source": "codex-app-host-default",
+        "fallback_reason": None,
+        **bindings,
+        "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+    }
+
+
+def review_adapter_selection_metadata(selection: dict[str, Any], *, reviewed_head: str) -> dict[str, Any]:
+    return {
+        "selected_adapter": selection["adapter"],
+        "selection_source": selection.get("selection_source"),
+        "fallback_reason": selection.get("fallback_reason"),
+        "app_server": selection.get("app_server"),
+        "thread_id": selection.get("thread_id"),
+        "thread_cwd": selection.get("thread_cwd"),
+        "target_root": selection.get("binding_summary", {}).get("target_root")
+        if isinstance(selection.get("binding_summary"), dict)
+        else None,
+        "reviewed_head": reviewed_head,
+        "thread_target_binding": selection.get("binding_summary"),
+    }
+
+
+def jsonrpc_send_request(stdin: Any, *, request_id: int, method: str, params: dict[str, Any]) -> None:
+    stdin.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}) + "\n")
+    stdin.flush()
+
+
+def jsonrpc_read_response(stdout: Any, *, request_id: int) -> tuple[dict[str, Any] | None, list[dict[str, Any]], list[str]]:
+    notifications: list[dict[str, Any]] = []
+    while True:
+        line = stdout.readline()
+        if not line:
+            return None, notifications, [f"app-server closed before response id {request_id}"]
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("id") == request_id:
+            return payload, notifications, []
+        notifications.append(payload)
+
+
+def find_exited_review_text(payload: Any) -> str | None:
+    if isinstance(payload, dict):
+        if payload.get("type") == "exitedReviewMode" and isinstance(payload.get("review"), str):
+            return payload["review"]
+        for value in payload.values():
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    return None
+
+
+def find_normalized_review_payload(payload: Any) -> dict[str, Any] | None:
+    normalized, errors = normalize_engine_review_result(payload, relative="app-server turn/start output")
+    if normalized is not None and not errors:
+        return normalized
+    if isinstance(payload, dict):
+        for value in payload.values():
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    return None
+
+
+def app_server_proxy_command(app_server: str) -> list[str] | None:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    if socket_path is None:
+        return None
+    return ["codex", "app-server", "proxy", "--sock", str(socket_path)]
+
+
+def run_codex_app_live_review(
+    *,
+    app_server: str,
+    thread_id: str,
+    reviewed_head: str,
+    thread_cwd: str,
+    prompt_text: str,
+) -> tuple[str | None, dict[str, Any], list[str]]:
+    command = app_server_proxy_command(app_server)
+    if command is None:
+        return None, {}, [f"unsupported Codex App review endpoint: {app_server}"]
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return None, {}, [f"Codex App review endpoint is unavailable: {exc}"]
+    assert process.stdin is not None
+    assert process.stdout is not None
+    metadata: dict[str, Any] = {"review_target": {"type": "commit", "sha": reviewed_head}}
+    try:
+        jsonrpc_send_request(process.stdin, request_id=1, method="initialize", params={"clientInfo": {"name": "loom", "version": "stage3"}, "capabilities": {}})
+        initialize_response, _, initialize_errors = jsonrpc_read_response(process.stdout, request_id=1)
+        if initialize_errors:
+            return None, metadata, initialize_errors
+        if isinstance(initialize_response, dict) and isinstance(initialize_response.get("error"), dict):
+            return None, metadata, [f"Codex App initialize failed: {initialize_response['error']}"]
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=2,
+            method="review/start",
+            params={
+                "threadId": thread_id,
+                "delivery": "inline",
+                "target": {"type": "commit", "sha": reviewed_head},
+            },
+        )
+        review_response, review_notifications, review_errors = jsonrpc_read_response(process.stdout, request_id=2)
+        if review_errors:
+            return None, metadata, review_errors
+        if isinstance(review_response, dict) and isinstance(review_response.get("error"), dict):
+            return None, metadata, [f"Codex App review/start failed: {review_response['error']}"]
+        result = review_response.get("result") if isinstance(review_response, dict) else None
+        if isinstance(result, dict):
+            metadata["review_thread_id"] = result.get("reviewThreadId")
+        review_text = find_exited_review_text(result) or find_exited_review_text(review_notifications)
+        if not isinstance(review_text, str) or not review_text.strip():
+            return None, metadata, ["Codex App review/start did not return exitedReviewMode.review"]
+
+        parsed_review, parsed_errors = normalize_authoritative_codex_app_review_text(review_text, relative="app-server review/start output")
+        if parsed_review is not None and not parsed_errors:
+            metadata["normalization_source"] = "review-start-json"
+            return review_text, {**metadata, "normalized": parsed_review}, []
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=3,
+            method="turn/start",
+            params={
+                "threadId": metadata.get("review_thread_id") or thread_id,
+                "cwd": thread_cwd,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Normalize this Codex App review output into the provided JSON schema. "
+                            "Return only the structured review result.\n\n"
+                            f"{review_text}"
+                        ),
+                    }
+                ],
+                "outputSchema": load_json_file(review_engine_schema_path()),
+            },
+        )
+        turn_response, turn_notifications, turn_errors = jsonrpc_read_response(process.stdout, request_id=3)
+        if turn_errors:
+            return review_text, metadata, turn_errors
+        if isinstance(turn_response, dict) and isinstance(turn_response.get("error"), dict):
+            return review_text, metadata, [f"Codex App turn/start normalization failed: {turn_response['error']}"]
+        normalized = find_normalized_review_payload(turn_response.get("result") if isinstance(turn_response, dict) else None)
+        if normalized is None:
+            normalized = find_normalized_review_payload(turn_notifications)
+        if normalized is None:
+            return review_text, metadata, ["Codex App turn/start did not return a Loom review result"]
+        metadata["normalization_source"] = "turn-start-output-schema"
+        return review_text, {**metadata, "normalized": normalized}, []
+    finally:
+        try:
+            process.terminate()
+        except OSError:
+            pass
+
+
+def shadow_adapter_slug(adapter: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
+
+
+def compare_review_findings(default_findings: list[dict[str, Any]], shadow_findings: list[dict[str, Any]]) -> dict[str, Any]:
+    default_ids = {str(finding.get("id")) for finding in default_findings if isinstance(finding, dict) and finding.get("id")}
+    shadow_ids = {str(finding.get("id")) for finding in shadow_findings if isinstance(finding, dict) and finding.get("id")}
+    shared = sorted(default_ids & shadow_ids)
+    default_only = sorted(default_ids - shadow_ids)
+    shadow_only = sorted(shadow_ids - default_ids)
+    result = "match" if not default_only and not shadow_only else "difference"
+    return {
+        "schema_version": "loom-review-shadow-diff/v1",
+        "result": result,
+        "summary": (
+            "Shadow review findings match the default review finding ids."
+            if result == "match"
+            else "Shadow review findings differ from the default review finding ids."
+        ),
+        "default_finding_ids": sorted(default_ids),
+        "shadow_finding_ids": sorted(shadow_ids),
+        "shared_finding_ids": shared,
+        "default_only_finding_ids": default_only,
+        "shadow_only_finding_ids": shadow_only,
+    }
+
+
+def run_codex_app_review_shadow_adapter(
+    context: dict[str, Any],
+    *,
+    adapter: str | None,
+    raw_file: str | None,
+    default_engine_payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not adapter:
+        return None
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    runtime_root = review_runtime_root(context, reviewed_head)
+    shadow_root = runtime_root / "shadow" / shadow_adapter_slug(adapter)
+    raw_path = shadow_root / "raw-review.txt"
+    findings_path = shadow_root / "normalized-findings.json"
+    metadata_path = shadow_root / "metadata.json"
+    diff_path = shadow_root / "parity-diff.json"
+    evidence = {
+        "runtime_root": relative_to_root(shadow_root, context["target_root"]),
+        "raw_review": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "parity_diff": relative_to_root(diff_path, context["target_root"]),
+    }
+
+    if adapter != CODEX_APP_REVIEW_SHADOW_ADAPTER:
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Unsupported shadow review adapter.",
+            "missing_inputs": [f"unsupported shadow review adapter: {adapter}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    if not raw_file:
+        metadata = {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "unavailable",
+            "reviewed_head": reviewed_head,
+            "summary": "Codex App review shadow adapter requires captured raw review text or a future live app-server runner.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "authoritative": False,
+        }
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(metadata_path, metadata)
+        return {
+            "adapter": adapter,
+            "result": "unavailable",
+            "summary": "Codex App review shadow adapter was requested but no raw review evidence was provided.",
+            "missing_inputs": ["--shadow-review-raw-file"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    source_path, source_errors = resolve_repo_relative_path(context["target_root"], raw_file, label="shadow review raw file")
+    if source_errors or source_path is None:
+        shadow_root.mkdir(parents=True, exist_ok=True)
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": source_errors,
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter refused an unsafe raw review locator.",
+            "missing_inputs": source_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    try:
+        raw_text = source_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow adapter could not read raw review evidence.",
+            "missing_inputs": [f"shadow review raw file: {exc.strerror or exc}"],
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    shadow_root.mkdir(parents=True, exist_ok=True)
+    raw_path.write_text(raw_text, encoding="utf-8")
+    normalized, normalization_errors = normalize_codex_app_review_text(
+        raw_text,
+        relative=relative_to_root(source_path, context["target_root"]),
+    )
+    if normalization_errors or normalized is None:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-shadow-metadata/v1",
+                "adapter": adapter,
+                "result": "block",
+                "reviewed_head": reviewed_head,
+                "missing_inputs": normalization_errors,
+                "raw_source": relative_to_root(source_path, context["target_root"]),
+                "authoritative": False,
+            },
+        )
+        return {
+            "adapter": adapter,
+            "result": "block",
+            "summary": "Codex App review shadow output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "blocking": False,
+            "authoritative": False,
+            "evidence": evidence,
+        }
+
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    default_findings: list[dict[str, Any]] = []
+    review_record_input = default_engine_payload.get("review_record_input")
+    if isinstance(review_record_input, dict):
+        default_findings_file = review_record_input.get("findings_file")
+        if isinstance(default_findings_file, str):
+            loaded_findings, _ = load_findings_file(context["target_root"], default_findings_file)
+            if isinstance(loaded_findings, list):
+                default_findings = loaded_findings
+    parity_diff = compare_review_findings(default_findings, normalized["findings"])
+    write_json_file(diff_path, parity_diff)
+    write_json_file(
+        metadata_path,
+        {
+            "schema_version": "loom-review-shadow-metadata/v1",
+            "adapter": adapter,
+            "result": "pass",
+            "reviewed_head": reviewed_head,
+            "raw_source": relative_to_root(source_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "parity_diff": relative_to_root(diff_path, context["target_root"]),
+            "authoritative": False,
+            "summary": normalized["summary"],
+        },
+    )
+    return {
+        "adapter": adapter,
+        "result": "pass",
+        "summary": "Codex App review shadow evidence was captured and normalized for comparison only.",
+        "missing_inputs": [],
+        "blocking": False,
+        "authoritative": False,
+        "evidence": evidence,
+        "decision": normalized["decision"],
+        "parity_diff": parity_diff,
+    }
+
+
+def run_codex_app_review_authoritative_adapter(
+    context: dict[str, Any],
+    build_payload: dict[str, Any],
+    review_path: str,
+    engine_profile: dict[str, Any],
+    *,
+    review_kind: str,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    raw_file: str | None,
+    adapter_selection: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            "app_server": app_server,
+            "thread_id": thread_id,
+            "thread_cwd": thread_cwd,
+            "raw_file": raw_file,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=app_server,
+                thread_id=thread_id,
+                thread_cwd=thread_cwd,
+                reviewed_head=reviewed_head,
+                raw_file=raw_file,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
+    runtime_root = review_runtime_root(context, reviewed_head)
+    raw_path = runtime_root / "engine-result.json"
+    findings_path = runtime_root / "normalized-findings.json"
+    metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
+    instructions_path = runtime_root / "prompt.txt"
+    context_pack = build_review_context_pack(context, review_path)
+    evidence = {
+        "runtime_root": relative_to_root(runtime_root, context["target_root"]),
+        "prompt": relative_to_root(instructions_path, context["target_root"]),
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+    }
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
+    instructions_path.write_text(
+        build_default_review_prompt(
+            context=context,
+            build_payload=build_payload,
+            runtime_fields=runtime_evidence_from_report(context["report"])[0],
+            review_path=review_path,
+            context_pack=context_pack,
+        ),
+        encoding="utf-8",
+    )
+
+    missing_inputs: list[str] = []
+    for label, value in (
+        ("--codex-app-review-app-server", app_server),
+        ("--codex-app-review-thread-id", thread_id),
+        ("--codex-app-review-cwd", thread_cwd),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(label)
+
+    cwd_relative: str | None = None
+    if isinstance(thread_cwd, str) and thread_cwd.strip():
+        try:
+            cwd_path = Path(thread_cwd).expanduser().resolve()
+        except OSError as exc:
+            missing_inputs.append(f"Codex App review cwd could not be resolved: {exc}")
+        else:
+            if cwd_path != context["target_root"]:
+                missing_inputs.append(
+                    f"Codex App review cwd `{cwd_path}` does not match target root `{context['target_root']}`"
+                )
+            else:
+                cwd_relative = relative_to_root(cwd_path, context["target_root"])
+
+    source_path: Path | None = None
+    source_relative: str | None = None
+    if isinstance(raw_file, str) and raw_file.strip():
+        source_path, source_errors = resolve_repo_relative_path(
+            context["target_root"],
+            raw_file,
+            label="Codex App authoritative review raw file",
+        )
+        missing_inputs.extend(source_errors)
+        if source_path is not None:
+            source_relative = relative_to_root(source_path, context["target_root"])
+    elif not codex_app_endpoint_is_live_capable(app_server):
+        missing_inputs.append("--codex-app-review-raw-file or live app-server endpoint")
+
+    if missing_inputs:
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                **selection_metadata,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "summary": "Codex App authoritative review adapter is missing required live binding proof.",
+                "missing_inputs": missing_inputs,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review adapter failed closed before a formal review record could be authored.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "runtime_conflict",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                **selection_metadata,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative or thread_cwd,
+                "raw_source": source_relative,
+            },
+        }
+
+    live_metadata: dict[str, Any] = {}
+    if source_path is not None:
+        try:
+            raw_text = source_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raw_text = ""
+            normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+            normalized = None
+        else:
+            normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+                raw_text,
+                relative=source_relative or str(raw_file),
+            )
+    else:
+        raw_text, live_metadata, normalization_errors = run_codex_app_live_review(
+            app_server=str(app_server),
+            thread_id=str(thread_id),
+            reviewed_head=reviewed_head,
+            thread_cwd=str(thread_cwd),
+            prompt_text=instructions_path.read_text(encoding="utf-8"),
+        )
+        normalized = live_metadata.get("normalized") if isinstance(live_metadata.get("normalized"), dict) else None
+        if raw_text is None:
+            raw_text = ""
+
+    if normalization_errors or normalized is None:
+        if raw_text:
+            raw_path.write_text(raw_text, encoding="utf-8")
+        write_json_file(
+            metadata_path,
+            {
+                "schema_version": "loom-review-engine-metadata/v1",
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                **selection_metadata,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "summary": "Codex App authoritative review output did not satisfy the Loom review result schema.",
+                "errors": normalization_errors,
+                "reviewed_head": reviewed_head,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
+            },
+        )
+        return {
+            "result": "block",
+            "summary": "Codex App authoritative review output could not be normalized safely.",
+            "missing_inputs": normalization_errors,
+            "fallback_to": None,
+            "engine": {
+                "engine": CODEX_APP_REVIEW_ENGINE,
+                "adapter": CODEX_APP_REVIEW_ADAPTER,
+                "profile": engine_profile,
+                "result": "block",
+                "failure_reason": "schema_drift",
+                "reviewed_head": reviewed_head,
+                "evidence": evidence,
+            },
+            "engine_metadata": {
+                **selection_metadata,
+                "app_server": app_server,
+                "thread_id": thread_id,
+                "thread_cwd": cwd_relative,
+                "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
+            },
+        }
+
+    raw_path.write_text(raw_text, encoding="utf-8")
+    write_json_file(findings_path, {"findings": normalized["findings"]})
+    metadata = {
+        "schema_version": "loom-review-engine-metadata/v1",
+        "engine": CODEX_APP_REVIEW_ENGINE,
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "profile": engine_profile,
+        **selection_metadata,
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+        "result": "pass",
+        "reviewed_head": reviewed_head,
+        "decision": normalized["decision"],
+        "summary": normalized["summary"],
+        "kind": review_kind,
+        "validation_summary": context["latest_validation_summary"],
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_relative,
+        "raw_source": source_relative,
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "review_thread_id": live_metadata.get("review_thread_id") if live_metadata else (thread_id if source_path is not None else None),
+        **({"live_review": {key: value for key, value in live_metadata.items() if key != "normalized"}} if live_metadata else {}),
+        "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
+    }
+    write_json_file(metadata_path, metadata)
+    return {
+        "result": "pass",
+        "summary": "Codex App authoritative review adapter produced a Loom-normalized formal review draft.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "engine": {
+            "engine": CODEX_APP_REVIEW_ENGINE,
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "profile": engine_profile,
+            "result": "pass",
+            "failure_reason": None,
+            "reviewed_head": reviewed_head,
+            "evidence": evidence,
+        },
+        "engine_metadata": metadata,
+        "review_record_input": {
+            "decision": normalized["decision"],
+            "summary": normalized["summary"],
+            "reviewer": CODEX_APP_REVIEW_ADAPTER,
+            "kind": review_kind,
+            "findings_file": relative_to_root(findings_path, context["target_root"]),
+            "engine_adapter": CODEX_APP_REVIEW_ADAPTER,
+            "engine_evidence": relative_to_root(raw_path, context["target_root"]),
+            "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
+        },
+    }
 
 
 def manual_review_payload(
@@ -7905,6 +9872,615 @@ def handle_host_binding(args: argparse.Namespace) -> int:
             branch_name=args.branch,
             head_sha=args.head_sha,
             base_sha=args.base_sha,
+        )
+    )
+
+
+def load_optional_json_fixture(target_root: Path, fixture: str | None, *, label: str) -> tuple[Any | None, list[str]]:
+    if not fixture:
+        return None, []
+    path, errors = resolve_repo_relative_path(target_root, fixture, label=label)
+    if errors:
+        return None, errors
+    assert path is not None
+    if not path.exists() or not path.is_file():
+        return None, [f"{label} points to a missing file: {fixture}"]
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), []
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, [f"invalid {label} `{fixture}`: {exc}"]
+
+
+def normalize_pr_fixture_payload(payload: Any) -> tuple[dict[str, Any] | None, list[str]]:
+    if not isinstance(payload, dict):
+        return None, ["PR payload fixture must be a JSON object"]
+    normalized = dict(payload)
+    if "isDraft" not in normalized and "draft" in normalized:
+        normalized["isDraft"] = bool(normalized.get("draft"))
+    if "headRefOid" not in normalized:
+        head = normalized.get("head") if isinstance(normalized.get("head"), dict) else None
+        if isinstance(head, dict) and isinstance(head.get("sha"), str):
+            normalized["headRefOid"] = head.get("sha")
+    if "headRefName" not in normalized:
+        head = normalized.get("head") if isinstance(normalized.get("head"), dict) else None
+        if isinstance(head, dict) and isinstance(head.get("ref"), str):
+            normalized["headRefName"] = head.get("ref")
+    if "baseRefName" not in normalized:
+        base = normalized.get("base") if isinstance(normalized.get("base"), dict) else None
+        if isinstance(base, dict) and isinstance(base.get("ref"), str):
+            normalized["baseRefName"] = base.get("ref")
+    if "state" in normalized:
+        normalized["state"] = str(normalized.get("state") or "unknown").upper()
+    else:
+        normalized["state"] = "OPEN"
+    return normalized, []
+
+
+def infer_pr_number_from_ref(ref: str | None) -> int | None:
+    if not isinstance(ref, str):
+        return None
+    for pattern in (r"(?:^|/)pr[-/](\d+)(?:[-/]|$)", r"pull/(\d+)/(?:head|merge)$"):
+        match = re.search(pattern, ref, flags=re.IGNORECASE)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def pr_work_item_from_body(body: Any) -> str | None:
+    if not isinstance(body, str):
+        return None
+    patterns = (
+        r"(?im)^\s*[-*]?\s*Loom Work Item\s*:\s*`?([A-Z]+-\d+|INIT-\d+)`?\s*$",
+        r"(?im)^\s*[-*]?\s*Work Item\s*:\s*`?([A-Z]+-\d+|INIT-\d+)`?\s*$",
+        r"(?im)^\s*[-*]?\s*Loom-Work-Item\s*:\s*`?([A-Z]+-\d+|INIT-\d+)`?\s*$",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, body)
+        if match:
+            return match.group(1).strip()
+    return None
+
+
+def pr_body_mentions_item(body: Any, item_id: str) -> bool:
+    if not isinstance(body, str):
+        return False
+    return bool(re.search(rf"(?<![A-Z0-9-]){re.escape(item_id)}(?![A-Z0-9-])", body))
+
+
+def load_pr_payload_for_gate(
+    *,
+    target_root: Path,
+    owner: str | None,
+    repo_name: str | None,
+    pr_number: int | None,
+    head_sha: str | None,
+    branch_name: str | None,
+    pr_payload_file: str | None,
+) -> tuple[dict[str, Any] | None, int | None, list[str], list[dict[str, Any]]]:
+    missing_inputs: list[str] = []
+    inferences: list[dict[str, Any]] = []
+    fixture, fixture_errors = load_optional_json_fixture(target_root, pr_payload_file, label="PR payload fixture")
+    if fixture_errors:
+        return None, pr_number, fixture_errors, inferences
+    if fixture is not None:
+        payload, errors = normalize_pr_fixture_payload(fixture)
+        if errors:
+            return None, pr_number, errors, inferences
+        inferred_number = pr_number or (int(payload["number"]) if isinstance(payload.get("number"), int) else None)
+        return payload, inferred_number, [], inferences
+
+    inferred_pr = pr_number or infer_pr_number_from_ref(branch_name)
+    if inferred_pr is not None and pr_number is None:
+        inferences.append({"from": "branch", "to": "pr", "status": "inferred", "pr": inferred_pr})
+
+    if inferred_pr is None and owner and repo_name and head_sha:
+        pulls, pull_errors = github_commit_pulls(target_root, owner, repo_name, head_sha)
+        if pull_errors:
+            missing_inputs.extend(f"head_sha: {message}" for message in pull_errors)
+        elif len(pulls) == 1 and isinstance(pulls[0].get("number"), int):
+            inferred_pr = int(pulls[0]["number"])
+            inferences.append({"from": "head_sha", "to": "pr", "status": "inferred", "pr": inferred_pr})
+        elif len(pulls) > 1:
+            missing_inputs.append("head_sha resolves to multiple PRs; pass --pr explicitly")
+
+    if inferred_pr is None:
+        return None, None, missing_inputs or ["pr | head-sha | branch"], inferences
+    if not owner or not repo_name:
+        return None, inferred_pr, ["owner/repo"], inferences
+    payload, errors = github_pr_payload(target_root, owner, repo_name, inferred_pr)
+    return payload, inferred_pr, errors, inferences
+
+
+def pr_gate_failure_taxonomy(missing_inputs: list[str], gate_result: str) -> list[str]:
+    categories: set[str] = set()
+    for message in missing_inputs:
+        lowered = str(message).lower()
+        if "pr" in lowered and ("unreadable" in lowered or "payload" in lowered or "head_sha" in lowered):
+            categories.add("pr_unreadable")
+        if "work item" in lowered or "current item mismatch" in lowered:
+            categories.add("work_item_binding_conflict" if "mismatch" in lowered else "work_item_binding_missing")
+        if "fact-chain" in lowered or "fact chain" in lowered:
+            categories.add("fact_chain_unreadable")
+        if "missing review" in lowered or "missing implementation review" in lowered or "missing review artifact" in lowered:
+            categories.add("review_missing")
+        if "schema_version" in lowered or "invalid review" in lowered:
+            categories.add("review_schema_invalid")
+        if "decision is blocking" in lowered or "decision is fallback" in lowered or "not approved" in lowered:
+            categories.add("review_not_approved")
+        if "stale" in lowered or "implementation drift" in lowered:
+            categories.add("review_stale")
+        if "validation summary" in lowered:
+            categories.add("validation_summary_drift")
+        if "reviewed_head" in lowered or "head binding" in lowered:
+            categories.add("head_binding_drift")
+        if "checkout head" in lowered:
+            categories.add("checkout_head_drift")
+        if "raw" in lowered or "shadow" in lowered:
+            categories.add("raw_evidence_bypass")
+        if "required check" in lowered or "branch protection" in lowered or "ruleset" in lowered:
+            categories.add("host_enforcement_unverified")
+    if gate_result == "fallback":
+        categories.add("prior_gate_fallback")
+    return sorted(categories)
+
+
+def pr_gate_payload(
+    *,
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    owner: str | None,
+    repo_name: str | None,
+    pr_number: int | None,
+    head_sha: str | None,
+    branch_name: str | None,
+    pr_payload_file: str | None,
+) -> dict[str, Any]:
+    detected_owner, detected_repo = detect_github_repo(target_root)
+    owner = owner or detected_owner
+    repo_name = repo_name or detected_repo
+    missing_inputs: list[str] = []
+    steps: list[dict[str, Any]] = []
+
+    runtime_state = runtime_state_payload(target_root)
+    steps.append(
+        {
+            "name": "runtime-state",
+            "result": runtime_state["result"],
+            "summary": runtime_state["summary"],
+            "missing_inputs": runtime_state["missing_inputs"],
+            "fallback_to": runtime_state["fallback_to"],
+        }
+    )
+    if runtime_state["result"] != "pass":
+        missing_inputs.extend(str(message) for message in runtime_state.get("missing_inputs", []))
+
+    pr_payload, effective_pr, pr_errors, inferences = load_pr_payload_for_gate(
+        target_root=target_root,
+        owner=owner,
+        repo_name=repo_name,
+        pr_number=pr_number,
+        head_sha=head_sha,
+        branch_name=branch_name,
+        pr_payload_file=pr_payload_file,
+    )
+    if pr_errors:
+        missing_inputs.extend(f"pr: {message}" for message in pr_errors)
+
+    body_item = pr_work_item_from_body(pr_payload.get("body") if isinstance(pr_payload, dict) else None)
+    effective_item = expected_item or body_item
+    if expected_item and body_item and expected_item != body_item:
+        missing_inputs.append(f"PR body Work Item `{body_item}` does not match expected `{expected_item}`")
+    if effective_item is None:
+        missing_inputs.append("PR body is missing `Loom Work Item: <item>`")
+
+    context: dict[str, Any] = {}
+    context_errors: list[str] = []
+    if effective_item is not None:
+        context, context_errors = load_context(target_root, output_relative, effective_item)
+    else:
+        context, context_errors = load_context(target_root, output_relative, expected_item)
+    if context_errors:
+        missing_inputs.extend(f"fact-chain: {message}" for message in context_errors)
+
+    pr_head = head_sha
+    if isinstance(pr_payload, dict) and isinstance(pr_payload.get("headRefOid"), str):
+        if pr_head and pr_payload["headRefOid"] != pr_head:
+            missing_inputs.append("PR payload headRefOid does not match --head-sha")
+        pr_head = pr_payload["headRefOid"]
+    if not pr_head:
+        missing_inputs.append("PR head SHA is unavailable")
+
+    pr_state = pr_payload.get("state") if isinstance(pr_payload, dict) else None
+    if pr_payload is not None:
+        if pr_state not in {"OPEN"}:
+            missing_inputs.append(f"PR state must be OPEN before controlled merge: {pr_state}")
+        if pr_payload.get("isDraft") is True:
+            missing_inputs.append("PR is draft")
+        if context and not pr_body_mentions_item(pr_payload.get("body"), context["item_id"]):
+            missing_inputs.append(f"PR body does not mention Loom Work Item `{context['item_id']}`")
+
+    current_head = git_head_sha(target_root)
+    if pr_head and current_head and pr_head != current_head:
+        missing_inputs.append("checkout head does not match PR head")
+
+    merge_checkpoint: dict[str, Any] = {
+        "result": "block",
+        "summary": "merge checkpoint was not evaluated.",
+        "missing_inputs": ["fact-chain"],
+        "fallback_to": "admission",
+    }
+    review_approval: dict[str, Any] = {
+        "status": "unavailable",
+        "path": None,
+        "decision": None,
+        "reviewed_head": None,
+        "head_binding": None,
+    }
+    if context:
+        merge_checkpoint = checkpoint_payload("merge", context)
+        review_record, review_path, review_errors = load_review_record(target_root, context["item_id"], context["review_entry"])
+        if review_record is None:
+            review_approval = {
+                "status": "missing",
+                "path": review_path,
+                "decision": None,
+                "reviewed_head": None,
+                "head_binding": None,
+                "missing_inputs": review_errors or [f"missing review artifact: {review_path}"],
+            }
+        else:
+            review_approval = {
+                "status": "approved" if review_record.get("decision") == "allow" and not review_errors else "not_approved",
+                "path": review_path,
+                "decision": review_record.get("decision"),
+                "reviewed_head": review_record.get("reviewed_head"),
+                "reviewed_validation_summary": review_record.get("reviewed_validation_summary"),
+                "head_binding": review_record.get("head_binding"),
+                "missing_inputs": review_errors,
+            }
+        if merge_checkpoint.get("result") in {"block", "fallback"}:
+            missing_inputs.extend(str(message) for message in merge_checkpoint.get("missing_inputs", []))
+        steps.append(
+            {
+                "name": "checkpoint-merge",
+                "result": merge_checkpoint.get("result"),
+                "summary": merge_checkpoint.get("summary"),
+                "missing_inputs": merge_checkpoint.get("missing_inputs", []),
+                "fallback_to": merge_checkpoint.get("fallback_to"),
+            }
+        )
+
+    # Make the bypass boundary explicit even when raw evidence is present in the repository.
+    if context:
+        runtime_review_root = target_root / ".loom/runtime/review" / context["item_id"]
+        raw_evidence_present = runtime_review_root.exists() and any(runtime_review_root.glob("**/*"))
+    else:
+        raw_evidence_present = False
+
+    result = "pass"
+    fallback_to: str | None = None
+    for step in steps:
+        if step.get("result") == "fallback":
+            result = "fallback"
+            fallback_to = step.get("fallback_to") or "build"
+            break
+        if step.get("result") == "block" and result == "pass":
+            result = "block"
+            fallback_to = step.get("fallback_to")
+    if missing_inputs and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or "build"
+
+    failure_taxonomy = pr_gate_failure_taxonomy(missing_inputs, result)
+    if raw_evidence_present and review_approval.get("status") != "approved" and "raw_evidence_bypass" not in failure_taxonomy:
+        failure_taxonomy.append("raw_evidence_bypass")
+    return {
+        "command": "pr-gate",
+        "operation": "check",
+        "schema_version": PR_MERGE_GATE_SCHEMA,
+        "result": result,
+        "summary": (
+            "PR merge gate found fresh authored semantic review approval for the current PR head."
+            if result == "pass"
+            else "PR merge gate is blocked or falling back before host merge."
+        ),
+        "missing_inputs": sorted(set(missing_inputs)),
+        "fallback_to": fallback_to,
+        "repository": {"owner": owner, "name": repo_name},
+        "pr": {
+            "number": effective_pr,
+            "state": pr_state,
+            "isDraft": pr_payload.get("isDraft") if isinstance(pr_payload, dict) else None,
+            "headRefName": pr_payload.get("headRefName") if isinstance(pr_payload, dict) else branch_name,
+            "baseRefName": pr_payload.get("baseRefName") if isinstance(pr_payload, dict) else None,
+            "head_sha": pr_head,
+            "url": pr_payload.get("url") if isinstance(pr_payload, dict) else None,
+            "work_item_from_body": body_item,
+        },
+        "work_item": {
+            "id": context.get("item_id") if context else effective_item,
+            "path": relative_to_root(context["work_item_path"], target_root) if context else None,
+            "review_entry": context.get("review_entry") if context else None,
+        },
+        "review_approval": review_approval,
+        "merge_checkpoint": merge_checkpoint,
+        "host_enforcement": {
+            "stable_check_name": PR_MERGE_GATE_CHECK_NAME,
+            "status": "not_checked",
+            "reason": "pr-gate check proves PR-local semantic approval; controlled-merge checks host required status.",
+        },
+        "approval_boundary": {
+            "authored_truth": "work_item.review_entry",
+            "raw_review_evidence_satisfies_approval": False,
+            "shadow_evidence_satisfies_approval": False,
+            "ci_success_satisfies_approval": False,
+            "raw_evidence_present": raw_evidence_present,
+        },
+        "failure_taxonomy": sorted(failure_taxonomy),
+        "steps": steps,
+        "inferences": inferences,
+    }
+
+
+def handle_pr_gate(args: argparse.Namespace) -> int:
+    target_root = Path(args.target).expanduser().resolve()
+    return emit(
+        pr_gate_payload(
+            target_root=target_root,
+            output_relative=args.output,
+            expected_item=args.item,
+            owner=args.owner,
+            repo_name=args.repo_name,
+            pr_number=args.pr,
+            head_sha=args.head_sha,
+            branch_name=args.branch,
+            pr_payload_file=args.pr_payload_file,
+        )
+    )
+
+
+def required_status_contexts_from_protection(payload: Any) -> list[str]:
+    if not isinstance(payload, dict):
+        return []
+    required_status = payload.get("required_status_checks")
+    if not isinstance(required_status, dict):
+        return []
+    contexts = required_status.get("contexts")
+    if isinstance(contexts, list):
+        return [str(context) for context in contexts if isinstance(context, str) and context.strip()]
+    checks = required_status.get("checks")
+    if isinstance(checks, list):
+        return [str(check.get("context")) for check in checks if isinstance(check, dict) and isinstance(check.get("context"), str)]
+    return []
+
+
+def required_status_contexts_from_branch_rules(payload: Any) -> list[str]:
+    rules = payload
+    if isinstance(payload, dict):
+        rules = payload.get("rules") or payload.get("data")
+    if not isinstance(rules, list):
+        return []
+    contexts: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict) or rule.get("type") != "required_status_checks":
+            continue
+        parameters = rule.get("parameters") if isinstance(rule.get("parameters"), dict) else {}
+        checks = parameters.get("required_status_checks")
+        if isinstance(checks, list):
+            for check in checks:
+                if isinstance(check, dict) and isinstance(check.get("context"), str):
+                    contexts.append(check["context"])
+                elif isinstance(check, str):
+                    contexts.append(check)
+        for fallback_key in ("contexts", "required_contexts"):
+            fallback_contexts = parameters.get(fallback_key)
+            if isinstance(fallback_contexts, list):
+                contexts.extend(str(context) for context in fallback_contexts if isinstance(context, str) and context.strip())
+    return sorted(set(contexts))
+
+
+def required_check_status_payload(status_rollup: Any, required_contexts: list[str]) -> dict[str, Any]:
+    runs = status_rollup if isinstance(status_rollup, list) else []
+    by_name: dict[str, list[dict[str, Any]]] = {}
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        name = run.get("name") or run.get("context")
+        if isinstance(name, str):
+            by_name.setdefault(name, []).append(run)
+    missing: list[str] = []
+    pending: list[str] = []
+    failing: list[str] = []
+    for context in required_contexts:
+        entries = by_name.get(context, [])
+        if not entries:
+            missing.append(context)
+            continue
+        if any(entry.get("conclusion") == "SUCCESS" or entry.get("state") == "SUCCESS" for entry in entries):
+            continue
+        if any(entry.get("status") not in {None, "COMPLETED"} for entry in entries):
+            pending.append(context)
+        else:
+            failing.append(context)
+    result = "pass" if not missing and not pending and not failing else "block"
+    return {
+        "result": result,
+        "required_contexts": required_contexts,
+        "missing": missing,
+        "pending": pending,
+        "failing": failing,
+    }
+
+
+def controlled_merge_payload(
+    *,
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    owner: str | None,
+    repo_name: str | None,
+    pr_number: int,
+    head_sha: str | None,
+    merge_method: str,
+    delete_branch: bool,
+    execute: bool,
+    pr_payload_file: str | None,
+    status_checks_file: str | None,
+    branch_protection_file: str | None,
+    ruleset_file: str | None,
+) -> dict[str, Any]:
+    detected_owner, detected_repo = detect_github_repo(target_root)
+    owner = owner or detected_owner
+    repo_name = repo_name or detected_repo
+    pr_gate = pr_gate_payload(
+        target_root=target_root,
+        output_relative=output_relative,
+        expected_item=expected_item,
+        owner=owner,
+        repo_name=repo_name,
+        pr_number=pr_number,
+        head_sha=head_sha,
+        branch_name=None,
+        pr_payload_file=pr_payload_file,
+    )
+    missing_inputs = [f"pr-gate: {message}" for message in pr_gate.get("missing_inputs", [])]
+    result = pr_gate.get("result")
+    fallback_to = pr_gate.get("fallback_to")
+
+    pr_payload = pr_gate.get("pr") if isinstance(pr_gate.get("pr"), dict) else {}
+    base_ref = pr_payload.get("baseRefName") if isinstance(pr_payload, dict) else None
+
+    protection_payload, protection_errors = load_optional_json_fixture(
+        target_root,
+        branch_protection_file,
+        label="branch protection fixture",
+    )
+    if protection_payload is None and not protection_errors and owner and repo_name and isinstance(base_ref, str) and base_ref:
+        protection_payload, protection_errors = gh_rest_json(
+            target_root,
+            f"repos/{owner}/{repo_name}/branches/{quote(base_ref, safe='')}/protection",
+        )
+    if protection_errors:
+        missing_inputs.extend(f"branch protection: {message}" for message in protection_errors)
+
+    ruleset_payload, ruleset_errors = load_optional_json_fixture(
+        target_root,
+        ruleset_file,
+        label="branch rules/ruleset fixture",
+    )
+    if ruleset_payload is None and not ruleset_errors and owner and repo_name and isinstance(base_ref, str) and base_ref:
+        ruleset_payload, ruleset_errors = github_public_rest_list(
+            f"repos/{owner}/{repo_name}/rules/branches/{quote(base_ref, safe='')}",
+        )
+    if ruleset_errors:
+        missing_inputs.extend(f"branch rules/ruleset: {message}" for message in ruleset_errors)
+
+    status_payload, status_errors = load_optional_json_fixture(
+        target_root,
+        status_checks_file,
+        label="status checks fixture",
+    )
+    if status_payload is None and not status_errors:
+        status_payload, status_errors = gh_json(
+            target_root,
+            ["pr", "view", str(pr_number), "--json", "statusCheckRollup"],
+        )
+    if status_errors:
+        missing_inputs.extend(f"status checks: {message}" for message in status_errors)
+
+    protection_contexts = required_status_contexts_from_protection(protection_payload)
+    ruleset_contexts = required_status_contexts_from_branch_rules(ruleset_payload)
+    required_contexts = sorted(set(protection_contexts + ruleset_contexts))
+    required_checks = required_check_status_payload(
+        status_payload.get("statusCheckRollup") if isinstance(status_payload, dict) else status_payload,
+        required_contexts,
+    )
+    if protection_payload is None and ruleset_payload is None:
+        missing_inputs.append("branch protection or ruleset readback is unavailable")
+    if PR_MERGE_GATE_CHECK_NAME not in required_contexts:
+        missing_inputs.append(f"required check `{PR_MERGE_GATE_CHECK_NAME}` is not enforced")
+    if required_checks["result"] != "pass":
+        labels = {"missing": "missing", "pending": "pending", "failing": "failing"}
+        for key in ("missing", "pending", "failing"):
+            for context in required_checks[key]:
+                missing_inputs.append(f"required check `{context}` is {labels[key]}")
+
+    merge_result: dict[str, Any] = {
+        "attempted": False,
+        "executed": False,
+        "dry_run": not execute,
+        "method": merge_method,
+        "delete_branch": delete_branch,
+    }
+    if missing_inputs and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or "merge"
+    if result == "pass" and execute:
+        command = ["gh", "pr", "merge", str(pr_number), f"--{merge_method}"]
+        if delete_branch:
+            command.append("--delete-branch")
+        completed = run_process(command, target_root)
+        merge_result["attempted"] = True
+        merge_result["command"] = command
+        merge_result["returncode"] = completed.returncode
+        merge_result["stdout"] = completed.stdout.strip()
+        merge_result["stderr"] = completed.stderr.strip()
+        if completed.returncode == 0:
+            merge_result["executed"] = True
+        else:
+            result = "block"
+            fallback_to = "merge"
+            missing_inputs.append(completed.stderr.strip() or completed.stdout.strip() or "gh pr merge failed")
+
+    return {
+        "command": "controlled-merge",
+        "operation": "merge" if execute else "check",
+        "schema_version": CONTROLLED_MERGE_SCHEMA,
+        "result": result,
+        "summary": (
+            "controlled merge preconditions passed and host merge was delegated."
+            if result == "pass" and execute
+            else "controlled merge preconditions passed; host merge was not executed."
+            if result == "pass"
+            else "controlled merge is blocked before host merge delegation."
+        ),
+        "missing_inputs": sorted(set(str(message) for message in missing_inputs)),
+        "fallback_to": fallback_to,
+        "repository": {"owner": owner, "name": repo_name},
+        "pr_gate": pr_gate,
+        "required_checks": required_checks,
+        "host_enforcement": {
+            "stable_check_name": PR_MERGE_GATE_CHECK_NAME,
+            "required_contexts": required_contexts,
+            "required": PR_MERGE_GATE_CHECK_NAME in required_contexts,
+            "branch_protection_readable": protection_payload is not None,
+            "branch_protection_required_contexts": protection_contexts,
+            "ruleset_readable": ruleset_payload is not None,
+            "ruleset_required_contexts": ruleset_contexts,
+        },
+        "merge": merge_result,
+    }
+
+
+def handle_controlled_merge(args: argparse.Namespace) -> int:
+    target_root = Path(args.target).expanduser().resolve()
+    return emit(
+        controlled_merge_payload(
+            target_root=target_root,
+            output_relative=args.output,
+            expected_item=args.item,
+            owner=args.owner,
+            repo_name=args.repo_name,
+            pr_number=args.pr,
+            head_sha=args.head_sha,
+            merge_method=args.merge_method,
+            delete_branch=args.delete_branch,
+            execute=args.execute and args.operation == "merge",
+            pr_payload_file=args.pr_payload_file,
+            status_checks_file=args.status_checks_file,
+            branch_protection_file=args.branch_protection_file,
+            ruleset_file=args.ruleset_file,
         )
     )
 
@@ -10278,9 +12854,13 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        current_head = git_head_sha(target_root) or "unknown-head"
+        adapter_selection = select_review_adapter(args, target_root, reviewed_head=current_head)
+        requested_engine_adapter = str(adapter_selection["adapter"])
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
+            adapter=requested_engine_adapter,
             requested_profile=args.engine_profile,
             requested_model=args.engine_model,
             requested_reasoning=args.engine_reasoning,
@@ -10303,14 +12883,15 @@ def handle_review(args: argparse.Namespace) -> int:
                     "missing_inputs": engine_profile_errors,
                     "fallback_to": None,
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -10343,25 +12924,47 @@ def handle_review(args: argparse.Namespace) -> int:
                     "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                     "current_checkpoint": flow_payload.get("current_checkpoint"),
                     "engine": {
-                        "engine": DEFAULT_REVIEW_ENGINE,
-                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "engine": CODEX_APP_REVIEW_ENGINE if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER else DEFAULT_REVIEW_ENGINE,
+                        "adapter": requested_engine_adapter,
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(
+        if requested_engine_adapter == CODEX_APP_REVIEW_ADAPTER:
+            engine_payload = run_codex_app_review_authoritative_adapter(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+                app_server=adapter_selection.get("app_server") if isinstance(adapter_selection.get("app_server"), str) else None,
+                thread_id=adapter_selection.get("thread_id") if isinstance(adapter_selection.get("thread_id"), str) else None,
+                thread_cwd=adapter_selection.get("thread_cwd") if isinstance(adapter_selection.get("thread_cwd"), str) else None,
+                raw_file=adapter_selection.get("raw_file") if isinstance(adapter_selection.get("raw_file"), str) else None,
+                adapter_selection=adapter_selection,
+            )
+        else:
+            engine_payload = run_default_review_engine(
+                context,
+                build_payload,
+                review_path,
+                engine_profile,
+                review_kind=review_kind,
+                adapter_selection=adapter_selection,
+            )
+        shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,
-            build_payload,
-            review_path,
-            engine_profile,
-            review_kind=review_kind,
+            adapter=args.shadow_engine_adapter,
+            raw_file=args.shadow_review_raw_file,
+            default_engine_payload=engine_payload,
         )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
@@ -10379,7 +12982,7 @@ def handle_review(args: argparse.Namespace) -> int:
         summary = (
             engine_payload["summary"]
             if result == "pass"
-            else "default review engine failed closed; record any formal review conclusion through the single review record."
+            else f"{requested_engine_adapter} review engine failed closed; record any formal review conclusion through the single review record."
         )
         return emit(
             {
@@ -10401,6 +13004,8 @@ def handle_review(args: argparse.Namespace) -> int:
                 "repo_specific_requirements": flow_payload.get("repo_specific_requirements"),
                 "current_checkpoint": flow_payload.get("current_checkpoint"),
                 "engine": engine_payload["engine"],
+                **({"engine_metadata": engine_payload["engine_metadata"]} if isinstance(engine_payload.get("engine_metadata"), dict) else {}),
+                **({"shadow_engine": shadow_engine_payload} if isinstance(shadow_engine_payload, dict) else {}),
                 "manual_review": manual_review,
                 **({"review_record_input": review_record_input} if isinstance(review_record_input, dict) else {}),
             }
@@ -12067,6 +14672,111 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 surface=args.surface,
             )
         )
+    if args.operation == "hook-envelope":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-target",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        if not args.envelope:
+            target_root = Path(args.target).expanduser().resolve()
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --envelope.",
+                    "missing_inputs": ["pass --envelope <repo_relative_envelope_path>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(target_root),
+                    "target": live_smoke_target_metadata(target_root),
+                    "command_plan": hook_envelope_command_plan(target_root, envelope=args.envelope),
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-envelope",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(
+            hook_envelope_payload(
+                Path(args.target).expanduser().resolve(),
+                envelope=args.envelope,
+                requirement=args.requirement,
+            )
+        )
+    if args.operation == "hooks-extension":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hooks-extension",
+                    "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+                    "result": "block",
+                    "summary": "hooks extension profile requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hooks-extension", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                    "hooks_extension": {
+                        **empty_hook_extension_profile(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "external-orchestrator-interop":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "external-orchestrator-interop",
+                    "schema_version": EXTERNAL_ORCHESTRATOR_CONFORMANCE_SCHEMA,
+                    "result": "block",
+                    "summary": "external orchestrator conformance requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "external-orchestrator-interop", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "external_orchestrator_enforcement": "not_applicable", "result": "pass"},
+                    "external_orchestrator": {
+                        **empty_external_orchestrator_conformance(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(external_orchestrator_conformance_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)
@@ -12116,6 +14826,10 @@ def main(argv: list[str] | None = None) -> int:
         return handle_carrier(args)
     if args.command == "host-binding":
         return handle_host_binding(args)
+    if args.command == "pr-gate":
+        return handle_pr_gate(args)
+    if args.command == "controlled-merge":
+        return handle_controlled_merge(args)
     if args.command == "runtime-evidence":
         return handle_runtime_evidence(args)
     if args.command == "state-check":

--- a/examples/new-project/.loom/bin/loom_init.py
+++ b/examples/new-project/.loom/bin/loom_init.py
@@ -1317,6 +1317,7 @@ def repo_interface_payload() -> dict[str, object]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/examples/new-project/.loom/bin/loom_status.py
+++ b/examples/new-project/.loom/bin/loom_status.py
@@ -205,6 +205,50 @@ def governance_control_status(
     }
 
 
+def external_orchestrator_consumer_status(
+    *,
+    control_status: dict[str, object],
+    provenance: dict[str, object],
+    recovery_readiness: dict[str, object],
+) -> dict[str, object]:
+    gate_chain = control_status.get("gate_chain")
+    if not isinstance(gate_chain, list):
+        gate_chain = []
+    external_gates = []
+    for gate in gate_chain:
+        if not isinstance(gate, dict):
+            continue
+        external_gates.append(
+            {
+                "name": gate.get("name"),
+                "result": gate.get("result"),
+                "classification": gate.get("classification"),
+                "missing_inputs": gate.get("missing_inputs", []),
+                "fallback_to": gate.get("fallback_to"),
+            }
+        )
+
+    return {
+        "schema_version": control_status.get("schema_version", "loom-governance-status/v2"),
+        "view": "external_orchestrator_consumer",
+        "result": control_status.get("result", "block"),
+        "current_gate": control_status.get("current_gate"),
+        "classifications": control_status.get("classifications", []),
+        "missing_inputs": control_status.get("missing_inputs", []),
+        "head_binding": control_status.get("head_binding", {}),
+        "gate_chain": external_gates,
+        "allowed_operations": ["status_read", "gate_read"],
+        "source_policy": {
+            "status_source": "derived_from_status_control_plane_v2",
+            "gate_source": "derived_from_governance_gate_chain",
+            "writeback": "recovery_entry_only",
+            "fallback_to": "current_checkpoint",
+        },
+        "provenance": provenance,
+        "recovery_readiness": recovery_readiness,
+    }
+
+
 def closeout_status_payload(
     *,
     github_status: dict[str, object],
@@ -535,6 +579,14 @@ def main(argv: list[str]) -> int:
         if result == "pass"
         else "status surface is readable, but one or more governance gates are still blocking or stale."
     )
+    provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    external_orchestrator = external_orchestrator_consumer_status(
+        control_status=control_status,
+        provenance=provenance,
+        recovery_readiness=recovery_readiness,
+    )
+
     return emit(
         {
             "command": "status",
@@ -543,8 +595,8 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
-            "provenance": report_provenance(context["report"]),
-            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "provenance": provenance,
+            "recovery_readiness": recovery_readiness,
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
@@ -586,6 +638,7 @@ def main(argv: list[str]) -> int:
             "ci_check_presence": ci_check_presence,
             "host_enforcement": host_enforcement,
             "governance_status": control_status,
+            "external_orchestrator": external_orchestrator,
             "governance_surface": governance_surface,
             "github": github_status,
         }

--- a/examples/new-project/.loom/bin/runtime_state.py
+++ b/examples/new-project/.loom/bin/runtime_state.py
@@ -279,6 +279,7 @@ def _validate_referenced_resources(skills_root: Path) -> tuple[dict[str, Any], l
         "shared/references/harness/runtime-state.md",
         "shared/references/harness/gate-chain.md",
         "shared/references/harness/controlled-merge.md",
+        "shared/references/harness/pr-merge-gate.md",
         "shared/references/harness/governance-failure-taxonomy.md",
         "shared/references/governance/governance-maturity-model.md",
         "shared/references/adoption/github-profile-upgrade.md",

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -462,8 +462,8 @@
         "source": "repo companion manifest.repo_interface"
       },
       "hook_locators": {
-        "status": "missing",
-        "locator": "unknown",
+        "status": "present",
+        "locator": ".loom/companion/repo-interface.json",
         "source": "repo companion interface"
       },
       "release_targets": {
@@ -615,10 +615,10 @@
       "hook_profile": {
         "schema_version": "loom-hooks-extension-profile/v1",
         "profile_id": "orchestration-extension/hooks",
-        "enabled": false,
+        "enabled": true,
         "result": "pass",
-        "status": "not_applicable",
-        "summary": "hooks extension profile is not enabled for this repository.",
+        "status": "present",
+        "summary": "hooks extension profile is enabled and hook declarations are safe.",
         "missing_inputs": [],
         "missing_optional": [],
         "checks": []

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -113,7 +113,7 @@
       "path": ".loom/bin/loom_init.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_init.py",
-      "sha256": "b90ef7fd44d5a85293adb1b8612be1661b8ad7c1fc0839fb7e84b8033ba14ab2"
+      "sha256": "606562d90aaf13dd07fc181311ae67133e3b3775503f6f41f7798b5e530c2b53"
     },
     {
       "path": ".loom/bin/fact_chain_support.py",
@@ -125,19 +125,19 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "74e79241be3580b532b6f94e8b2ec92c4bbc2ed544da56ba1e2b10b2c4c761c9"
+      "sha256": "bd4ba5a3dd0fa02fec634af94479e0290c1beaa8802002d93b60830192d4ae0e"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "396de1848b81471ec3f4c13b608b97cfb267e7e972bb38b64b14302f8707eeac"
+      "sha256": "3338d1f304cb641b6ccafc5d24ed25c3cae3d208eca2a11a5a4293b52d6ccb27"
     },
     {
       "path": ".loom/bin/loom_status.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_status.py",
-      "sha256": "ba8689ff47e4cb22fd44ea5d0042166af380d671673b9215ce6cfc4d558254bf"
+      "sha256": "31bbe5965183bf9458fccde49230a0f8d918b319088937b322c0c04a68edb948"
     },
     {
       "path": ".loom/bin/runtime_paths.py",
@@ -149,13 +149,13 @@
       "path": ".loom/bin/runtime_state.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/runtime_state.py",
-      "sha256": "e4de653a5206269faa731808a0f44667a7db811053b8488e8b61a6393917815b"
+      "sha256": "049d7bc65bb1cdd25359ccf93b9b43ff2b02bd899309d2a92a317147bda7dcc4"
     },
     {
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "ecd391d04d0c2d5ac2c3ea66148ec5263a6fcca0d79387709a377ae4deb92c38"
+      "sha256": "2e749d12ac01328ea1a7aa5c95c6c69b6432dbbef2f928f22545224c25cfe231"
     },
     {
       "path": "AGENTS.md",
@@ -351,7 +351,8 @@
         "py-compile",
         "demo-bootstrap",
         "repo-local-cli",
-        "loom-check"
+        "loom-check",
+        "loom-pr-merge-gate"
       ],
       "pr_reviews": "not_required",
       "rulesets": {
@@ -459,6 +460,11 @@
         "status": "present",
         "locator": ".loom/companion/repo-interface.json",
         "source": "repo companion manifest.repo_interface"
+      },
+      "hook_locators": {
+        "status": "missing",
+        "locator": "unknown",
+        "source": "repo companion interface"
       },
       "release_targets": {
         "availability": "present",
@@ -606,6 +612,17 @@
         "missing_inputs": [],
         "fallback_to": null
       },
+      "hook_profile": {
+        "schema_version": "loom-hooks-extension-profile/v1",
+        "profile_id": "orchestration-extension/hooks",
+        "enabled": false,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "hooks extension profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": []
+      },
       "summary": "repo companion manifest and machine-readable repo interface are readable.",
       "missing_inputs": [],
       "missing_optional": []
@@ -632,7 +649,12 @@
         "locator": ".loom/companion/interop.json",
         "source": "repo interop contract"
       },
-      "summary": "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity.",
+      "external_orchestrators": {
+        "status": "present",
+        "locator": ".loom/companion/interop.json",
+        "source": "repo interop contract"
+      },
+      "summary": "repo interop contract is readable for host adapters, repo-native carriers, shadow parity, and external orchestrator locators.",
       "missing_inputs": [],
       "missing_optional": []
     },

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -35,7 +35,7 @@
       "path": ".loom/bin/loom_init.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_init.py",
-      "sha256": "b90ef7fd44d5a85293adb1b8612be1661b8ad7c1fc0839fb7e84b8033ba14ab2"
+      "sha256": "606562d90aaf13dd07fc181311ae67133e3b3775503f6f41f7798b5e530c2b53"
     },
     {
       "path": ".loom/bin/fact_chain_support.py",
@@ -47,19 +47,19 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "74e79241be3580b532b6f94e8b2ec92c4bbc2ed544da56ba1e2b10b2c4c761c9"
+      "sha256": "bd4ba5a3dd0fa02fec634af94479e0290c1beaa8802002d93b60830192d4ae0e"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "396de1848b81471ec3f4c13b608b97cfb267e7e972bb38b64b14302f8707eeac"
+      "sha256": "3338d1f304cb641b6ccafc5d24ed25c3cae3d208eca2a11a5a4293b52d6ccb27"
     },
     {
       "path": ".loom/bin/loom_status.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_status.py",
-      "sha256": "ba8689ff47e4cb22fd44ea5d0042166af380d671673b9215ce6cfc4d558254bf"
+      "sha256": "31bbe5965183bf9458fccde49230a0f8d918b319088937b322c0c04a68edb948"
     },
     {
       "path": ".loom/bin/runtime_paths.py",
@@ -71,13 +71,13 @@
       "path": ".loom/bin/runtime_state.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/runtime_state.py",
-      "sha256": "e4de653a5206269faa731808a0f44667a7db811053b8488e8b61a6393917815b"
+      "sha256": "049d7bc65bb1cdd25359ccf93b9b43ff2b02bd899309d2a92a317147bda7dcc4"
     },
     {
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "ecd391d04d0c2d5ac2c3ea66148ec5263a6fcca0d79387709a377ae4deb92c38"
+      "sha256": "2e749d12ac01328ea1a7aa5c95c6c69b6432dbbef2f928f22545224c25cfe231"
     },
     {
       "path": "AGENTS.md",

--- a/examples/new-project/.loom/companion/repo-interface.json
+++ b/examples/new-project/.loom/companion/repo-interface.json
@@ -25,6 +25,7 @@
   },
   "dynamic_tool_locators": [],
   "policy_locators": [],
+  "hook_locators": [],
   "release_targets": {
     "catalog_locator": ".loom/companion/releases/catalog.json",
     "current_target_locator": ".loom/companion/releases/current.json",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.107",
+  "version": "0.1.108",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.107",
+      "version": "0.1.108",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.107",
+  "version": "0.1.108",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-adopt/.loom-runtime/loom-review/SKILL.md
@@ -42,9 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 选择安全的 authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
 
-默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
+已验证 Codex App host context 中，默认 `review run` 使用 `loom/codex-app-review`，并必须证明 app-server/session locator、thread id、cwd proof、target root 与 reviewed head 绑定一致；该路径不得启动嵌套 `codex exec`。`CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex` + `codex exec --output-schema`。proof 冲突、cwd / target / head 不匹配或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -54,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 
@@ -75,7 +75,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - review 机械基线结果
 - build gate 是否允许进入正式审查
 - review artifact 的定位与已记录结论
-- 默认 engine 的执行结果、evidence 定位与 fail-closed 原因
+- selected adapter、fallback reason、thread/target binding summary、reviewed head、evidence 定位与 fail-closed 原因
 - manual review 的回退写回入口
 - review record 中的权威 findings / disposition 摘要
 - 审查结论（`allow` / `block` / `fallback`）

--- a/skills/loom-adopt/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-adopt/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,7 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
-- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/review-execution.md
@@ -21,7 +21,7 @@ Loom 把 review 分成四层：
 1. `flow review`
    - 只读基线；确认是否具备进入 formal review 的条件
 2. `review run`
-   - 调用默认 Codex-backed reviewer，产出结构化 review evidence 与 Loom-normalized findings
+   - 按宿主 proof 选择 authoritative adapter，产出结构化 review evidence 与 Loom-normalized findings
 3. `review record`
    - 把 formal review 结论写入单一 authored review record
 
@@ -47,27 +47,33 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责选择安全的 authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
+默认 engine 按宿主 proof 选择：
+
+- 已验证 Codex App host context 默认选择 `loom/codex-app-review`，不启动嵌套 `codex exec`
+- `CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex`，能力来源仍是 `codex exec --output-schema`
+- 显式 `--engine-adapter` 优先级最高，继续保留 Stage 2 authoritative opt-in / fallback 调试入口
+
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-Codex App review adapter 有两种显式入口，默认均不启用：
+Codex App review adapter 有三种入口：
 
-- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
-- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- verified host default：不传 `--engine-adapter`，但必须能证明 app-server/session locator、thread id、thread cwd、target root 与 reviewed head 绑定一致
+- explicit authoritative：显式选择 `review run --engine-adapter loom/codex-app-review`，用于调试或非默认宿主
+- shadow comparison：显式选择 `review run --shadow-engine-adapter loom/codex-app-review`
 - shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
-- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
-- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
-- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof；live app-server unavailable 时默认 fallback 到 `loom/default-codex`
+- thread cwd proof 必须等于 target root；cwd / target / reviewed head 绑定冲突或 schema proof 失败时必须 fail closed
 - authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
 - authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
+- `engine_metadata` 必须记录 selected adapter、selection source、fallback reason、thread/target binding summary、reviewed head 与 evidence locators
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
@@ -77,8 +83,8 @@ Codex App review adapter 有两种显式入口，默认均不启用：
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
-- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
+- `adapter`: `loom/default-codex` 或 verified/explicit `loom/codex-app-review`
+- `engine`: `codex` 或 verified/explicit `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -3126,6 +3126,19 @@ def require_review_run_payload(
                 for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
                     if not isinstance(evidence.get(key), str) or not evidence.get(key):
                         failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
+    engine_metadata = payload.get("engine_metadata")
+    if engine_adapter == "loom/codex-app-review" and engine.get("result") == "pass":
+        if not isinstance(engine_metadata, dict):
+            failures.append(Failure(category, f"{context} app review pass must expose `engine_metadata`"))
+        else:
+            for key in ("selected_adapter", "selection_source", "app_server", "thread_id", "thread_cwd", "raw_result", "normalized_findings", "context_pack", "reviewed_head"):
+                value = engine_metadata.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} app review metadata must include non-empty `{key}`"))
+            if engine_metadata.get("selected_adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} app review metadata must bind the selected adapter"))
+            if "normalized review_record_input only" not in str(engine_metadata.get("authority_boundary", "")):
+                failures.append(Failure(category, f"{context} app review metadata must keep raw App output outside merge-ready truth"))
 
 
 def require_runtime_state_payload(
@@ -5725,7 +5738,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
 
         prepare_review_target(review_target, "review run positive chain")
         write_fake_codex(fake_bin / "codex", mode="success")
-        success_env = prepend_path_env(fake_bin)
+        success_env = prepend_path_env(fake_bin, {"CI": "", "CODEX_CI": ""})
 
         payload, error = load_command_json(
             root,
@@ -5893,6 +5906,217 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_default_target = Path(tmp) / "review-run-codex-app-default"
+        prepare_review_target(app_default_target, "review run Codex App host default")
+        app_default_raw = app_default_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_default_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_default_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App default reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-default-warn-1",
+                            "summary": "Codex App default review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_default_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-default-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-default-proof",
+                "--codex-app-review-cwd",
+                str(app_default_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App host default failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App host default",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("adapter") != "loom/codex-app-review" or engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must select the app adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review" or review_record_input.get("reviewer") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must author app adapter review_record_input"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("selection_source") != "codex-app-host-default" or metadata.get("thread_id") != "thread-stage3-default-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must expose selected adapter and thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_default_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored default app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume default Codex App raw evidence before review record is authored"))
+
+        app_ci_fallback_target = Path(tmp) / "review-run-codex-app-ci-fallback"
+        prepare_review_target(app_ci_fallback_target, "review run Codex App CI fallback")
+        app_ci_raw = app_ci_fallback_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_ci_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_ci_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_ci_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-ci-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-ci-proof",
+                "--codex-app-review-cwd",
+                str(app_ci_fallback_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=prepend_path_env(fake_bin, {"CODEX_CI": "1"}),
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App CI fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App CI fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "ci-or-codex-ci":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App CI fallback must keep the default codex exec adapter"))
+
+        app_unavailable_fallback_target = Path(tmp) / "review-run-codex-app-unavailable-fallback"
+        prepare_review_target(app_unavailable_fallback_target, "review run Codex App unavailable fallback")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_unavailable_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                f"unix://{tmp}/missing-codex-app.sock",
+                "--codex-app-review-thread-id",
+                "thread-stage3-missing-endpoint",
+                "--codex-app-review-cwd",
+                str(app_unavailable_fallback_target),
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App unavailable fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App unavailable fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "app-server-unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App unavailable fallback must record default adapter fallback"))
+
+        app_conflict_target = Path(tmp) / "review-run-codex-app-proof-conflict"
+        prepare_review_target(app_conflict_target, "review run Codex App proof conflict")
+        app_conflict_raw = app_conflict_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_conflict_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_conflict_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_conflict_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-conflict-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-conflict-proof",
+                "--codex-app-review-cwd",
+                str(Path(tmp) / "different-cwd"),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App proof conflict failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must fail closed"))
+        else:
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            if engine.get("adapter") != "loom/codex-app-review" or engine.get("failure_reason") != "runtime_conflict":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not fallback to default codex"))
+            if "does not match target root" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must expose cwd mismatch"))
+            if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not emit review_record_input"))
 
         app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
         prepare_review_target(app_authoritative_target, "review run Codex App authoritative")

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,6 +118,10 @@ CODEX_APP_REVIEW_ENGINE = "codex-app-review"
 CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
 AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
+CODEX_APP_REVIEW_ENDPOINT_ENV = "LOOM_CODEX_APP_REVIEW_ENDPOINT"
+CODEX_APP_REVIEW_THREAD_ID_ENV = "LOOM_CODEX_APP_REVIEW_THREAD_ID"
+CODEX_APP_REVIEW_CWD_ENV = "LOOM_CODEX_APP_REVIEW_CWD"
+CODEX_THREAD_ID_ENV = "CODEX_THREAD_ID"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS: int | None = None
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -492,26 +496,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
         help=(
             "Optional authoritative review engine adapter for review run/record. "
-            "Default review run remains loom/default-codex."
+            "When omitted, verified Codex App sessions use loom/codex-app-review; headless/CI fallback remains loom/default-codex."
         ),
     )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
     review.add_argument(
         "--codex-app-review-app-server",
-        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App app-server/session locator. Defaults to ${CODEX_APP_REVIEW_ENDPOINT_ENV} when available.",
     )
     review.add_argument(
         "--codex-app-review-thread-id",
-        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread id. Defaults to ${CODEX_APP_REVIEW_THREAD_ID_ENV}, or ${CODEX_THREAD_ID_ENV} when an endpoint is present.",
     )
     review.add_argument(
         "--codex-app-review-cwd",
-        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread cwd proof. Defaults to ${CODEX_APP_REVIEW_CWD_ENV}.",
     )
     review.add_argument(
         "--codex-app-review-raw-file",
-        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+        help="Optional repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
     )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
@@ -4250,6 +4254,19 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def truthy_env(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def non_empty_str(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def execution_attempt_directory(target_root: Path, item_id: str) -> Path:
     return target_root / ".loom/runtime/attempts" / item_id
 
@@ -6264,8 +6281,26 @@ def run_default_review_engine(
     engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "explicit-or-legacy-default",
+            "fallback_reason": None,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=None,
+                thread_id=None,
+                thread_cwd=None,
+                reviewed_head=reviewed_head,
+                raw_file=None,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     prompt_path = runtime_root / "prompt.txt"
     result_path = runtime_root / "engine-result.json"
@@ -6313,6 +6348,7 @@ def run_default_review_engine(
                     "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
+            "engine_metadata": selection_metadata,
         }
 
     scratch_dir.mkdir(parents=True, exist_ok=True)
@@ -6403,6 +6439,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
@@ -6424,6 +6461,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     if raw_payload is not None and not result_path.exists():
@@ -6440,6 +6478,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
@@ -6462,6 +6501,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     write_json_file(findings_path, {"findings": normalized_payload["findings"]})
@@ -6471,6 +6511,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
@@ -6494,6 +6535,13 @@ def run_default_review_engine(
             "failure_reason": None,
             "reviewed_head": reviewed_head,
             "evidence": engine_evidence,
+        },
+        "engine_metadata": {
+            **selection_metadata,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "raw_result": relative_to_root(result_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "metadata": relative_to_root(metadata_path, context["target_root"]),
         },
         "review_record_input": {
             "decision": normalized_payload["decision"],
@@ -7254,6 +7302,312 @@ def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: st
     return normalized, []
 
 
+def codex_app_endpoint_socket_path(app_server: str | None) -> Path | None:
+    endpoint = non_empty_str(app_server)
+    if endpoint is None:
+        return None
+    if endpoint.startswith("unix://"):
+        path_text = endpoint.removeprefix("unix://")
+    elif endpoint.startswith("/"):
+        path_text = endpoint
+    else:
+        return None
+    if not path_text:
+        return None
+    return Path(path_text).expanduser()
+
+
+def codex_app_endpoint_is_live_capable(app_server: str | None) -> bool:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    return socket_path is not None and socket_path.exists()
+
+
+def codex_app_review_bindings_from_args_env(args: argparse.Namespace) -> dict[str, str | None]:
+    app_server = non_empty_str(args.codex_app_review_app_server) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_ENDPOINT_ENV))
+    thread_id = (
+        non_empty_str(args.codex_app_review_thread_id)
+        or non_empty_str(os.environ.get(CODEX_APP_REVIEW_THREAD_ID_ENV))
+        or (non_empty_str(os.environ.get(CODEX_THREAD_ID_ENV)) if app_server else None)
+    )
+    thread_cwd = non_empty_str(args.codex_app_review_cwd) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_CWD_ENV))
+    raw_file = non_empty_str(args.codex_app_review_raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": thread_cwd,
+        "raw_file": raw_file,
+    }
+
+
+def codex_app_binding_summary(
+    target_root: Path,
+    *,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    reviewed_head: str,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    cwd_match: bool | None = None
+    cwd_summary: str | None = thread_cwd
+    if non_empty_str(thread_cwd):
+        try:
+            cwd_path = Path(str(thread_cwd)).expanduser().resolve()
+        except OSError:
+            cwd_match = False
+        else:
+            cwd_match = cwd_path == target_root
+            cwd_summary = str(cwd_path)
+    raw_source: str | None = None
+    if non_empty_str(raw_file):
+        raw_path, raw_errors = resolve_repo_relative_path(target_root, str(raw_file), label="Codex App authoritative review raw file")
+        if raw_path is not None and not raw_errors:
+            raw_source = relative_to_root(raw_path, target_root)
+        else:
+            raw_source = str(raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_summary,
+        "thread_cwd_matches_target_root": cwd_match,
+        "target_root": str(target_root),
+        "reviewed_head": reviewed_head,
+        "raw_source": raw_source,
+        "live_endpoint_capable": codex_app_endpoint_is_live_capable(app_server),
+    }
+
+
+def select_review_adapter(
+    args: argparse.Namespace,
+    target_root: Path,
+    *,
+    reviewed_head: str,
+) -> dict[str, Any]:
+    bindings = codex_app_review_bindings_from_args_env(args)
+    explicit_adapter = non_empty_str(args.engine_adapter)
+    if explicit_adapter:
+        return {
+            "adapter": explicit_adapter,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    if truthy_env("CI") or truthy_env("CODEX_CI"):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "headless-fallback",
+            "fallback_reason": "ci-or-codex-ci",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    app_server = bindings["app_server"]
+    thread_id = bindings["thread_id"]
+    thread_cwd = bindings["thread_cwd"]
+    raw_file = bindings["raw_file"]
+    if not app_server or not thread_id or not thread_cwd:
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "missing-codex-app-host-proof",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    if not raw_file and not codex_app_endpoint_is_live_capable(app_server):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "app-server-unavailable",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    return {
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "selection_source": "codex-app-host-default",
+        "fallback_reason": None,
+        **bindings,
+        "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+    }
+
+
+def review_adapter_selection_metadata(selection: dict[str, Any], *, reviewed_head: str) -> dict[str, Any]:
+    return {
+        "selected_adapter": selection["adapter"],
+        "selection_source": selection.get("selection_source"),
+        "fallback_reason": selection.get("fallback_reason"),
+        "app_server": selection.get("app_server"),
+        "thread_id": selection.get("thread_id"),
+        "thread_cwd": selection.get("thread_cwd"),
+        "target_root": selection.get("binding_summary", {}).get("target_root")
+        if isinstance(selection.get("binding_summary"), dict)
+        else None,
+        "reviewed_head": reviewed_head,
+        "thread_target_binding": selection.get("binding_summary"),
+    }
+
+
+def jsonrpc_send_request(stdin: Any, *, request_id: int, method: str, params: dict[str, Any]) -> None:
+    stdin.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}) + "\n")
+    stdin.flush()
+
+
+def jsonrpc_read_response(stdout: Any, *, request_id: int) -> tuple[dict[str, Any] | None, list[dict[str, Any]], list[str]]:
+    notifications: list[dict[str, Any]] = []
+    while True:
+        line = stdout.readline()
+        if not line:
+            return None, notifications, [f"app-server closed before response id {request_id}"]
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("id") == request_id:
+            return payload, notifications, []
+        notifications.append(payload)
+
+
+def find_exited_review_text(payload: Any) -> str | None:
+    if isinstance(payload, dict):
+        if payload.get("type") == "exitedReviewMode" and isinstance(payload.get("review"), str):
+            return payload["review"]
+        for value in payload.values():
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    return None
+
+
+def find_normalized_review_payload(payload: Any) -> dict[str, Any] | None:
+    normalized, errors = normalize_engine_review_result(payload, relative="app-server turn/start output")
+    if normalized is not None and not errors:
+        return normalized
+    if isinstance(payload, dict):
+        for value in payload.values():
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    return None
+
+
+def app_server_proxy_command(app_server: str) -> list[str] | None:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    if socket_path is None:
+        return None
+    return ["codex", "app-server", "proxy", "--sock", str(socket_path)]
+
+
+def run_codex_app_live_review(
+    *,
+    app_server: str,
+    thread_id: str,
+    reviewed_head: str,
+    thread_cwd: str,
+    prompt_text: str,
+) -> tuple[str | None, dict[str, Any], list[str]]:
+    command = app_server_proxy_command(app_server)
+    if command is None:
+        return None, {}, [f"unsupported Codex App review endpoint: {app_server}"]
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return None, {}, [f"Codex App review endpoint is unavailable: {exc}"]
+    assert process.stdin is not None
+    assert process.stdout is not None
+    metadata: dict[str, Any] = {"review_target": {"type": "commit", "sha": reviewed_head}}
+    try:
+        jsonrpc_send_request(process.stdin, request_id=1, method="initialize", params={"clientInfo": {"name": "loom", "version": "stage3"}, "capabilities": {}})
+        initialize_response, _, initialize_errors = jsonrpc_read_response(process.stdout, request_id=1)
+        if initialize_errors:
+            return None, metadata, initialize_errors
+        if isinstance(initialize_response, dict) and isinstance(initialize_response.get("error"), dict):
+            return None, metadata, [f"Codex App initialize failed: {initialize_response['error']}"]
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=2,
+            method="review/start",
+            params={
+                "threadId": thread_id,
+                "delivery": "inline",
+                "target": {"type": "commit", "sha": reviewed_head},
+            },
+        )
+        review_response, review_notifications, review_errors = jsonrpc_read_response(process.stdout, request_id=2)
+        if review_errors:
+            return None, metadata, review_errors
+        if isinstance(review_response, dict) and isinstance(review_response.get("error"), dict):
+            return None, metadata, [f"Codex App review/start failed: {review_response['error']}"]
+        result = review_response.get("result") if isinstance(review_response, dict) else None
+        if isinstance(result, dict):
+            metadata["review_thread_id"] = result.get("reviewThreadId")
+        review_text = find_exited_review_text(result) or find_exited_review_text(review_notifications)
+        if not isinstance(review_text, str) or not review_text.strip():
+            return None, metadata, ["Codex App review/start did not return exitedReviewMode.review"]
+
+        parsed_review, parsed_errors = normalize_authoritative_codex_app_review_text(review_text, relative="app-server review/start output")
+        if parsed_review is not None and not parsed_errors:
+            metadata["normalization_source"] = "review-start-json"
+            return review_text, {**metadata, "normalized": parsed_review}, []
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=3,
+            method="turn/start",
+            params={
+                "threadId": metadata.get("review_thread_id") or thread_id,
+                "cwd": thread_cwd,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Normalize this Codex App review output into the provided JSON schema. "
+                            "Return only the structured review result.\n\n"
+                            f"{review_text}"
+                        ),
+                    }
+                ],
+                "outputSchema": load_json_file(review_engine_schema_path()),
+            },
+        )
+        turn_response, turn_notifications, turn_errors = jsonrpc_read_response(process.stdout, request_id=3)
+        if turn_errors:
+            return review_text, metadata, turn_errors
+        if isinstance(turn_response, dict) and isinstance(turn_response.get("error"), dict):
+            return review_text, metadata, [f"Codex App turn/start normalization failed: {turn_response['error']}"]
+        normalized = find_normalized_review_payload(turn_response.get("result") if isinstance(turn_response, dict) else None)
+        if normalized is None:
+            normalized = find_normalized_review_payload(turn_notifications)
+        if normalized is None:
+            return review_text, metadata, ["Codex App turn/start did not return a Loom review result"]
+        metadata["normalization_source"] = "turn-start-output-schema"
+        return review_text, {**metadata, "normalized": normalized}, []
+    finally:
+        try:
+            process.terminate()
+        except OSError:
+            pass
+
+
 def shadow_adapter_slug(adapter: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
 
@@ -7453,8 +7807,30 @@ def run_codex_app_review_authoritative_adapter(
     thread_id: str | None,
     thread_cwd: str | None,
     raw_file: str | None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            "app_server": app_server,
+            "thread_id": thread_id,
+            "thread_cwd": thread_cwd,
+            "raw_file": raw_file,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=app_server,
+                thread_id=thread_id,
+                thread_cwd=thread_cwd,
+                reviewed_head=reviewed_head,
+                raw_file=raw_file,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     raw_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
@@ -7488,7 +7864,6 @@ def run_codex_app_review_authoritative_adapter(
         ("--codex-app-review-app-server", app_server),
         ("--codex-app-review-thread-id", thread_id),
         ("--codex-app-review-cwd", thread_cwd),
-        ("--codex-app-review-raw-file", raw_file),
     ):
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(label)
@@ -7518,6 +7893,8 @@ def run_codex_app_review_authoritative_adapter(
         missing_inputs.extend(source_errors)
         if source_path is not None:
             source_relative = relative_to_root(source_path, context["target_root"])
+    elif not codex_app_endpoint_is_live_capable(app_server):
+        missing_inputs.append("--codex-app-review-raw-file or live app-server endpoint")
 
     if missing_inputs:
         write_json_file(
@@ -7527,6 +7904,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "runtime_conflict",
@@ -7553,6 +7931,7 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative or thread_cwd,
@@ -7560,17 +7939,30 @@ def run_codex_app_review_authoritative_adapter(
             },
         }
 
-    try:
-        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
-    except OSError as exc:
-        raw_text = ""
-        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
-        normalized = None
+    live_metadata: dict[str, Any] = {}
+    if source_path is not None:
+        try:
+            raw_text = source_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raw_text = ""
+            normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+            normalized = None
+        else:
+            normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+                raw_text,
+                relative=source_relative or str(raw_file),
+            )
     else:
-        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
-            raw_text,
-            relative=source_relative or str(raw_file),
+        raw_text, live_metadata, normalization_errors = run_codex_app_live_review(
+            app_server=str(app_server),
+            thread_id=str(thread_id),
+            reviewed_head=reviewed_head,
+            thread_cwd=str(thread_cwd),
+            prompt_text=instructions_path.read_text(encoding="utf-8"),
         )
+        normalized = live_metadata.get("normalized") if isinstance(live_metadata.get("normalized"), dict) else None
+        if raw_text is None:
+            raw_text = ""
 
     if normalization_errors or normalized is None:
         if raw_text:
@@ -7582,6 +7974,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "schema_drift",
@@ -7592,6 +7985,7 @@ def run_codex_app_review_authoritative_adapter(
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         )
         return {
@@ -7609,10 +8003,12 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         }
 
@@ -7623,6 +8019,7 @@ def run_codex_app_review_authoritative_adapter(
         "engine": CODEX_APP_REVIEW_ENGINE,
         "adapter": CODEX_APP_REVIEW_ADAPTER,
         "profile": engine_profile,
+        **selection_metadata,
         "context_pack": relative_to_root(context_pack_path, context["target_root"]),
         "result": "pass",
         "reviewed_head": reviewed_head,
@@ -7634,6 +8031,11 @@ def run_codex_app_review_authoritative_adapter(
         "thread_id": thread_id,
         "thread_cwd": cwd_relative,
         "raw_source": source_relative,
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "review_thread_id": live_metadata.get("review_thread_id") if live_metadata else (thread_id if source_path is not None else None),
+        **({"live_review": {key: value for key, value in live_metadata.items() if key != "normalized"}} if live_metadata else {}),
         "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
     }
     write_json_file(metadata_path, metadata)
@@ -12452,7 +12854,9 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
-        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
+        current_head = git_head_sha(target_root) or "unknown-head"
+        adapter_selection = select_review_adapter(args, target_root, reviewed_head=current_head)
+        requested_engine_adapter = str(adapter_selection["adapter"])
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
@@ -12484,9 +12888,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12524,9 +12929,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12539,10 +12945,11 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
-                app_server=args.codex_app_review_app_server,
-                thread_id=args.codex_app_review_thread_id,
-                thread_cwd=args.codex_app_review_cwd,
-                raw_file=args.codex_app_review_raw_file,
+                app_server=adapter_selection.get("app_server") if isinstance(adapter_selection.get("app_server"), str) else None,
+                thread_id=adapter_selection.get("thread_id") if isinstance(adapter_selection.get("thread_id"), str) else None,
+                thread_cwd=adapter_selection.get("thread_cwd") if isinstance(adapter_selection.get("thread_cwd"), str) else None,
+                raw_file=adapter_selection.get("raw_file") if isinstance(adapter_selection.get("raw_file"), str) else None,
+                adapter_selection=adapter_selection,
             )
         else:
             engine_payload = run_default_review_engine(
@@ -12551,6 +12958,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
+                adapter_selection=adapter_selection,
             )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,

--- a/skills/loom-build/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-build/.loom-runtime/loom-review/SKILL.md
@@ -42,9 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 选择安全的 authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
 
-默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
+已验证 Codex App host context 中，默认 `review run` 使用 `loom/codex-app-review`，并必须证明 app-server/session locator、thread id、cwd proof、target root 与 reviewed head 绑定一致；该路径不得启动嵌套 `codex exec`。`CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex` + `codex exec --output-schema`。proof 冲突、cwd / target / head 不匹配或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -54,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 
@@ -75,7 +75,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - review 机械基线结果
 - build gate 是否允许进入正式审查
 - review artifact 的定位与已记录结论
-- 默认 engine 的执行结果、evidence 定位与 fail-closed 原因
+- selected adapter、fallback reason、thread/target binding summary、reviewed head、evidence 定位与 fail-closed 原因
 - manual review 的回退写回入口
 - review record 中的权威 findings / disposition 摘要
 - 审查结论（`allow` / `block` / `fallback`）

--- a/skills/loom-build/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-build/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,7 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
-- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-build/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/review-execution.md
@@ -21,7 +21,7 @@ Loom 把 review 分成四层：
 1. `flow review`
    - 只读基线；确认是否具备进入 formal review 的条件
 2. `review run`
-   - 调用默认 Codex-backed reviewer，产出结构化 review evidence 与 Loom-normalized findings
+   - 按宿主 proof 选择 authoritative adapter，产出结构化 review evidence 与 Loom-normalized findings
 3. `review record`
    - 把 formal review 结论写入单一 authored review record
 
@@ -47,27 +47,33 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责选择安全的 authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
+默认 engine 按宿主 proof 选择：
+
+- 已验证 Codex App host context 默认选择 `loom/codex-app-review`，不启动嵌套 `codex exec`
+- `CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex`，能力来源仍是 `codex exec --output-schema`
+- 显式 `--engine-adapter` 优先级最高，继续保留 Stage 2 authoritative opt-in / fallback 调试入口
+
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-Codex App review adapter 有两种显式入口，默认均不启用：
+Codex App review adapter 有三种入口：
 
-- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
-- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- verified host default：不传 `--engine-adapter`，但必须能证明 app-server/session locator、thread id、thread cwd、target root 与 reviewed head 绑定一致
+- explicit authoritative：显式选择 `review run --engine-adapter loom/codex-app-review`，用于调试或非默认宿主
+- shadow comparison：显式选择 `review run --shadow-engine-adapter loom/codex-app-review`
 - shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
-- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
-- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
-- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof；live app-server unavailable 时默认 fallback 到 `loom/default-codex`
+- thread cwd proof 必须等于 target root；cwd / target / reviewed head 绑定冲突或 schema proof 失败时必须 fail closed
 - authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
 - authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
+- `engine_metadata` 必须记录 selected adapter、selection source、fallback reason、thread/target binding summary、reviewed head 与 evidence locators
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
@@ -77,8 +83,8 @@ Codex App review adapter 有两种显式入口，默认均不启用：
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
-- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
+- `adapter`: `loom/default-codex` 或 verified/explicit `loom/codex-app-review`
+- `engine`: `codex` 或 verified/explicit `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -3126,6 +3126,19 @@ def require_review_run_payload(
                 for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
                     if not isinstance(evidence.get(key), str) or not evidence.get(key):
                         failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
+    engine_metadata = payload.get("engine_metadata")
+    if engine_adapter == "loom/codex-app-review" and engine.get("result") == "pass":
+        if not isinstance(engine_metadata, dict):
+            failures.append(Failure(category, f"{context} app review pass must expose `engine_metadata`"))
+        else:
+            for key in ("selected_adapter", "selection_source", "app_server", "thread_id", "thread_cwd", "raw_result", "normalized_findings", "context_pack", "reviewed_head"):
+                value = engine_metadata.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} app review metadata must include non-empty `{key}`"))
+            if engine_metadata.get("selected_adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} app review metadata must bind the selected adapter"))
+            if "normalized review_record_input only" not in str(engine_metadata.get("authority_boundary", "")):
+                failures.append(Failure(category, f"{context} app review metadata must keep raw App output outside merge-ready truth"))
 
 
 def require_runtime_state_payload(
@@ -5725,7 +5738,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
 
         prepare_review_target(review_target, "review run positive chain")
         write_fake_codex(fake_bin / "codex", mode="success")
-        success_env = prepend_path_env(fake_bin)
+        success_env = prepend_path_env(fake_bin, {"CI": "", "CODEX_CI": ""})
 
         payload, error = load_command_json(
             root,
@@ -5893,6 +5906,217 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_default_target = Path(tmp) / "review-run-codex-app-default"
+        prepare_review_target(app_default_target, "review run Codex App host default")
+        app_default_raw = app_default_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_default_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_default_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App default reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-default-warn-1",
+                            "summary": "Codex App default review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_default_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-default-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-default-proof",
+                "--codex-app-review-cwd",
+                str(app_default_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App host default failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App host default",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("adapter") != "loom/codex-app-review" or engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must select the app adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review" or review_record_input.get("reviewer") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must author app adapter review_record_input"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("selection_source") != "codex-app-host-default" or metadata.get("thread_id") != "thread-stage3-default-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must expose selected adapter and thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_default_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored default app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume default Codex App raw evidence before review record is authored"))
+
+        app_ci_fallback_target = Path(tmp) / "review-run-codex-app-ci-fallback"
+        prepare_review_target(app_ci_fallback_target, "review run Codex App CI fallback")
+        app_ci_raw = app_ci_fallback_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_ci_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_ci_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_ci_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-ci-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-ci-proof",
+                "--codex-app-review-cwd",
+                str(app_ci_fallback_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=prepend_path_env(fake_bin, {"CODEX_CI": "1"}),
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App CI fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App CI fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "ci-or-codex-ci":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App CI fallback must keep the default codex exec adapter"))
+
+        app_unavailable_fallback_target = Path(tmp) / "review-run-codex-app-unavailable-fallback"
+        prepare_review_target(app_unavailable_fallback_target, "review run Codex App unavailable fallback")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_unavailable_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                f"unix://{tmp}/missing-codex-app.sock",
+                "--codex-app-review-thread-id",
+                "thread-stage3-missing-endpoint",
+                "--codex-app-review-cwd",
+                str(app_unavailable_fallback_target),
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App unavailable fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App unavailable fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "app-server-unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App unavailable fallback must record default adapter fallback"))
+
+        app_conflict_target = Path(tmp) / "review-run-codex-app-proof-conflict"
+        prepare_review_target(app_conflict_target, "review run Codex App proof conflict")
+        app_conflict_raw = app_conflict_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_conflict_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_conflict_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_conflict_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-conflict-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-conflict-proof",
+                "--codex-app-review-cwd",
+                str(Path(tmp) / "different-cwd"),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App proof conflict failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must fail closed"))
+        else:
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            if engine.get("adapter") != "loom/codex-app-review" or engine.get("failure_reason") != "runtime_conflict":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not fallback to default codex"))
+            if "does not match target root" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must expose cwd mismatch"))
+            if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not emit review_record_input"))
 
         app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
         prepare_review_target(app_authoritative_target, "review run Codex App authoritative")

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,6 +118,10 @@ CODEX_APP_REVIEW_ENGINE = "codex-app-review"
 CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
 AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
+CODEX_APP_REVIEW_ENDPOINT_ENV = "LOOM_CODEX_APP_REVIEW_ENDPOINT"
+CODEX_APP_REVIEW_THREAD_ID_ENV = "LOOM_CODEX_APP_REVIEW_THREAD_ID"
+CODEX_APP_REVIEW_CWD_ENV = "LOOM_CODEX_APP_REVIEW_CWD"
+CODEX_THREAD_ID_ENV = "CODEX_THREAD_ID"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS: int | None = None
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -492,26 +496,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
         help=(
             "Optional authoritative review engine adapter for review run/record. "
-            "Default review run remains loom/default-codex."
+            "When omitted, verified Codex App sessions use loom/codex-app-review; headless/CI fallback remains loom/default-codex."
         ),
     )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
     review.add_argument(
         "--codex-app-review-app-server",
-        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App app-server/session locator. Defaults to ${CODEX_APP_REVIEW_ENDPOINT_ENV} when available.",
     )
     review.add_argument(
         "--codex-app-review-thread-id",
-        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread id. Defaults to ${CODEX_APP_REVIEW_THREAD_ID_ENV}, or ${CODEX_THREAD_ID_ENV} when an endpoint is present.",
     )
     review.add_argument(
         "--codex-app-review-cwd",
-        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread cwd proof. Defaults to ${CODEX_APP_REVIEW_CWD_ENV}.",
     )
     review.add_argument(
         "--codex-app-review-raw-file",
-        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+        help="Optional repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
     )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
@@ -4250,6 +4254,19 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def truthy_env(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def non_empty_str(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def execution_attempt_directory(target_root: Path, item_id: str) -> Path:
     return target_root / ".loom/runtime/attempts" / item_id
 
@@ -6264,8 +6281,26 @@ def run_default_review_engine(
     engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "explicit-or-legacy-default",
+            "fallback_reason": None,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=None,
+                thread_id=None,
+                thread_cwd=None,
+                reviewed_head=reviewed_head,
+                raw_file=None,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     prompt_path = runtime_root / "prompt.txt"
     result_path = runtime_root / "engine-result.json"
@@ -6313,6 +6348,7 @@ def run_default_review_engine(
                     "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
+            "engine_metadata": selection_metadata,
         }
 
     scratch_dir.mkdir(parents=True, exist_ok=True)
@@ -6403,6 +6439,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
@@ -6424,6 +6461,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     if raw_payload is not None and not result_path.exists():
@@ -6440,6 +6478,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
@@ -6462,6 +6501,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     write_json_file(findings_path, {"findings": normalized_payload["findings"]})
@@ -6471,6 +6511,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
@@ -6494,6 +6535,13 @@ def run_default_review_engine(
             "failure_reason": None,
             "reviewed_head": reviewed_head,
             "evidence": engine_evidence,
+        },
+        "engine_metadata": {
+            **selection_metadata,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "raw_result": relative_to_root(result_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "metadata": relative_to_root(metadata_path, context["target_root"]),
         },
         "review_record_input": {
             "decision": normalized_payload["decision"],
@@ -7254,6 +7302,312 @@ def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: st
     return normalized, []
 
 
+def codex_app_endpoint_socket_path(app_server: str | None) -> Path | None:
+    endpoint = non_empty_str(app_server)
+    if endpoint is None:
+        return None
+    if endpoint.startswith("unix://"):
+        path_text = endpoint.removeprefix("unix://")
+    elif endpoint.startswith("/"):
+        path_text = endpoint
+    else:
+        return None
+    if not path_text:
+        return None
+    return Path(path_text).expanduser()
+
+
+def codex_app_endpoint_is_live_capable(app_server: str | None) -> bool:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    return socket_path is not None and socket_path.exists()
+
+
+def codex_app_review_bindings_from_args_env(args: argparse.Namespace) -> dict[str, str | None]:
+    app_server = non_empty_str(args.codex_app_review_app_server) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_ENDPOINT_ENV))
+    thread_id = (
+        non_empty_str(args.codex_app_review_thread_id)
+        or non_empty_str(os.environ.get(CODEX_APP_REVIEW_THREAD_ID_ENV))
+        or (non_empty_str(os.environ.get(CODEX_THREAD_ID_ENV)) if app_server else None)
+    )
+    thread_cwd = non_empty_str(args.codex_app_review_cwd) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_CWD_ENV))
+    raw_file = non_empty_str(args.codex_app_review_raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": thread_cwd,
+        "raw_file": raw_file,
+    }
+
+
+def codex_app_binding_summary(
+    target_root: Path,
+    *,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    reviewed_head: str,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    cwd_match: bool | None = None
+    cwd_summary: str | None = thread_cwd
+    if non_empty_str(thread_cwd):
+        try:
+            cwd_path = Path(str(thread_cwd)).expanduser().resolve()
+        except OSError:
+            cwd_match = False
+        else:
+            cwd_match = cwd_path == target_root
+            cwd_summary = str(cwd_path)
+    raw_source: str | None = None
+    if non_empty_str(raw_file):
+        raw_path, raw_errors = resolve_repo_relative_path(target_root, str(raw_file), label="Codex App authoritative review raw file")
+        if raw_path is not None and not raw_errors:
+            raw_source = relative_to_root(raw_path, target_root)
+        else:
+            raw_source = str(raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_summary,
+        "thread_cwd_matches_target_root": cwd_match,
+        "target_root": str(target_root),
+        "reviewed_head": reviewed_head,
+        "raw_source": raw_source,
+        "live_endpoint_capable": codex_app_endpoint_is_live_capable(app_server),
+    }
+
+
+def select_review_adapter(
+    args: argparse.Namespace,
+    target_root: Path,
+    *,
+    reviewed_head: str,
+) -> dict[str, Any]:
+    bindings = codex_app_review_bindings_from_args_env(args)
+    explicit_adapter = non_empty_str(args.engine_adapter)
+    if explicit_adapter:
+        return {
+            "adapter": explicit_adapter,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    if truthy_env("CI") or truthy_env("CODEX_CI"):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "headless-fallback",
+            "fallback_reason": "ci-or-codex-ci",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    app_server = bindings["app_server"]
+    thread_id = bindings["thread_id"]
+    thread_cwd = bindings["thread_cwd"]
+    raw_file = bindings["raw_file"]
+    if not app_server or not thread_id or not thread_cwd:
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "missing-codex-app-host-proof",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    if not raw_file and not codex_app_endpoint_is_live_capable(app_server):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "app-server-unavailable",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    return {
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "selection_source": "codex-app-host-default",
+        "fallback_reason": None,
+        **bindings,
+        "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+    }
+
+
+def review_adapter_selection_metadata(selection: dict[str, Any], *, reviewed_head: str) -> dict[str, Any]:
+    return {
+        "selected_adapter": selection["adapter"],
+        "selection_source": selection.get("selection_source"),
+        "fallback_reason": selection.get("fallback_reason"),
+        "app_server": selection.get("app_server"),
+        "thread_id": selection.get("thread_id"),
+        "thread_cwd": selection.get("thread_cwd"),
+        "target_root": selection.get("binding_summary", {}).get("target_root")
+        if isinstance(selection.get("binding_summary"), dict)
+        else None,
+        "reviewed_head": reviewed_head,
+        "thread_target_binding": selection.get("binding_summary"),
+    }
+
+
+def jsonrpc_send_request(stdin: Any, *, request_id: int, method: str, params: dict[str, Any]) -> None:
+    stdin.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}) + "\n")
+    stdin.flush()
+
+
+def jsonrpc_read_response(stdout: Any, *, request_id: int) -> tuple[dict[str, Any] | None, list[dict[str, Any]], list[str]]:
+    notifications: list[dict[str, Any]] = []
+    while True:
+        line = stdout.readline()
+        if not line:
+            return None, notifications, [f"app-server closed before response id {request_id}"]
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("id") == request_id:
+            return payload, notifications, []
+        notifications.append(payload)
+
+
+def find_exited_review_text(payload: Any) -> str | None:
+    if isinstance(payload, dict):
+        if payload.get("type") == "exitedReviewMode" and isinstance(payload.get("review"), str):
+            return payload["review"]
+        for value in payload.values():
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    return None
+
+
+def find_normalized_review_payload(payload: Any) -> dict[str, Any] | None:
+    normalized, errors = normalize_engine_review_result(payload, relative="app-server turn/start output")
+    if normalized is not None and not errors:
+        return normalized
+    if isinstance(payload, dict):
+        for value in payload.values():
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    return None
+
+
+def app_server_proxy_command(app_server: str) -> list[str] | None:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    if socket_path is None:
+        return None
+    return ["codex", "app-server", "proxy", "--sock", str(socket_path)]
+
+
+def run_codex_app_live_review(
+    *,
+    app_server: str,
+    thread_id: str,
+    reviewed_head: str,
+    thread_cwd: str,
+    prompt_text: str,
+) -> tuple[str | None, dict[str, Any], list[str]]:
+    command = app_server_proxy_command(app_server)
+    if command is None:
+        return None, {}, [f"unsupported Codex App review endpoint: {app_server}"]
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return None, {}, [f"Codex App review endpoint is unavailable: {exc}"]
+    assert process.stdin is not None
+    assert process.stdout is not None
+    metadata: dict[str, Any] = {"review_target": {"type": "commit", "sha": reviewed_head}}
+    try:
+        jsonrpc_send_request(process.stdin, request_id=1, method="initialize", params={"clientInfo": {"name": "loom", "version": "stage3"}, "capabilities": {}})
+        initialize_response, _, initialize_errors = jsonrpc_read_response(process.stdout, request_id=1)
+        if initialize_errors:
+            return None, metadata, initialize_errors
+        if isinstance(initialize_response, dict) and isinstance(initialize_response.get("error"), dict):
+            return None, metadata, [f"Codex App initialize failed: {initialize_response['error']}"]
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=2,
+            method="review/start",
+            params={
+                "threadId": thread_id,
+                "delivery": "inline",
+                "target": {"type": "commit", "sha": reviewed_head},
+            },
+        )
+        review_response, review_notifications, review_errors = jsonrpc_read_response(process.stdout, request_id=2)
+        if review_errors:
+            return None, metadata, review_errors
+        if isinstance(review_response, dict) and isinstance(review_response.get("error"), dict):
+            return None, metadata, [f"Codex App review/start failed: {review_response['error']}"]
+        result = review_response.get("result") if isinstance(review_response, dict) else None
+        if isinstance(result, dict):
+            metadata["review_thread_id"] = result.get("reviewThreadId")
+        review_text = find_exited_review_text(result) or find_exited_review_text(review_notifications)
+        if not isinstance(review_text, str) or not review_text.strip():
+            return None, metadata, ["Codex App review/start did not return exitedReviewMode.review"]
+
+        parsed_review, parsed_errors = normalize_authoritative_codex_app_review_text(review_text, relative="app-server review/start output")
+        if parsed_review is not None and not parsed_errors:
+            metadata["normalization_source"] = "review-start-json"
+            return review_text, {**metadata, "normalized": parsed_review}, []
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=3,
+            method="turn/start",
+            params={
+                "threadId": metadata.get("review_thread_id") or thread_id,
+                "cwd": thread_cwd,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Normalize this Codex App review output into the provided JSON schema. "
+                            "Return only the structured review result.\n\n"
+                            f"{review_text}"
+                        ),
+                    }
+                ],
+                "outputSchema": load_json_file(review_engine_schema_path()),
+            },
+        )
+        turn_response, turn_notifications, turn_errors = jsonrpc_read_response(process.stdout, request_id=3)
+        if turn_errors:
+            return review_text, metadata, turn_errors
+        if isinstance(turn_response, dict) and isinstance(turn_response.get("error"), dict):
+            return review_text, metadata, [f"Codex App turn/start normalization failed: {turn_response['error']}"]
+        normalized = find_normalized_review_payload(turn_response.get("result") if isinstance(turn_response, dict) else None)
+        if normalized is None:
+            normalized = find_normalized_review_payload(turn_notifications)
+        if normalized is None:
+            return review_text, metadata, ["Codex App turn/start did not return a Loom review result"]
+        metadata["normalization_source"] = "turn-start-output-schema"
+        return review_text, {**metadata, "normalized": normalized}, []
+    finally:
+        try:
+            process.terminate()
+        except OSError:
+            pass
+
+
 def shadow_adapter_slug(adapter: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
 
@@ -7453,8 +7807,30 @@ def run_codex_app_review_authoritative_adapter(
     thread_id: str | None,
     thread_cwd: str | None,
     raw_file: str | None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            "app_server": app_server,
+            "thread_id": thread_id,
+            "thread_cwd": thread_cwd,
+            "raw_file": raw_file,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=app_server,
+                thread_id=thread_id,
+                thread_cwd=thread_cwd,
+                reviewed_head=reviewed_head,
+                raw_file=raw_file,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     raw_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
@@ -7488,7 +7864,6 @@ def run_codex_app_review_authoritative_adapter(
         ("--codex-app-review-app-server", app_server),
         ("--codex-app-review-thread-id", thread_id),
         ("--codex-app-review-cwd", thread_cwd),
-        ("--codex-app-review-raw-file", raw_file),
     ):
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(label)
@@ -7518,6 +7893,8 @@ def run_codex_app_review_authoritative_adapter(
         missing_inputs.extend(source_errors)
         if source_path is not None:
             source_relative = relative_to_root(source_path, context["target_root"])
+    elif not codex_app_endpoint_is_live_capable(app_server):
+        missing_inputs.append("--codex-app-review-raw-file or live app-server endpoint")
 
     if missing_inputs:
         write_json_file(
@@ -7527,6 +7904,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "runtime_conflict",
@@ -7553,6 +7931,7 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative or thread_cwd,
@@ -7560,17 +7939,30 @@ def run_codex_app_review_authoritative_adapter(
             },
         }
 
-    try:
-        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
-    except OSError as exc:
-        raw_text = ""
-        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
-        normalized = None
+    live_metadata: dict[str, Any] = {}
+    if source_path is not None:
+        try:
+            raw_text = source_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raw_text = ""
+            normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+            normalized = None
+        else:
+            normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+                raw_text,
+                relative=source_relative or str(raw_file),
+            )
     else:
-        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
-            raw_text,
-            relative=source_relative or str(raw_file),
+        raw_text, live_metadata, normalization_errors = run_codex_app_live_review(
+            app_server=str(app_server),
+            thread_id=str(thread_id),
+            reviewed_head=reviewed_head,
+            thread_cwd=str(thread_cwd),
+            prompt_text=instructions_path.read_text(encoding="utf-8"),
         )
+        normalized = live_metadata.get("normalized") if isinstance(live_metadata.get("normalized"), dict) else None
+        if raw_text is None:
+            raw_text = ""
 
     if normalization_errors or normalized is None:
         if raw_text:
@@ -7582,6 +7974,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "schema_drift",
@@ -7592,6 +7985,7 @@ def run_codex_app_review_authoritative_adapter(
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         )
         return {
@@ -7609,10 +8003,12 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         }
 
@@ -7623,6 +8019,7 @@ def run_codex_app_review_authoritative_adapter(
         "engine": CODEX_APP_REVIEW_ENGINE,
         "adapter": CODEX_APP_REVIEW_ADAPTER,
         "profile": engine_profile,
+        **selection_metadata,
         "context_pack": relative_to_root(context_pack_path, context["target_root"]),
         "result": "pass",
         "reviewed_head": reviewed_head,
@@ -7634,6 +8031,11 @@ def run_codex_app_review_authoritative_adapter(
         "thread_id": thread_id,
         "thread_cwd": cwd_relative,
         "raw_source": source_relative,
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "review_thread_id": live_metadata.get("review_thread_id") if live_metadata else (thread_id if source_path is not None else None),
+        **({"live_review": {key: value for key, value in live_metadata.items() if key != "normalized"}} if live_metadata else {}),
         "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
     }
     write_json_file(metadata_path, metadata)
@@ -12452,7 +12854,9 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
-        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
+        current_head = git_head_sha(target_root) or "unknown-head"
+        adapter_selection = select_review_adapter(args, target_root, reviewed_head=current_head)
+        requested_engine_adapter = str(adapter_selection["adapter"])
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
@@ -12484,9 +12888,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12524,9 +12929,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12539,10 +12945,11 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
-                app_server=args.codex_app_review_app_server,
-                thread_id=args.codex_app_review_thread_id,
-                thread_cwd=args.codex_app_review_cwd,
-                raw_file=args.codex_app_review_raw_file,
+                app_server=adapter_selection.get("app_server") if isinstance(adapter_selection.get("app_server"), str) else None,
+                thread_id=adapter_selection.get("thread_id") if isinstance(adapter_selection.get("thread_id"), str) else None,
+                thread_cwd=adapter_selection.get("thread_cwd") if isinstance(adapter_selection.get("thread_cwd"), str) else None,
+                raw_file=adapter_selection.get("raw_file") if isinstance(adapter_selection.get("raw_file"), str) else None,
+                adapter_selection=adapter_selection,
             )
         else:
             engine_payload = run_default_review_engine(
@@ -12551,6 +12958,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
+                adapter_selection=adapter_selection,
             )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,

--- a/skills/loom-handoff/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-handoff/.loom-runtime/loom-review/SKILL.md
@@ -42,9 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 选择安全的 authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
 
-默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
+已验证 Codex App host context 中，默认 `review run` 使用 `loom/codex-app-review`，并必须证明 app-server/session locator、thread id、cwd proof、target root 与 reviewed head 绑定一致；该路径不得启动嵌套 `codex exec`。`CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex` + `codex exec --output-schema`。proof 冲突、cwd / target / head 不匹配或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -54,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 
@@ -75,7 +75,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - review 机械基线结果
 - build gate 是否允许进入正式审查
 - review artifact 的定位与已记录结论
-- 默认 engine 的执行结果、evidence 定位与 fail-closed 原因
+- selected adapter、fallback reason、thread/target binding summary、reviewed head、evidence 定位与 fail-closed 原因
 - manual review 的回退写回入口
 - review record 中的权威 findings / disposition 摘要
 - 审查结论（`allow` / `block` / `fallback`）

--- a/skills/loom-handoff/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-handoff/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,7 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
-- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/review-execution.md
@@ -21,7 +21,7 @@ Loom 把 review 分成四层：
 1. `flow review`
    - 只读基线；确认是否具备进入 formal review 的条件
 2. `review run`
-   - 调用默认 Codex-backed reviewer，产出结构化 review evidence 与 Loom-normalized findings
+   - 按宿主 proof 选择 authoritative adapter，产出结构化 review evidence 与 Loom-normalized findings
 3. `review record`
    - 把 formal review 结论写入单一 authored review record
 
@@ -47,27 +47,33 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责选择安全的 authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
+默认 engine 按宿主 proof 选择：
+
+- 已验证 Codex App host context 默认选择 `loom/codex-app-review`，不启动嵌套 `codex exec`
+- `CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex`，能力来源仍是 `codex exec --output-schema`
+- 显式 `--engine-adapter` 优先级最高，继续保留 Stage 2 authoritative opt-in / fallback 调试入口
+
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-Codex App review adapter 有两种显式入口，默认均不启用：
+Codex App review adapter 有三种入口：
 
-- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
-- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- verified host default：不传 `--engine-adapter`，但必须能证明 app-server/session locator、thread id、thread cwd、target root 与 reviewed head 绑定一致
+- explicit authoritative：显式选择 `review run --engine-adapter loom/codex-app-review`，用于调试或非默认宿主
+- shadow comparison：显式选择 `review run --shadow-engine-adapter loom/codex-app-review`
 - shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
-- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
-- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
-- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof；live app-server unavailable 时默认 fallback 到 `loom/default-codex`
+- thread cwd proof 必须等于 target root；cwd / target / reviewed head 绑定冲突或 schema proof 失败时必须 fail closed
 - authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
 - authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
+- `engine_metadata` 必须记录 selected adapter、selection source、fallback reason、thread/target binding summary、reviewed head 与 evidence locators
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
@@ -77,8 +83,8 @@ Codex App review adapter 有两种显式入口，默认均不启用：
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
-- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
+- `adapter`: `loom/default-codex` 或 verified/explicit `loom/codex-app-review`
+- `engine`: `codex` 或 verified/explicit `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -3126,6 +3126,19 @@ def require_review_run_payload(
                 for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
                     if not isinstance(evidence.get(key), str) or not evidence.get(key):
                         failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
+    engine_metadata = payload.get("engine_metadata")
+    if engine_adapter == "loom/codex-app-review" and engine.get("result") == "pass":
+        if not isinstance(engine_metadata, dict):
+            failures.append(Failure(category, f"{context} app review pass must expose `engine_metadata`"))
+        else:
+            for key in ("selected_adapter", "selection_source", "app_server", "thread_id", "thread_cwd", "raw_result", "normalized_findings", "context_pack", "reviewed_head"):
+                value = engine_metadata.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} app review metadata must include non-empty `{key}`"))
+            if engine_metadata.get("selected_adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} app review metadata must bind the selected adapter"))
+            if "normalized review_record_input only" not in str(engine_metadata.get("authority_boundary", "")):
+                failures.append(Failure(category, f"{context} app review metadata must keep raw App output outside merge-ready truth"))
 
 
 def require_runtime_state_payload(
@@ -5725,7 +5738,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
 
         prepare_review_target(review_target, "review run positive chain")
         write_fake_codex(fake_bin / "codex", mode="success")
-        success_env = prepend_path_env(fake_bin)
+        success_env = prepend_path_env(fake_bin, {"CI": "", "CODEX_CI": ""})
 
         payload, error = load_command_json(
             root,
@@ -5893,6 +5906,217 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_default_target = Path(tmp) / "review-run-codex-app-default"
+        prepare_review_target(app_default_target, "review run Codex App host default")
+        app_default_raw = app_default_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_default_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_default_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App default reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-default-warn-1",
+                            "summary": "Codex App default review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_default_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-default-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-default-proof",
+                "--codex-app-review-cwd",
+                str(app_default_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App host default failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App host default",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("adapter") != "loom/codex-app-review" or engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must select the app adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review" or review_record_input.get("reviewer") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must author app adapter review_record_input"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("selection_source") != "codex-app-host-default" or metadata.get("thread_id") != "thread-stage3-default-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must expose selected adapter and thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_default_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored default app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume default Codex App raw evidence before review record is authored"))
+
+        app_ci_fallback_target = Path(tmp) / "review-run-codex-app-ci-fallback"
+        prepare_review_target(app_ci_fallback_target, "review run Codex App CI fallback")
+        app_ci_raw = app_ci_fallback_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_ci_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_ci_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_ci_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-ci-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-ci-proof",
+                "--codex-app-review-cwd",
+                str(app_ci_fallback_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=prepend_path_env(fake_bin, {"CODEX_CI": "1"}),
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App CI fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App CI fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "ci-or-codex-ci":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App CI fallback must keep the default codex exec adapter"))
+
+        app_unavailable_fallback_target = Path(tmp) / "review-run-codex-app-unavailable-fallback"
+        prepare_review_target(app_unavailable_fallback_target, "review run Codex App unavailable fallback")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_unavailable_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                f"unix://{tmp}/missing-codex-app.sock",
+                "--codex-app-review-thread-id",
+                "thread-stage3-missing-endpoint",
+                "--codex-app-review-cwd",
+                str(app_unavailable_fallback_target),
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App unavailable fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App unavailable fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "app-server-unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App unavailable fallback must record default adapter fallback"))
+
+        app_conflict_target = Path(tmp) / "review-run-codex-app-proof-conflict"
+        prepare_review_target(app_conflict_target, "review run Codex App proof conflict")
+        app_conflict_raw = app_conflict_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_conflict_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_conflict_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_conflict_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-conflict-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-conflict-proof",
+                "--codex-app-review-cwd",
+                str(Path(tmp) / "different-cwd"),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App proof conflict failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must fail closed"))
+        else:
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            if engine.get("adapter") != "loom/codex-app-review" or engine.get("failure_reason") != "runtime_conflict":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not fallback to default codex"))
+            if "does not match target root" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must expose cwd mismatch"))
+            if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not emit review_record_input"))
 
         app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
         prepare_review_target(app_authoritative_target, "review run Codex App authoritative")

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,6 +118,10 @@ CODEX_APP_REVIEW_ENGINE = "codex-app-review"
 CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
 AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
+CODEX_APP_REVIEW_ENDPOINT_ENV = "LOOM_CODEX_APP_REVIEW_ENDPOINT"
+CODEX_APP_REVIEW_THREAD_ID_ENV = "LOOM_CODEX_APP_REVIEW_THREAD_ID"
+CODEX_APP_REVIEW_CWD_ENV = "LOOM_CODEX_APP_REVIEW_CWD"
+CODEX_THREAD_ID_ENV = "CODEX_THREAD_ID"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS: int | None = None
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -492,26 +496,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
         help=(
             "Optional authoritative review engine adapter for review run/record. "
-            "Default review run remains loom/default-codex."
+            "When omitted, verified Codex App sessions use loom/codex-app-review; headless/CI fallback remains loom/default-codex."
         ),
     )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
     review.add_argument(
         "--codex-app-review-app-server",
-        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App app-server/session locator. Defaults to ${CODEX_APP_REVIEW_ENDPOINT_ENV} when available.",
     )
     review.add_argument(
         "--codex-app-review-thread-id",
-        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread id. Defaults to ${CODEX_APP_REVIEW_THREAD_ID_ENV}, or ${CODEX_THREAD_ID_ENV} when an endpoint is present.",
     )
     review.add_argument(
         "--codex-app-review-cwd",
-        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread cwd proof. Defaults to ${CODEX_APP_REVIEW_CWD_ENV}.",
     )
     review.add_argument(
         "--codex-app-review-raw-file",
-        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+        help="Optional repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
     )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
@@ -4250,6 +4254,19 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def truthy_env(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def non_empty_str(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def execution_attempt_directory(target_root: Path, item_id: str) -> Path:
     return target_root / ".loom/runtime/attempts" / item_id
 
@@ -6264,8 +6281,26 @@ def run_default_review_engine(
     engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "explicit-or-legacy-default",
+            "fallback_reason": None,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=None,
+                thread_id=None,
+                thread_cwd=None,
+                reviewed_head=reviewed_head,
+                raw_file=None,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     prompt_path = runtime_root / "prompt.txt"
     result_path = runtime_root / "engine-result.json"
@@ -6313,6 +6348,7 @@ def run_default_review_engine(
                     "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
+            "engine_metadata": selection_metadata,
         }
 
     scratch_dir.mkdir(parents=True, exist_ok=True)
@@ -6403,6 +6439,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
@@ -6424,6 +6461,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     if raw_payload is not None and not result_path.exists():
@@ -6440,6 +6478,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
@@ -6462,6 +6501,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     write_json_file(findings_path, {"findings": normalized_payload["findings"]})
@@ -6471,6 +6511,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
@@ -6494,6 +6535,13 @@ def run_default_review_engine(
             "failure_reason": None,
             "reviewed_head": reviewed_head,
             "evidence": engine_evidence,
+        },
+        "engine_metadata": {
+            **selection_metadata,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "raw_result": relative_to_root(result_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "metadata": relative_to_root(metadata_path, context["target_root"]),
         },
         "review_record_input": {
             "decision": normalized_payload["decision"],
@@ -7254,6 +7302,312 @@ def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: st
     return normalized, []
 
 
+def codex_app_endpoint_socket_path(app_server: str | None) -> Path | None:
+    endpoint = non_empty_str(app_server)
+    if endpoint is None:
+        return None
+    if endpoint.startswith("unix://"):
+        path_text = endpoint.removeprefix("unix://")
+    elif endpoint.startswith("/"):
+        path_text = endpoint
+    else:
+        return None
+    if not path_text:
+        return None
+    return Path(path_text).expanduser()
+
+
+def codex_app_endpoint_is_live_capable(app_server: str | None) -> bool:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    return socket_path is not None and socket_path.exists()
+
+
+def codex_app_review_bindings_from_args_env(args: argparse.Namespace) -> dict[str, str | None]:
+    app_server = non_empty_str(args.codex_app_review_app_server) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_ENDPOINT_ENV))
+    thread_id = (
+        non_empty_str(args.codex_app_review_thread_id)
+        or non_empty_str(os.environ.get(CODEX_APP_REVIEW_THREAD_ID_ENV))
+        or (non_empty_str(os.environ.get(CODEX_THREAD_ID_ENV)) if app_server else None)
+    )
+    thread_cwd = non_empty_str(args.codex_app_review_cwd) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_CWD_ENV))
+    raw_file = non_empty_str(args.codex_app_review_raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": thread_cwd,
+        "raw_file": raw_file,
+    }
+
+
+def codex_app_binding_summary(
+    target_root: Path,
+    *,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    reviewed_head: str,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    cwd_match: bool | None = None
+    cwd_summary: str | None = thread_cwd
+    if non_empty_str(thread_cwd):
+        try:
+            cwd_path = Path(str(thread_cwd)).expanduser().resolve()
+        except OSError:
+            cwd_match = False
+        else:
+            cwd_match = cwd_path == target_root
+            cwd_summary = str(cwd_path)
+    raw_source: str | None = None
+    if non_empty_str(raw_file):
+        raw_path, raw_errors = resolve_repo_relative_path(target_root, str(raw_file), label="Codex App authoritative review raw file")
+        if raw_path is not None and not raw_errors:
+            raw_source = relative_to_root(raw_path, target_root)
+        else:
+            raw_source = str(raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_summary,
+        "thread_cwd_matches_target_root": cwd_match,
+        "target_root": str(target_root),
+        "reviewed_head": reviewed_head,
+        "raw_source": raw_source,
+        "live_endpoint_capable": codex_app_endpoint_is_live_capable(app_server),
+    }
+
+
+def select_review_adapter(
+    args: argparse.Namespace,
+    target_root: Path,
+    *,
+    reviewed_head: str,
+) -> dict[str, Any]:
+    bindings = codex_app_review_bindings_from_args_env(args)
+    explicit_adapter = non_empty_str(args.engine_adapter)
+    if explicit_adapter:
+        return {
+            "adapter": explicit_adapter,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    if truthy_env("CI") or truthy_env("CODEX_CI"):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "headless-fallback",
+            "fallback_reason": "ci-or-codex-ci",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    app_server = bindings["app_server"]
+    thread_id = bindings["thread_id"]
+    thread_cwd = bindings["thread_cwd"]
+    raw_file = bindings["raw_file"]
+    if not app_server or not thread_id or not thread_cwd:
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "missing-codex-app-host-proof",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    if not raw_file and not codex_app_endpoint_is_live_capable(app_server):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "app-server-unavailable",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    return {
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "selection_source": "codex-app-host-default",
+        "fallback_reason": None,
+        **bindings,
+        "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+    }
+
+
+def review_adapter_selection_metadata(selection: dict[str, Any], *, reviewed_head: str) -> dict[str, Any]:
+    return {
+        "selected_adapter": selection["adapter"],
+        "selection_source": selection.get("selection_source"),
+        "fallback_reason": selection.get("fallback_reason"),
+        "app_server": selection.get("app_server"),
+        "thread_id": selection.get("thread_id"),
+        "thread_cwd": selection.get("thread_cwd"),
+        "target_root": selection.get("binding_summary", {}).get("target_root")
+        if isinstance(selection.get("binding_summary"), dict)
+        else None,
+        "reviewed_head": reviewed_head,
+        "thread_target_binding": selection.get("binding_summary"),
+    }
+
+
+def jsonrpc_send_request(stdin: Any, *, request_id: int, method: str, params: dict[str, Any]) -> None:
+    stdin.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}) + "\n")
+    stdin.flush()
+
+
+def jsonrpc_read_response(stdout: Any, *, request_id: int) -> tuple[dict[str, Any] | None, list[dict[str, Any]], list[str]]:
+    notifications: list[dict[str, Any]] = []
+    while True:
+        line = stdout.readline()
+        if not line:
+            return None, notifications, [f"app-server closed before response id {request_id}"]
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("id") == request_id:
+            return payload, notifications, []
+        notifications.append(payload)
+
+
+def find_exited_review_text(payload: Any) -> str | None:
+    if isinstance(payload, dict):
+        if payload.get("type") == "exitedReviewMode" and isinstance(payload.get("review"), str):
+            return payload["review"]
+        for value in payload.values():
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    return None
+
+
+def find_normalized_review_payload(payload: Any) -> dict[str, Any] | None:
+    normalized, errors = normalize_engine_review_result(payload, relative="app-server turn/start output")
+    if normalized is not None and not errors:
+        return normalized
+    if isinstance(payload, dict):
+        for value in payload.values():
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    return None
+
+
+def app_server_proxy_command(app_server: str) -> list[str] | None:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    if socket_path is None:
+        return None
+    return ["codex", "app-server", "proxy", "--sock", str(socket_path)]
+
+
+def run_codex_app_live_review(
+    *,
+    app_server: str,
+    thread_id: str,
+    reviewed_head: str,
+    thread_cwd: str,
+    prompt_text: str,
+) -> tuple[str | None, dict[str, Any], list[str]]:
+    command = app_server_proxy_command(app_server)
+    if command is None:
+        return None, {}, [f"unsupported Codex App review endpoint: {app_server}"]
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return None, {}, [f"Codex App review endpoint is unavailable: {exc}"]
+    assert process.stdin is not None
+    assert process.stdout is not None
+    metadata: dict[str, Any] = {"review_target": {"type": "commit", "sha": reviewed_head}}
+    try:
+        jsonrpc_send_request(process.stdin, request_id=1, method="initialize", params={"clientInfo": {"name": "loom", "version": "stage3"}, "capabilities": {}})
+        initialize_response, _, initialize_errors = jsonrpc_read_response(process.stdout, request_id=1)
+        if initialize_errors:
+            return None, metadata, initialize_errors
+        if isinstance(initialize_response, dict) and isinstance(initialize_response.get("error"), dict):
+            return None, metadata, [f"Codex App initialize failed: {initialize_response['error']}"]
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=2,
+            method="review/start",
+            params={
+                "threadId": thread_id,
+                "delivery": "inline",
+                "target": {"type": "commit", "sha": reviewed_head},
+            },
+        )
+        review_response, review_notifications, review_errors = jsonrpc_read_response(process.stdout, request_id=2)
+        if review_errors:
+            return None, metadata, review_errors
+        if isinstance(review_response, dict) and isinstance(review_response.get("error"), dict):
+            return None, metadata, [f"Codex App review/start failed: {review_response['error']}"]
+        result = review_response.get("result") if isinstance(review_response, dict) else None
+        if isinstance(result, dict):
+            metadata["review_thread_id"] = result.get("reviewThreadId")
+        review_text = find_exited_review_text(result) or find_exited_review_text(review_notifications)
+        if not isinstance(review_text, str) or not review_text.strip():
+            return None, metadata, ["Codex App review/start did not return exitedReviewMode.review"]
+
+        parsed_review, parsed_errors = normalize_authoritative_codex_app_review_text(review_text, relative="app-server review/start output")
+        if parsed_review is not None and not parsed_errors:
+            metadata["normalization_source"] = "review-start-json"
+            return review_text, {**metadata, "normalized": parsed_review}, []
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=3,
+            method="turn/start",
+            params={
+                "threadId": metadata.get("review_thread_id") or thread_id,
+                "cwd": thread_cwd,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Normalize this Codex App review output into the provided JSON schema. "
+                            "Return only the structured review result.\n\n"
+                            f"{review_text}"
+                        ),
+                    }
+                ],
+                "outputSchema": load_json_file(review_engine_schema_path()),
+            },
+        )
+        turn_response, turn_notifications, turn_errors = jsonrpc_read_response(process.stdout, request_id=3)
+        if turn_errors:
+            return review_text, metadata, turn_errors
+        if isinstance(turn_response, dict) and isinstance(turn_response.get("error"), dict):
+            return review_text, metadata, [f"Codex App turn/start normalization failed: {turn_response['error']}"]
+        normalized = find_normalized_review_payload(turn_response.get("result") if isinstance(turn_response, dict) else None)
+        if normalized is None:
+            normalized = find_normalized_review_payload(turn_notifications)
+        if normalized is None:
+            return review_text, metadata, ["Codex App turn/start did not return a Loom review result"]
+        metadata["normalization_source"] = "turn-start-output-schema"
+        return review_text, {**metadata, "normalized": normalized}, []
+    finally:
+        try:
+            process.terminate()
+        except OSError:
+            pass
+
+
 def shadow_adapter_slug(adapter: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
 
@@ -7453,8 +7807,30 @@ def run_codex_app_review_authoritative_adapter(
     thread_id: str | None,
     thread_cwd: str | None,
     raw_file: str | None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            "app_server": app_server,
+            "thread_id": thread_id,
+            "thread_cwd": thread_cwd,
+            "raw_file": raw_file,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=app_server,
+                thread_id=thread_id,
+                thread_cwd=thread_cwd,
+                reviewed_head=reviewed_head,
+                raw_file=raw_file,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     raw_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
@@ -7488,7 +7864,6 @@ def run_codex_app_review_authoritative_adapter(
         ("--codex-app-review-app-server", app_server),
         ("--codex-app-review-thread-id", thread_id),
         ("--codex-app-review-cwd", thread_cwd),
-        ("--codex-app-review-raw-file", raw_file),
     ):
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(label)
@@ -7518,6 +7893,8 @@ def run_codex_app_review_authoritative_adapter(
         missing_inputs.extend(source_errors)
         if source_path is not None:
             source_relative = relative_to_root(source_path, context["target_root"])
+    elif not codex_app_endpoint_is_live_capable(app_server):
+        missing_inputs.append("--codex-app-review-raw-file or live app-server endpoint")
 
     if missing_inputs:
         write_json_file(
@@ -7527,6 +7904,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "runtime_conflict",
@@ -7553,6 +7931,7 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative or thread_cwd,
@@ -7560,17 +7939,30 @@ def run_codex_app_review_authoritative_adapter(
             },
         }
 
-    try:
-        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
-    except OSError as exc:
-        raw_text = ""
-        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
-        normalized = None
+    live_metadata: dict[str, Any] = {}
+    if source_path is not None:
+        try:
+            raw_text = source_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raw_text = ""
+            normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+            normalized = None
+        else:
+            normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+                raw_text,
+                relative=source_relative or str(raw_file),
+            )
     else:
-        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
-            raw_text,
-            relative=source_relative or str(raw_file),
+        raw_text, live_metadata, normalization_errors = run_codex_app_live_review(
+            app_server=str(app_server),
+            thread_id=str(thread_id),
+            reviewed_head=reviewed_head,
+            thread_cwd=str(thread_cwd),
+            prompt_text=instructions_path.read_text(encoding="utf-8"),
         )
+        normalized = live_metadata.get("normalized") if isinstance(live_metadata.get("normalized"), dict) else None
+        if raw_text is None:
+            raw_text = ""
 
     if normalization_errors or normalized is None:
         if raw_text:
@@ -7582,6 +7974,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "schema_drift",
@@ -7592,6 +7985,7 @@ def run_codex_app_review_authoritative_adapter(
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         )
         return {
@@ -7609,10 +8003,12 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         }
 
@@ -7623,6 +8019,7 @@ def run_codex_app_review_authoritative_adapter(
         "engine": CODEX_APP_REVIEW_ENGINE,
         "adapter": CODEX_APP_REVIEW_ADAPTER,
         "profile": engine_profile,
+        **selection_metadata,
         "context_pack": relative_to_root(context_pack_path, context["target_root"]),
         "result": "pass",
         "reviewed_head": reviewed_head,
@@ -7634,6 +8031,11 @@ def run_codex_app_review_authoritative_adapter(
         "thread_id": thread_id,
         "thread_cwd": cwd_relative,
         "raw_source": source_relative,
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "review_thread_id": live_metadata.get("review_thread_id") if live_metadata else (thread_id if source_path is not None else None),
+        **({"live_review": {key: value for key, value in live_metadata.items() if key != "normalized"}} if live_metadata else {}),
         "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
     }
     write_json_file(metadata_path, metadata)
@@ -12452,7 +12854,9 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
-        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
+        current_head = git_head_sha(target_root) or "unknown-head"
+        adapter_selection = select_review_adapter(args, target_root, reviewed_head=current_head)
+        requested_engine_adapter = str(adapter_selection["adapter"])
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
@@ -12484,9 +12888,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12524,9 +12929,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12539,10 +12945,11 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
-                app_server=args.codex_app_review_app_server,
-                thread_id=args.codex_app_review_thread_id,
-                thread_cwd=args.codex_app_review_cwd,
-                raw_file=args.codex_app_review_raw_file,
+                app_server=adapter_selection.get("app_server") if isinstance(adapter_selection.get("app_server"), str) else None,
+                thread_id=adapter_selection.get("thread_id") if isinstance(adapter_selection.get("thread_id"), str) else None,
+                thread_cwd=adapter_selection.get("thread_cwd") if isinstance(adapter_selection.get("thread_cwd"), str) else None,
+                raw_file=adapter_selection.get("raw_file") if isinstance(adapter_selection.get("raw_file"), str) else None,
+                adapter_selection=adapter_selection,
             )
         else:
             engine_payload = run_default_review_engine(
@@ -12551,6 +12958,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
+                adapter_selection=adapter_selection,
             )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,

--- a/skills/loom-init/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-init/.loom-runtime/loom-review/SKILL.md
@@ -42,9 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 选择安全的 authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
 
-默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
+已验证 Codex App host context 中，默认 `review run` 使用 `loom/codex-app-review`，并必须证明 app-server/session locator、thread id、cwd proof、target root 与 reviewed head 绑定一致；该路径不得启动嵌套 `codex exec`。`CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex` + `codex exec --output-schema`。proof 冲突、cwd / target / head 不匹配或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -54,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 
@@ -75,7 +75,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - review 机械基线结果
 - build gate 是否允许进入正式审查
 - review artifact 的定位与已记录结论
-- 默认 engine 的执行结果、evidence 定位与 fail-closed 原因
+- selected adapter、fallback reason、thread/target binding summary、reviewed head、evidence 定位与 fail-closed 原因
 - manual review 的回退写回入口
 - review record 中的权威 findings / disposition 摘要
 - 审查结论（`allow` / `block` / `fallback`）

--- a/skills/loom-init/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-init/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,7 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
-- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-init/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/review-execution.md
@@ -21,7 +21,7 @@ Loom 把 review 分成四层：
 1. `flow review`
    - 只读基线；确认是否具备进入 formal review 的条件
 2. `review run`
-   - 调用默认 Codex-backed reviewer，产出结构化 review evidence 与 Loom-normalized findings
+   - 按宿主 proof 选择 authoritative adapter，产出结构化 review evidence 与 Loom-normalized findings
 3. `review record`
    - 把 formal review 结论写入单一 authored review record
 
@@ -47,27 +47,33 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责选择安全的 authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
+默认 engine 按宿主 proof 选择：
+
+- 已验证 Codex App host context 默认选择 `loom/codex-app-review`，不启动嵌套 `codex exec`
+- `CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex`，能力来源仍是 `codex exec --output-schema`
+- 显式 `--engine-adapter` 优先级最高，继续保留 Stage 2 authoritative opt-in / fallback 调试入口
+
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-Codex App review adapter 有两种显式入口，默认均不启用：
+Codex App review adapter 有三种入口：
 
-- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
-- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- verified host default：不传 `--engine-adapter`，但必须能证明 app-server/session locator、thread id、thread cwd、target root 与 reviewed head 绑定一致
+- explicit authoritative：显式选择 `review run --engine-adapter loom/codex-app-review`，用于调试或非默认宿主
+- shadow comparison：显式选择 `review run --shadow-engine-adapter loom/codex-app-review`
 - shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
-- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
-- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
-- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof；live app-server unavailable 时默认 fallback 到 `loom/default-codex`
+- thread cwd proof 必须等于 target root；cwd / target / reviewed head 绑定冲突或 schema proof 失败时必须 fail closed
 - authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
 - authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
+- `engine_metadata` 必须记录 selected adapter、selection source、fallback reason、thread/target binding summary、reviewed head 与 evidence locators
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
@@ -77,8 +83,8 @@ Codex App review adapter 有两种显式入口，默认均不启用：
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
-- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
+- `adapter`: `loom/default-codex` 或 verified/explicit `loom/codex-app-review`
+- `engine`: `codex` 或 verified/explicit `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -3126,6 +3126,19 @@ def require_review_run_payload(
                 for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
                     if not isinstance(evidence.get(key), str) or not evidence.get(key):
                         failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
+    engine_metadata = payload.get("engine_metadata")
+    if engine_adapter == "loom/codex-app-review" and engine.get("result") == "pass":
+        if not isinstance(engine_metadata, dict):
+            failures.append(Failure(category, f"{context} app review pass must expose `engine_metadata`"))
+        else:
+            for key in ("selected_adapter", "selection_source", "app_server", "thread_id", "thread_cwd", "raw_result", "normalized_findings", "context_pack", "reviewed_head"):
+                value = engine_metadata.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} app review metadata must include non-empty `{key}`"))
+            if engine_metadata.get("selected_adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} app review metadata must bind the selected adapter"))
+            if "normalized review_record_input only" not in str(engine_metadata.get("authority_boundary", "")):
+                failures.append(Failure(category, f"{context} app review metadata must keep raw App output outside merge-ready truth"))
 
 
 def require_runtime_state_payload(
@@ -5725,7 +5738,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
 
         prepare_review_target(review_target, "review run positive chain")
         write_fake_codex(fake_bin / "codex", mode="success")
-        success_env = prepend_path_env(fake_bin)
+        success_env = prepend_path_env(fake_bin, {"CI": "", "CODEX_CI": ""})
 
         payload, error = load_command_json(
             root,
@@ -5893,6 +5906,217 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_default_target = Path(tmp) / "review-run-codex-app-default"
+        prepare_review_target(app_default_target, "review run Codex App host default")
+        app_default_raw = app_default_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_default_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_default_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App default reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-default-warn-1",
+                            "summary": "Codex App default review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_default_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-default-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-default-proof",
+                "--codex-app-review-cwd",
+                str(app_default_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App host default failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App host default",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("adapter") != "loom/codex-app-review" or engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must select the app adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review" or review_record_input.get("reviewer") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must author app adapter review_record_input"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("selection_source") != "codex-app-host-default" or metadata.get("thread_id") != "thread-stage3-default-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must expose selected adapter and thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_default_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored default app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume default Codex App raw evidence before review record is authored"))
+
+        app_ci_fallback_target = Path(tmp) / "review-run-codex-app-ci-fallback"
+        prepare_review_target(app_ci_fallback_target, "review run Codex App CI fallback")
+        app_ci_raw = app_ci_fallback_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_ci_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_ci_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_ci_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-ci-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-ci-proof",
+                "--codex-app-review-cwd",
+                str(app_ci_fallback_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=prepend_path_env(fake_bin, {"CODEX_CI": "1"}),
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App CI fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App CI fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "ci-or-codex-ci":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App CI fallback must keep the default codex exec adapter"))
+
+        app_unavailable_fallback_target = Path(tmp) / "review-run-codex-app-unavailable-fallback"
+        prepare_review_target(app_unavailable_fallback_target, "review run Codex App unavailable fallback")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_unavailable_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                f"unix://{tmp}/missing-codex-app.sock",
+                "--codex-app-review-thread-id",
+                "thread-stage3-missing-endpoint",
+                "--codex-app-review-cwd",
+                str(app_unavailable_fallback_target),
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App unavailable fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App unavailable fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "app-server-unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App unavailable fallback must record default adapter fallback"))
+
+        app_conflict_target = Path(tmp) / "review-run-codex-app-proof-conflict"
+        prepare_review_target(app_conflict_target, "review run Codex App proof conflict")
+        app_conflict_raw = app_conflict_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_conflict_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_conflict_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_conflict_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-conflict-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-conflict-proof",
+                "--codex-app-review-cwd",
+                str(Path(tmp) / "different-cwd"),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App proof conflict failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must fail closed"))
+        else:
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            if engine.get("adapter") != "loom/codex-app-review" or engine.get("failure_reason") != "runtime_conflict":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not fallback to default codex"))
+            if "does not match target root" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must expose cwd mismatch"))
+            if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not emit review_record_input"))
 
         app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
         prepare_review_target(app_authoritative_target, "review run Codex App authoritative")

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,6 +118,10 @@ CODEX_APP_REVIEW_ENGINE = "codex-app-review"
 CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
 AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
+CODEX_APP_REVIEW_ENDPOINT_ENV = "LOOM_CODEX_APP_REVIEW_ENDPOINT"
+CODEX_APP_REVIEW_THREAD_ID_ENV = "LOOM_CODEX_APP_REVIEW_THREAD_ID"
+CODEX_APP_REVIEW_CWD_ENV = "LOOM_CODEX_APP_REVIEW_CWD"
+CODEX_THREAD_ID_ENV = "CODEX_THREAD_ID"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS: int | None = None
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -492,26 +496,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
         help=(
             "Optional authoritative review engine adapter for review run/record. "
-            "Default review run remains loom/default-codex."
+            "When omitted, verified Codex App sessions use loom/codex-app-review; headless/CI fallback remains loom/default-codex."
         ),
     )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
     review.add_argument(
         "--codex-app-review-app-server",
-        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App app-server/session locator. Defaults to ${CODEX_APP_REVIEW_ENDPOINT_ENV} when available.",
     )
     review.add_argument(
         "--codex-app-review-thread-id",
-        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread id. Defaults to ${CODEX_APP_REVIEW_THREAD_ID_ENV}, or ${CODEX_THREAD_ID_ENV} when an endpoint is present.",
     )
     review.add_argument(
         "--codex-app-review-cwd",
-        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread cwd proof. Defaults to ${CODEX_APP_REVIEW_CWD_ENV}.",
     )
     review.add_argument(
         "--codex-app-review-raw-file",
-        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+        help="Optional repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
     )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
@@ -4250,6 +4254,19 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def truthy_env(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def non_empty_str(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def execution_attempt_directory(target_root: Path, item_id: str) -> Path:
     return target_root / ".loom/runtime/attempts" / item_id
 
@@ -6264,8 +6281,26 @@ def run_default_review_engine(
     engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "explicit-or-legacy-default",
+            "fallback_reason": None,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=None,
+                thread_id=None,
+                thread_cwd=None,
+                reviewed_head=reviewed_head,
+                raw_file=None,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     prompt_path = runtime_root / "prompt.txt"
     result_path = runtime_root / "engine-result.json"
@@ -6313,6 +6348,7 @@ def run_default_review_engine(
                     "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
+            "engine_metadata": selection_metadata,
         }
 
     scratch_dir.mkdir(parents=True, exist_ok=True)
@@ -6403,6 +6439,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
@@ -6424,6 +6461,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     if raw_payload is not None and not result_path.exists():
@@ -6440,6 +6478,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
@@ -6462,6 +6501,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     write_json_file(findings_path, {"findings": normalized_payload["findings"]})
@@ -6471,6 +6511,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
@@ -6494,6 +6535,13 @@ def run_default_review_engine(
             "failure_reason": None,
             "reviewed_head": reviewed_head,
             "evidence": engine_evidence,
+        },
+        "engine_metadata": {
+            **selection_metadata,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "raw_result": relative_to_root(result_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "metadata": relative_to_root(metadata_path, context["target_root"]),
         },
         "review_record_input": {
             "decision": normalized_payload["decision"],
@@ -7254,6 +7302,312 @@ def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: st
     return normalized, []
 
 
+def codex_app_endpoint_socket_path(app_server: str | None) -> Path | None:
+    endpoint = non_empty_str(app_server)
+    if endpoint is None:
+        return None
+    if endpoint.startswith("unix://"):
+        path_text = endpoint.removeprefix("unix://")
+    elif endpoint.startswith("/"):
+        path_text = endpoint
+    else:
+        return None
+    if not path_text:
+        return None
+    return Path(path_text).expanduser()
+
+
+def codex_app_endpoint_is_live_capable(app_server: str | None) -> bool:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    return socket_path is not None and socket_path.exists()
+
+
+def codex_app_review_bindings_from_args_env(args: argparse.Namespace) -> dict[str, str | None]:
+    app_server = non_empty_str(args.codex_app_review_app_server) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_ENDPOINT_ENV))
+    thread_id = (
+        non_empty_str(args.codex_app_review_thread_id)
+        or non_empty_str(os.environ.get(CODEX_APP_REVIEW_THREAD_ID_ENV))
+        or (non_empty_str(os.environ.get(CODEX_THREAD_ID_ENV)) if app_server else None)
+    )
+    thread_cwd = non_empty_str(args.codex_app_review_cwd) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_CWD_ENV))
+    raw_file = non_empty_str(args.codex_app_review_raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": thread_cwd,
+        "raw_file": raw_file,
+    }
+
+
+def codex_app_binding_summary(
+    target_root: Path,
+    *,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    reviewed_head: str,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    cwd_match: bool | None = None
+    cwd_summary: str | None = thread_cwd
+    if non_empty_str(thread_cwd):
+        try:
+            cwd_path = Path(str(thread_cwd)).expanduser().resolve()
+        except OSError:
+            cwd_match = False
+        else:
+            cwd_match = cwd_path == target_root
+            cwd_summary = str(cwd_path)
+    raw_source: str | None = None
+    if non_empty_str(raw_file):
+        raw_path, raw_errors = resolve_repo_relative_path(target_root, str(raw_file), label="Codex App authoritative review raw file")
+        if raw_path is not None and not raw_errors:
+            raw_source = relative_to_root(raw_path, target_root)
+        else:
+            raw_source = str(raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_summary,
+        "thread_cwd_matches_target_root": cwd_match,
+        "target_root": str(target_root),
+        "reviewed_head": reviewed_head,
+        "raw_source": raw_source,
+        "live_endpoint_capable": codex_app_endpoint_is_live_capable(app_server),
+    }
+
+
+def select_review_adapter(
+    args: argparse.Namespace,
+    target_root: Path,
+    *,
+    reviewed_head: str,
+) -> dict[str, Any]:
+    bindings = codex_app_review_bindings_from_args_env(args)
+    explicit_adapter = non_empty_str(args.engine_adapter)
+    if explicit_adapter:
+        return {
+            "adapter": explicit_adapter,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    if truthy_env("CI") or truthy_env("CODEX_CI"):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "headless-fallback",
+            "fallback_reason": "ci-or-codex-ci",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    app_server = bindings["app_server"]
+    thread_id = bindings["thread_id"]
+    thread_cwd = bindings["thread_cwd"]
+    raw_file = bindings["raw_file"]
+    if not app_server or not thread_id or not thread_cwd:
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "missing-codex-app-host-proof",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    if not raw_file and not codex_app_endpoint_is_live_capable(app_server):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "app-server-unavailable",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    return {
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "selection_source": "codex-app-host-default",
+        "fallback_reason": None,
+        **bindings,
+        "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+    }
+
+
+def review_adapter_selection_metadata(selection: dict[str, Any], *, reviewed_head: str) -> dict[str, Any]:
+    return {
+        "selected_adapter": selection["adapter"],
+        "selection_source": selection.get("selection_source"),
+        "fallback_reason": selection.get("fallback_reason"),
+        "app_server": selection.get("app_server"),
+        "thread_id": selection.get("thread_id"),
+        "thread_cwd": selection.get("thread_cwd"),
+        "target_root": selection.get("binding_summary", {}).get("target_root")
+        if isinstance(selection.get("binding_summary"), dict)
+        else None,
+        "reviewed_head": reviewed_head,
+        "thread_target_binding": selection.get("binding_summary"),
+    }
+
+
+def jsonrpc_send_request(stdin: Any, *, request_id: int, method: str, params: dict[str, Any]) -> None:
+    stdin.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}) + "\n")
+    stdin.flush()
+
+
+def jsonrpc_read_response(stdout: Any, *, request_id: int) -> tuple[dict[str, Any] | None, list[dict[str, Any]], list[str]]:
+    notifications: list[dict[str, Any]] = []
+    while True:
+        line = stdout.readline()
+        if not line:
+            return None, notifications, [f"app-server closed before response id {request_id}"]
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("id") == request_id:
+            return payload, notifications, []
+        notifications.append(payload)
+
+
+def find_exited_review_text(payload: Any) -> str | None:
+    if isinstance(payload, dict):
+        if payload.get("type") == "exitedReviewMode" and isinstance(payload.get("review"), str):
+            return payload["review"]
+        for value in payload.values():
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    return None
+
+
+def find_normalized_review_payload(payload: Any) -> dict[str, Any] | None:
+    normalized, errors = normalize_engine_review_result(payload, relative="app-server turn/start output")
+    if normalized is not None and not errors:
+        return normalized
+    if isinstance(payload, dict):
+        for value in payload.values():
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    return None
+
+
+def app_server_proxy_command(app_server: str) -> list[str] | None:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    if socket_path is None:
+        return None
+    return ["codex", "app-server", "proxy", "--sock", str(socket_path)]
+
+
+def run_codex_app_live_review(
+    *,
+    app_server: str,
+    thread_id: str,
+    reviewed_head: str,
+    thread_cwd: str,
+    prompt_text: str,
+) -> tuple[str | None, dict[str, Any], list[str]]:
+    command = app_server_proxy_command(app_server)
+    if command is None:
+        return None, {}, [f"unsupported Codex App review endpoint: {app_server}"]
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return None, {}, [f"Codex App review endpoint is unavailable: {exc}"]
+    assert process.stdin is not None
+    assert process.stdout is not None
+    metadata: dict[str, Any] = {"review_target": {"type": "commit", "sha": reviewed_head}}
+    try:
+        jsonrpc_send_request(process.stdin, request_id=1, method="initialize", params={"clientInfo": {"name": "loom", "version": "stage3"}, "capabilities": {}})
+        initialize_response, _, initialize_errors = jsonrpc_read_response(process.stdout, request_id=1)
+        if initialize_errors:
+            return None, metadata, initialize_errors
+        if isinstance(initialize_response, dict) and isinstance(initialize_response.get("error"), dict):
+            return None, metadata, [f"Codex App initialize failed: {initialize_response['error']}"]
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=2,
+            method="review/start",
+            params={
+                "threadId": thread_id,
+                "delivery": "inline",
+                "target": {"type": "commit", "sha": reviewed_head},
+            },
+        )
+        review_response, review_notifications, review_errors = jsonrpc_read_response(process.stdout, request_id=2)
+        if review_errors:
+            return None, metadata, review_errors
+        if isinstance(review_response, dict) and isinstance(review_response.get("error"), dict):
+            return None, metadata, [f"Codex App review/start failed: {review_response['error']}"]
+        result = review_response.get("result") if isinstance(review_response, dict) else None
+        if isinstance(result, dict):
+            metadata["review_thread_id"] = result.get("reviewThreadId")
+        review_text = find_exited_review_text(result) or find_exited_review_text(review_notifications)
+        if not isinstance(review_text, str) or not review_text.strip():
+            return None, metadata, ["Codex App review/start did not return exitedReviewMode.review"]
+
+        parsed_review, parsed_errors = normalize_authoritative_codex_app_review_text(review_text, relative="app-server review/start output")
+        if parsed_review is not None and not parsed_errors:
+            metadata["normalization_source"] = "review-start-json"
+            return review_text, {**metadata, "normalized": parsed_review}, []
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=3,
+            method="turn/start",
+            params={
+                "threadId": metadata.get("review_thread_id") or thread_id,
+                "cwd": thread_cwd,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Normalize this Codex App review output into the provided JSON schema. "
+                            "Return only the structured review result.\n\n"
+                            f"{review_text}"
+                        ),
+                    }
+                ],
+                "outputSchema": load_json_file(review_engine_schema_path()),
+            },
+        )
+        turn_response, turn_notifications, turn_errors = jsonrpc_read_response(process.stdout, request_id=3)
+        if turn_errors:
+            return review_text, metadata, turn_errors
+        if isinstance(turn_response, dict) and isinstance(turn_response.get("error"), dict):
+            return review_text, metadata, [f"Codex App turn/start normalization failed: {turn_response['error']}"]
+        normalized = find_normalized_review_payload(turn_response.get("result") if isinstance(turn_response, dict) else None)
+        if normalized is None:
+            normalized = find_normalized_review_payload(turn_notifications)
+        if normalized is None:
+            return review_text, metadata, ["Codex App turn/start did not return a Loom review result"]
+        metadata["normalization_source"] = "turn-start-output-schema"
+        return review_text, {**metadata, "normalized": normalized}, []
+    finally:
+        try:
+            process.terminate()
+        except OSError:
+            pass
+
+
 def shadow_adapter_slug(adapter: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
 
@@ -7453,8 +7807,30 @@ def run_codex_app_review_authoritative_adapter(
     thread_id: str | None,
     thread_cwd: str | None,
     raw_file: str | None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            "app_server": app_server,
+            "thread_id": thread_id,
+            "thread_cwd": thread_cwd,
+            "raw_file": raw_file,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=app_server,
+                thread_id=thread_id,
+                thread_cwd=thread_cwd,
+                reviewed_head=reviewed_head,
+                raw_file=raw_file,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     raw_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
@@ -7488,7 +7864,6 @@ def run_codex_app_review_authoritative_adapter(
         ("--codex-app-review-app-server", app_server),
         ("--codex-app-review-thread-id", thread_id),
         ("--codex-app-review-cwd", thread_cwd),
-        ("--codex-app-review-raw-file", raw_file),
     ):
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(label)
@@ -7518,6 +7893,8 @@ def run_codex_app_review_authoritative_adapter(
         missing_inputs.extend(source_errors)
         if source_path is not None:
             source_relative = relative_to_root(source_path, context["target_root"])
+    elif not codex_app_endpoint_is_live_capable(app_server):
+        missing_inputs.append("--codex-app-review-raw-file or live app-server endpoint")
 
     if missing_inputs:
         write_json_file(
@@ -7527,6 +7904,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "runtime_conflict",
@@ -7553,6 +7931,7 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative or thread_cwd,
@@ -7560,17 +7939,30 @@ def run_codex_app_review_authoritative_adapter(
             },
         }
 
-    try:
-        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
-    except OSError as exc:
-        raw_text = ""
-        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
-        normalized = None
+    live_metadata: dict[str, Any] = {}
+    if source_path is not None:
+        try:
+            raw_text = source_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raw_text = ""
+            normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+            normalized = None
+        else:
+            normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+                raw_text,
+                relative=source_relative or str(raw_file),
+            )
     else:
-        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
-            raw_text,
-            relative=source_relative or str(raw_file),
+        raw_text, live_metadata, normalization_errors = run_codex_app_live_review(
+            app_server=str(app_server),
+            thread_id=str(thread_id),
+            reviewed_head=reviewed_head,
+            thread_cwd=str(thread_cwd),
+            prompt_text=instructions_path.read_text(encoding="utf-8"),
         )
+        normalized = live_metadata.get("normalized") if isinstance(live_metadata.get("normalized"), dict) else None
+        if raw_text is None:
+            raw_text = ""
 
     if normalization_errors or normalized is None:
         if raw_text:
@@ -7582,6 +7974,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "schema_drift",
@@ -7592,6 +7985,7 @@ def run_codex_app_review_authoritative_adapter(
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         )
         return {
@@ -7609,10 +8003,12 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         }
 
@@ -7623,6 +8019,7 @@ def run_codex_app_review_authoritative_adapter(
         "engine": CODEX_APP_REVIEW_ENGINE,
         "adapter": CODEX_APP_REVIEW_ADAPTER,
         "profile": engine_profile,
+        **selection_metadata,
         "context_pack": relative_to_root(context_pack_path, context["target_root"]),
         "result": "pass",
         "reviewed_head": reviewed_head,
@@ -7634,6 +8031,11 @@ def run_codex_app_review_authoritative_adapter(
         "thread_id": thread_id,
         "thread_cwd": cwd_relative,
         "raw_source": source_relative,
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "review_thread_id": live_metadata.get("review_thread_id") if live_metadata else (thread_id if source_path is not None else None),
+        **({"live_review": {key: value for key, value in live_metadata.items() if key != "normalized"}} if live_metadata else {}),
         "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
     }
     write_json_file(metadata_path, metadata)
@@ -12452,7 +12854,9 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
-        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
+        current_head = git_head_sha(target_root) or "unknown-head"
+        adapter_selection = select_review_adapter(args, target_root, reviewed_head=current_head)
+        requested_engine_adapter = str(adapter_selection["adapter"])
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
@@ -12484,9 +12888,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12524,9 +12929,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12539,10 +12945,11 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
-                app_server=args.codex_app_review_app_server,
-                thread_id=args.codex_app_review_thread_id,
-                thread_cwd=args.codex_app_review_cwd,
-                raw_file=args.codex_app_review_raw_file,
+                app_server=adapter_selection.get("app_server") if isinstance(adapter_selection.get("app_server"), str) else None,
+                thread_id=adapter_selection.get("thread_id") if isinstance(adapter_selection.get("thread_id"), str) else None,
+                thread_cwd=adapter_selection.get("thread_cwd") if isinstance(adapter_selection.get("thread_cwd"), str) else None,
+                raw_file=adapter_selection.get("raw_file") if isinstance(adapter_selection.get("raw_file"), str) else None,
+                adapter_selection=adapter_selection,
             )
         else:
             engine_payload = run_default_review_engine(
@@ -12551,6 +12958,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
+                adapter_selection=adapter_selection,
             )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,

--- a/skills/loom-merge-ready/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-review/SKILL.md
@@ -42,9 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 选择安全的 authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
 
-默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
+已验证 Codex App host context 中，默认 `review run` 使用 `loom/codex-app-review`，并必须证明 app-server/session locator、thread id、cwd proof、target root 与 reviewed head 绑定一致；该路径不得启动嵌套 `codex exec`。`CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex` + `codex exec --output-schema`。proof 冲突、cwd / target / head 不匹配或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -54,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 
@@ -75,7 +75,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - review 机械基线结果
 - build gate 是否允许进入正式审查
 - review artifact 的定位与已记录结论
-- 默认 engine 的执行结果、evidence 定位与 fail-closed 原因
+- selected adapter、fallback reason、thread/target binding summary、reviewed head、evidence 定位与 fail-closed 原因
 - manual review 的回退写回入口
 - review record 中的权威 findings / disposition 摘要
 - 审查结论（`allow` / `block` / `fallback`）

--- a/skills/loom-merge-ready/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,7 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
-- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/review-execution.md
@@ -21,7 +21,7 @@ Loom 把 review 分成四层：
 1. `flow review`
    - 只读基线；确认是否具备进入 formal review 的条件
 2. `review run`
-   - 调用默认 Codex-backed reviewer，产出结构化 review evidence 与 Loom-normalized findings
+   - 按宿主 proof 选择 authoritative adapter，产出结构化 review evidence 与 Loom-normalized findings
 3. `review record`
    - 把 formal review 结论写入单一 authored review record
 
@@ -47,27 +47,33 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责选择安全的 authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
+默认 engine 按宿主 proof 选择：
+
+- 已验证 Codex App host context 默认选择 `loom/codex-app-review`，不启动嵌套 `codex exec`
+- `CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex`，能力来源仍是 `codex exec --output-schema`
+- 显式 `--engine-adapter` 优先级最高，继续保留 Stage 2 authoritative opt-in / fallback 调试入口
+
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-Codex App review adapter 有两种显式入口，默认均不启用：
+Codex App review adapter 有三种入口：
 
-- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
-- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- verified host default：不传 `--engine-adapter`，但必须能证明 app-server/session locator、thread id、thread cwd、target root 与 reviewed head 绑定一致
+- explicit authoritative：显式选择 `review run --engine-adapter loom/codex-app-review`，用于调试或非默认宿主
+- shadow comparison：显式选择 `review run --shadow-engine-adapter loom/codex-app-review`
 - shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
-- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
-- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
-- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof；live app-server unavailable 时默认 fallback 到 `loom/default-codex`
+- thread cwd proof 必须等于 target root；cwd / target / reviewed head 绑定冲突或 schema proof 失败时必须 fail closed
 - authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
 - authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
+- `engine_metadata` 必须记录 selected adapter、selection source、fallback reason、thread/target binding summary、reviewed head 与 evidence locators
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
@@ -77,8 +83,8 @@ Codex App review adapter 有两种显式入口，默认均不启用：
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
-- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
+- `adapter`: `loom/default-codex` 或 verified/explicit `loom/codex-app-review`
+- `engine`: `codex` 或 verified/explicit `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -3126,6 +3126,19 @@ def require_review_run_payload(
                 for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
                     if not isinstance(evidence.get(key), str) or not evidence.get(key):
                         failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
+    engine_metadata = payload.get("engine_metadata")
+    if engine_adapter == "loom/codex-app-review" and engine.get("result") == "pass":
+        if not isinstance(engine_metadata, dict):
+            failures.append(Failure(category, f"{context} app review pass must expose `engine_metadata`"))
+        else:
+            for key in ("selected_adapter", "selection_source", "app_server", "thread_id", "thread_cwd", "raw_result", "normalized_findings", "context_pack", "reviewed_head"):
+                value = engine_metadata.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} app review metadata must include non-empty `{key}`"))
+            if engine_metadata.get("selected_adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} app review metadata must bind the selected adapter"))
+            if "normalized review_record_input only" not in str(engine_metadata.get("authority_boundary", "")):
+                failures.append(Failure(category, f"{context} app review metadata must keep raw App output outside merge-ready truth"))
 
 
 def require_runtime_state_payload(
@@ -5725,7 +5738,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
 
         prepare_review_target(review_target, "review run positive chain")
         write_fake_codex(fake_bin / "codex", mode="success")
-        success_env = prepend_path_env(fake_bin)
+        success_env = prepend_path_env(fake_bin, {"CI": "", "CODEX_CI": ""})
 
         payload, error = load_command_json(
             root,
@@ -5893,6 +5906,217 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_default_target = Path(tmp) / "review-run-codex-app-default"
+        prepare_review_target(app_default_target, "review run Codex App host default")
+        app_default_raw = app_default_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_default_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_default_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App default reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-default-warn-1",
+                            "summary": "Codex App default review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_default_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-default-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-default-proof",
+                "--codex-app-review-cwd",
+                str(app_default_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App host default failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App host default",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("adapter") != "loom/codex-app-review" or engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must select the app adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review" or review_record_input.get("reviewer") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must author app adapter review_record_input"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("selection_source") != "codex-app-host-default" or metadata.get("thread_id") != "thread-stage3-default-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must expose selected adapter and thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_default_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored default app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume default Codex App raw evidence before review record is authored"))
+
+        app_ci_fallback_target = Path(tmp) / "review-run-codex-app-ci-fallback"
+        prepare_review_target(app_ci_fallback_target, "review run Codex App CI fallback")
+        app_ci_raw = app_ci_fallback_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_ci_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_ci_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_ci_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-ci-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-ci-proof",
+                "--codex-app-review-cwd",
+                str(app_ci_fallback_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=prepend_path_env(fake_bin, {"CODEX_CI": "1"}),
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App CI fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App CI fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "ci-or-codex-ci":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App CI fallback must keep the default codex exec adapter"))
+
+        app_unavailable_fallback_target = Path(tmp) / "review-run-codex-app-unavailable-fallback"
+        prepare_review_target(app_unavailable_fallback_target, "review run Codex App unavailable fallback")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_unavailable_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                f"unix://{tmp}/missing-codex-app.sock",
+                "--codex-app-review-thread-id",
+                "thread-stage3-missing-endpoint",
+                "--codex-app-review-cwd",
+                str(app_unavailable_fallback_target),
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App unavailable fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App unavailable fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "app-server-unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App unavailable fallback must record default adapter fallback"))
+
+        app_conflict_target = Path(tmp) / "review-run-codex-app-proof-conflict"
+        prepare_review_target(app_conflict_target, "review run Codex App proof conflict")
+        app_conflict_raw = app_conflict_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_conflict_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_conflict_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_conflict_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-conflict-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-conflict-proof",
+                "--codex-app-review-cwd",
+                str(Path(tmp) / "different-cwd"),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App proof conflict failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must fail closed"))
+        else:
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            if engine.get("adapter") != "loom/codex-app-review" or engine.get("failure_reason") != "runtime_conflict":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not fallback to default codex"))
+            if "does not match target root" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must expose cwd mismatch"))
+            if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not emit review_record_input"))
 
         app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
         prepare_review_target(app_authoritative_target, "review run Codex App authoritative")

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,6 +118,10 @@ CODEX_APP_REVIEW_ENGINE = "codex-app-review"
 CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
 AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
+CODEX_APP_REVIEW_ENDPOINT_ENV = "LOOM_CODEX_APP_REVIEW_ENDPOINT"
+CODEX_APP_REVIEW_THREAD_ID_ENV = "LOOM_CODEX_APP_REVIEW_THREAD_ID"
+CODEX_APP_REVIEW_CWD_ENV = "LOOM_CODEX_APP_REVIEW_CWD"
+CODEX_THREAD_ID_ENV = "CODEX_THREAD_ID"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS: int | None = None
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -492,26 +496,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
         help=(
             "Optional authoritative review engine adapter for review run/record. "
-            "Default review run remains loom/default-codex."
+            "When omitted, verified Codex App sessions use loom/codex-app-review; headless/CI fallback remains loom/default-codex."
         ),
     )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
     review.add_argument(
         "--codex-app-review-app-server",
-        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App app-server/session locator. Defaults to ${CODEX_APP_REVIEW_ENDPOINT_ENV} when available.",
     )
     review.add_argument(
         "--codex-app-review-thread-id",
-        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread id. Defaults to ${CODEX_APP_REVIEW_THREAD_ID_ENV}, or ${CODEX_THREAD_ID_ENV} when an endpoint is present.",
     )
     review.add_argument(
         "--codex-app-review-cwd",
-        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread cwd proof. Defaults to ${CODEX_APP_REVIEW_CWD_ENV}.",
     )
     review.add_argument(
         "--codex-app-review-raw-file",
-        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+        help="Optional repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
     )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
@@ -4250,6 +4254,19 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def truthy_env(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def non_empty_str(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def execution_attempt_directory(target_root: Path, item_id: str) -> Path:
     return target_root / ".loom/runtime/attempts" / item_id
 
@@ -6264,8 +6281,26 @@ def run_default_review_engine(
     engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "explicit-or-legacy-default",
+            "fallback_reason": None,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=None,
+                thread_id=None,
+                thread_cwd=None,
+                reviewed_head=reviewed_head,
+                raw_file=None,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     prompt_path = runtime_root / "prompt.txt"
     result_path = runtime_root / "engine-result.json"
@@ -6313,6 +6348,7 @@ def run_default_review_engine(
                     "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
+            "engine_metadata": selection_metadata,
         }
 
     scratch_dir.mkdir(parents=True, exist_ok=True)
@@ -6403,6 +6439,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
@@ -6424,6 +6461,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     if raw_payload is not None and not result_path.exists():
@@ -6440,6 +6478,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
@@ -6462,6 +6501,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     write_json_file(findings_path, {"findings": normalized_payload["findings"]})
@@ -6471,6 +6511,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
@@ -6494,6 +6535,13 @@ def run_default_review_engine(
             "failure_reason": None,
             "reviewed_head": reviewed_head,
             "evidence": engine_evidence,
+        },
+        "engine_metadata": {
+            **selection_metadata,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "raw_result": relative_to_root(result_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "metadata": relative_to_root(metadata_path, context["target_root"]),
         },
         "review_record_input": {
             "decision": normalized_payload["decision"],
@@ -7254,6 +7302,312 @@ def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: st
     return normalized, []
 
 
+def codex_app_endpoint_socket_path(app_server: str | None) -> Path | None:
+    endpoint = non_empty_str(app_server)
+    if endpoint is None:
+        return None
+    if endpoint.startswith("unix://"):
+        path_text = endpoint.removeprefix("unix://")
+    elif endpoint.startswith("/"):
+        path_text = endpoint
+    else:
+        return None
+    if not path_text:
+        return None
+    return Path(path_text).expanduser()
+
+
+def codex_app_endpoint_is_live_capable(app_server: str | None) -> bool:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    return socket_path is not None and socket_path.exists()
+
+
+def codex_app_review_bindings_from_args_env(args: argparse.Namespace) -> dict[str, str | None]:
+    app_server = non_empty_str(args.codex_app_review_app_server) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_ENDPOINT_ENV))
+    thread_id = (
+        non_empty_str(args.codex_app_review_thread_id)
+        or non_empty_str(os.environ.get(CODEX_APP_REVIEW_THREAD_ID_ENV))
+        or (non_empty_str(os.environ.get(CODEX_THREAD_ID_ENV)) if app_server else None)
+    )
+    thread_cwd = non_empty_str(args.codex_app_review_cwd) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_CWD_ENV))
+    raw_file = non_empty_str(args.codex_app_review_raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": thread_cwd,
+        "raw_file": raw_file,
+    }
+
+
+def codex_app_binding_summary(
+    target_root: Path,
+    *,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    reviewed_head: str,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    cwd_match: bool | None = None
+    cwd_summary: str | None = thread_cwd
+    if non_empty_str(thread_cwd):
+        try:
+            cwd_path = Path(str(thread_cwd)).expanduser().resolve()
+        except OSError:
+            cwd_match = False
+        else:
+            cwd_match = cwd_path == target_root
+            cwd_summary = str(cwd_path)
+    raw_source: str | None = None
+    if non_empty_str(raw_file):
+        raw_path, raw_errors = resolve_repo_relative_path(target_root, str(raw_file), label="Codex App authoritative review raw file")
+        if raw_path is not None and not raw_errors:
+            raw_source = relative_to_root(raw_path, target_root)
+        else:
+            raw_source = str(raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_summary,
+        "thread_cwd_matches_target_root": cwd_match,
+        "target_root": str(target_root),
+        "reviewed_head": reviewed_head,
+        "raw_source": raw_source,
+        "live_endpoint_capable": codex_app_endpoint_is_live_capable(app_server),
+    }
+
+
+def select_review_adapter(
+    args: argparse.Namespace,
+    target_root: Path,
+    *,
+    reviewed_head: str,
+) -> dict[str, Any]:
+    bindings = codex_app_review_bindings_from_args_env(args)
+    explicit_adapter = non_empty_str(args.engine_adapter)
+    if explicit_adapter:
+        return {
+            "adapter": explicit_adapter,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    if truthy_env("CI") or truthy_env("CODEX_CI"):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "headless-fallback",
+            "fallback_reason": "ci-or-codex-ci",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    app_server = bindings["app_server"]
+    thread_id = bindings["thread_id"]
+    thread_cwd = bindings["thread_cwd"]
+    raw_file = bindings["raw_file"]
+    if not app_server or not thread_id or not thread_cwd:
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "missing-codex-app-host-proof",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    if not raw_file and not codex_app_endpoint_is_live_capable(app_server):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "app-server-unavailable",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    return {
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "selection_source": "codex-app-host-default",
+        "fallback_reason": None,
+        **bindings,
+        "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+    }
+
+
+def review_adapter_selection_metadata(selection: dict[str, Any], *, reviewed_head: str) -> dict[str, Any]:
+    return {
+        "selected_adapter": selection["adapter"],
+        "selection_source": selection.get("selection_source"),
+        "fallback_reason": selection.get("fallback_reason"),
+        "app_server": selection.get("app_server"),
+        "thread_id": selection.get("thread_id"),
+        "thread_cwd": selection.get("thread_cwd"),
+        "target_root": selection.get("binding_summary", {}).get("target_root")
+        if isinstance(selection.get("binding_summary"), dict)
+        else None,
+        "reviewed_head": reviewed_head,
+        "thread_target_binding": selection.get("binding_summary"),
+    }
+
+
+def jsonrpc_send_request(stdin: Any, *, request_id: int, method: str, params: dict[str, Any]) -> None:
+    stdin.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}) + "\n")
+    stdin.flush()
+
+
+def jsonrpc_read_response(stdout: Any, *, request_id: int) -> tuple[dict[str, Any] | None, list[dict[str, Any]], list[str]]:
+    notifications: list[dict[str, Any]] = []
+    while True:
+        line = stdout.readline()
+        if not line:
+            return None, notifications, [f"app-server closed before response id {request_id}"]
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("id") == request_id:
+            return payload, notifications, []
+        notifications.append(payload)
+
+
+def find_exited_review_text(payload: Any) -> str | None:
+    if isinstance(payload, dict):
+        if payload.get("type") == "exitedReviewMode" and isinstance(payload.get("review"), str):
+            return payload["review"]
+        for value in payload.values():
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    return None
+
+
+def find_normalized_review_payload(payload: Any) -> dict[str, Any] | None:
+    normalized, errors = normalize_engine_review_result(payload, relative="app-server turn/start output")
+    if normalized is not None and not errors:
+        return normalized
+    if isinstance(payload, dict):
+        for value in payload.values():
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    return None
+
+
+def app_server_proxy_command(app_server: str) -> list[str] | None:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    if socket_path is None:
+        return None
+    return ["codex", "app-server", "proxy", "--sock", str(socket_path)]
+
+
+def run_codex_app_live_review(
+    *,
+    app_server: str,
+    thread_id: str,
+    reviewed_head: str,
+    thread_cwd: str,
+    prompt_text: str,
+) -> tuple[str | None, dict[str, Any], list[str]]:
+    command = app_server_proxy_command(app_server)
+    if command is None:
+        return None, {}, [f"unsupported Codex App review endpoint: {app_server}"]
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return None, {}, [f"Codex App review endpoint is unavailable: {exc}"]
+    assert process.stdin is not None
+    assert process.stdout is not None
+    metadata: dict[str, Any] = {"review_target": {"type": "commit", "sha": reviewed_head}}
+    try:
+        jsonrpc_send_request(process.stdin, request_id=1, method="initialize", params={"clientInfo": {"name": "loom", "version": "stage3"}, "capabilities": {}})
+        initialize_response, _, initialize_errors = jsonrpc_read_response(process.stdout, request_id=1)
+        if initialize_errors:
+            return None, metadata, initialize_errors
+        if isinstance(initialize_response, dict) and isinstance(initialize_response.get("error"), dict):
+            return None, metadata, [f"Codex App initialize failed: {initialize_response['error']}"]
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=2,
+            method="review/start",
+            params={
+                "threadId": thread_id,
+                "delivery": "inline",
+                "target": {"type": "commit", "sha": reviewed_head},
+            },
+        )
+        review_response, review_notifications, review_errors = jsonrpc_read_response(process.stdout, request_id=2)
+        if review_errors:
+            return None, metadata, review_errors
+        if isinstance(review_response, dict) and isinstance(review_response.get("error"), dict):
+            return None, metadata, [f"Codex App review/start failed: {review_response['error']}"]
+        result = review_response.get("result") if isinstance(review_response, dict) else None
+        if isinstance(result, dict):
+            metadata["review_thread_id"] = result.get("reviewThreadId")
+        review_text = find_exited_review_text(result) or find_exited_review_text(review_notifications)
+        if not isinstance(review_text, str) or not review_text.strip():
+            return None, metadata, ["Codex App review/start did not return exitedReviewMode.review"]
+
+        parsed_review, parsed_errors = normalize_authoritative_codex_app_review_text(review_text, relative="app-server review/start output")
+        if parsed_review is not None and not parsed_errors:
+            metadata["normalization_source"] = "review-start-json"
+            return review_text, {**metadata, "normalized": parsed_review}, []
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=3,
+            method="turn/start",
+            params={
+                "threadId": metadata.get("review_thread_id") or thread_id,
+                "cwd": thread_cwd,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Normalize this Codex App review output into the provided JSON schema. "
+                            "Return only the structured review result.\n\n"
+                            f"{review_text}"
+                        ),
+                    }
+                ],
+                "outputSchema": load_json_file(review_engine_schema_path()),
+            },
+        )
+        turn_response, turn_notifications, turn_errors = jsonrpc_read_response(process.stdout, request_id=3)
+        if turn_errors:
+            return review_text, metadata, turn_errors
+        if isinstance(turn_response, dict) and isinstance(turn_response.get("error"), dict):
+            return review_text, metadata, [f"Codex App turn/start normalization failed: {turn_response['error']}"]
+        normalized = find_normalized_review_payload(turn_response.get("result") if isinstance(turn_response, dict) else None)
+        if normalized is None:
+            normalized = find_normalized_review_payload(turn_notifications)
+        if normalized is None:
+            return review_text, metadata, ["Codex App turn/start did not return a Loom review result"]
+        metadata["normalization_source"] = "turn-start-output-schema"
+        return review_text, {**metadata, "normalized": normalized}, []
+    finally:
+        try:
+            process.terminate()
+        except OSError:
+            pass
+
+
 def shadow_adapter_slug(adapter: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
 
@@ -7453,8 +7807,30 @@ def run_codex_app_review_authoritative_adapter(
     thread_id: str | None,
     thread_cwd: str | None,
     raw_file: str | None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            "app_server": app_server,
+            "thread_id": thread_id,
+            "thread_cwd": thread_cwd,
+            "raw_file": raw_file,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=app_server,
+                thread_id=thread_id,
+                thread_cwd=thread_cwd,
+                reviewed_head=reviewed_head,
+                raw_file=raw_file,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     raw_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
@@ -7488,7 +7864,6 @@ def run_codex_app_review_authoritative_adapter(
         ("--codex-app-review-app-server", app_server),
         ("--codex-app-review-thread-id", thread_id),
         ("--codex-app-review-cwd", thread_cwd),
-        ("--codex-app-review-raw-file", raw_file),
     ):
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(label)
@@ -7518,6 +7893,8 @@ def run_codex_app_review_authoritative_adapter(
         missing_inputs.extend(source_errors)
         if source_path is not None:
             source_relative = relative_to_root(source_path, context["target_root"])
+    elif not codex_app_endpoint_is_live_capable(app_server):
+        missing_inputs.append("--codex-app-review-raw-file or live app-server endpoint")
 
     if missing_inputs:
         write_json_file(
@@ -7527,6 +7904,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "runtime_conflict",
@@ -7553,6 +7931,7 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative or thread_cwd,
@@ -7560,17 +7939,30 @@ def run_codex_app_review_authoritative_adapter(
             },
         }
 
-    try:
-        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
-    except OSError as exc:
-        raw_text = ""
-        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
-        normalized = None
+    live_metadata: dict[str, Any] = {}
+    if source_path is not None:
+        try:
+            raw_text = source_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raw_text = ""
+            normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+            normalized = None
+        else:
+            normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+                raw_text,
+                relative=source_relative or str(raw_file),
+            )
     else:
-        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
-            raw_text,
-            relative=source_relative or str(raw_file),
+        raw_text, live_metadata, normalization_errors = run_codex_app_live_review(
+            app_server=str(app_server),
+            thread_id=str(thread_id),
+            reviewed_head=reviewed_head,
+            thread_cwd=str(thread_cwd),
+            prompt_text=instructions_path.read_text(encoding="utf-8"),
         )
+        normalized = live_metadata.get("normalized") if isinstance(live_metadata.get("normalized"), dict) else None
+        if raw_text is None:
+            raw_text = ""
 
     if normalization_errors or normalized is None:
         if raw_text:
@@ -7582,6 +7974,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "schema_drift",
@@ -7592,6 +7985,7 @@ def run_codex_app_review_authoritative_adapter(
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         )
         return {
@@ -7609,10 +8003,12 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         }
 
@@ -7623,6 +8019,7 @@ def run_codex_app_review_authoritative_adapter(
         "engine": CODEX_APP_REVIEW_ENGINE,
         "adapter": CODEX_APP_REVIEW_ADAPTER,
         "profile": engine_profile,
+        **selection_metadata,
         "context_pack": relative_to_root(context_pack_path, context["target_root"]),
         "result": "pass",
         "reviewed_head": reviewed_head,
@@ -7634,6 +8031,11 @@ def run_codex_app_review_authoritative_adapter(
         "thread_id": thread_id,
         "thread_cwd": cwd_relative,
         "raw_source": source_relative,
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "review_thread_id": live_metadata.get("review_thread_id") if live_metadata else (thread_id if source_path is not None else None),
+        **({"live_review": {key: value for key, value in live_metadata.items() if key != "normalized"}} if live_metadata else {}),
         "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
     }
     write_json_file(metadata_path, metadata)
@@ -12452,7 +12854,9 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
-        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
+        current_head = git_head_sha(target_root) or "unknown-head"
+        adapter_selection = select_review_adapter(args, target_root, reviewed_head=current_head)
+        requested_engine_adapter = str(adapter_selection["adapter"])
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
@@ -12484,9 +12888,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12524,9 +12929,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12539,10 +12945,11 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
-                app_server=args.codex_app_review_app_server,
-                thread_id=args.codex_app_review_thread_id,
-                thread_cwd=args.codex_app_review_cwd,
-                raw_file=args.codex_app_review_raw_file,
+                app_server=adapter_selection.get("app_server") if isinstance(adapter_selection.get("app_server"), str) else None,
+                thread_id=adapter_selection.get("thread_id") if isinstance(adapter_selection.get("thread_id"), str) else None,
+                thread_cwd=adapter_selection.get("thread_cwd") if isinstance(adapter_selection.get("thread_cwd"), str) else None,
+                raw_file=adapter_selection.get("raw_file") if isinstance(adapter_selection.get("raw_file"), str) else None,
+                adapter_selection=adapter_selection,
             )
         else:
             engine_payload = run_default_review_engine(
@@ -12551,6 +12958,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
+                adapter_selection=adapter_selection,
             )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,

--- a/skills/loom-pre-review/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-review/SKILL.md
@@ -42,9 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 选择安全的 authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
 
-默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
+已验证 Codex App host context 中，默认 `review run` 使用 `loom/codex-app-review`，并必须证明 app-server/session locator、thread id、cwd proof、target root 与 reviewed head 绑定一致；该路径不得启动嵌套 `codex exec`。`CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex` + `codex exec --output-schema`。proof 冲突、cwd / target / head 不匹配或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -54,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 
@@ -75,7 +75,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - review 机械基线结果
 - build gate 是否允许进入正式审查
 - review artifact 的定位与已记录结论
-- 默认 engine 的执行结果、evidence 定位与 fail-closed 原因
+- selected adapter、fallback reason、thread/target binding summary、reviewed head、evidence 定位与 fail-closed 原因
 - manual review 的回退写回入口
 - review record 中的权威 findings / disposition 摘要
 - 审查结论（`allow` / `block` / `fallback`）

--- a/skills/loom-pre-review/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,7 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
-- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/review-execution.md
@@ -21,7 +21,7 @@ Loom 把 review 分成四层：
 1. `flow review`
    - 只读基线；确认是否具备进入 formal review 的条件
 2. `review run`
-   - 调用默认 Codex-backed reviewer，产出结构化 review evidence 与 Loom-normalized findings
+   - 按宿主 proof 选择 authoritative adapter，产出结构化 review evidence 与 Loom-normalized findings
 3. `review record`
    - 把 formal review 结论写入单一 authored review record
 
@@ -47,27 +47,33 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责选择安全的 authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
+默认 engine 按宿主 proof 选择：
+
+- 已验证 Codex App host context 默认选择 `loom/codex-app-review`，不启动嵌套 `codex exec`
+- `CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex`，能力来源仍是 `codex exec --output-schema`
+- 显式 `--engine-adapter` 优先级最高，继续保留 Stage 2 authoritative opt-in / fallback 调试入口
+
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-Codex App review adapter 有两种显式入口，默认均不启用：
+Codex App review adapter 有三种入口：
 
-- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
-- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- verified host default：不传 `--engine-adapter`，但必须能证明 app-server/session locator、thread id、thread cwd、target root 与 reviewed head 绑定一致
+- explicit authoritative：显式选择 `review run --engine-adapter loom/codex-app-review`，用于调试或非默认宿主
+- shadow comparison：显式选择 `review run --shadow-engine-adapter loom/codex-app-review`
 - shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
-- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
-- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
-- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof；live app-server unavailable 时默认 fallback 到 `loom/default-codex`
+- thread cwd proof 必须等于 target root；cwd / target / reviewed head 绑定冲突或 schema proof 失败时必须 fail closed
 - authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
 - authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
+- `engine_metadata` 必须记录 selected adapter、selection source、fallback reason、thread/target binding summary、reviewed head 与 evidence locators
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
@@ -77,8 +83,8 @@ Codex App review adapter 有两种显式入口，默认均不启用：
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
-- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
+- `adapter`: `loom/default-codex` 或 verified/explicit `loom/codex-app-review`
+- `engine`: `codex` 或 verified/explicit `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -3126,6 +3126,19 @@ def require_review_run_payload(
                 for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
                     if not isinstance(evidence.get(key), str) or not evidence.get(key):
                         failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
+    engine_metadata = payload.get("engine_metadata")
+    if engine_adapter == "loom/codex-app-review" and engine.get("result") == "pass":
+        if not isinstance(engine_metadata, dict):
+            failures.append(Failure(category, f"{context} app review pass must expose `engine_metadata`"))
+        else:
+            for key in ("selected_adapter", "selection_source", "app_server", "thread_id", "thread_cwd", "raw_result", "normalized_findings", "context_pack", "reviewed_head"):
+                value = engine_metadata.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} app review metadata must include non-empty `{key}`"))
+            if engine_metadata.get("selected_adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} app review metadata must bind the selected adapter"))
+            if "normalized review_record_input only" not in str(engine_metadata.get("authority_boundary", "")):
+                failures.append(Failure(category, f"{context} app review metadata must keep raw App output outside merge-ready truth"))
 
 
 def require_runtime_state_payload(
@@ -5725,7 +5738,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
 
         prepare_review_target(review_target, "review run positive chain")
         write_fake_codex(fake_bin / "codex", mode="success")
-        success_env = prepend_path_env(fake_bin)
+        success_env = prepend_path_env(fake_bin, {"CI": "", "CODEX_CI": ""})
 
         payload, error = load_command_json(
             root,
@@ -5893,6 +5906,217 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_default_target = Path(tmp) / "review-run-codex-app-default"
+        prepare_review_target(app_default_target, "review run Codex App host default")
+        app_default_raw = app_default_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_default_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_default_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App default reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-default-warn-1",
+                            "summary": "Codex App default review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_default_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-default-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-default-proof",
+                "--codex-app-review-cwd",
+                str(app_default_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App host default failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App host default",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("adapter") != "loom/codex-app-review" or engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must select the app adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review" or review_record_input.get("reviewer") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must author app adapter review_record_input"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("selection_source") != "codex-app-host-default" or metadata.get("thread_id") != "thread-stage3-default-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must expose selected adapter and thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_default_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored default app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume default Codex App raw evidence before review record is authored"))
+
+        app_ci_fallback_target = Path(tmp) / "review-run-codex-app-ci-fallback"
+        prepare_review_target(app_ci_fallback_target, "review run Codex App CI fallback")
+        app_ci_raw = app_ci_fallback_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_ci_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_ci_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_ci_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-ci-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-ci-proof",
+                "--codex-app-review-cwd",
+                str(app_ci_fallback_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=prepend_path_env(fake_bin, {"CODEX_CI": "1"}),
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App CI fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App CI fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "ci-or-codex-ci":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App CI fallback must keep the default codex exec adapter"))
+
+        app_unavailable_fallback_target = Path(tmp) / "review-run-codex-app-unavailable-fallback"
+        prepare_review_target(app_unavailable_fallback_target, "review run Codex App unavailable fallback")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_unavailable_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                f"unix://{tmp}/missing-codex-app.sock",
+                "--codex-app-review-thread-id",
+                "thread-stage3-missing-endpoint",
+                "--codex-app-review-cwd",
+                str(app_unavailable_fallback_target),
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App unavailable fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App unavailable fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "app-server-unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App unavailable fallback must record default adapter fallback"))
+
+        app_conflict_target = Path(tmp) / "review-run-codex-app-proof-conflict"
+        prepare_review_target(app_conflict_target, "review run Codex App proof conflict")
+        app_conflict_raw = app_conflict_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_conflict_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_conflict_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_conflict_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-conflict-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-conflict-proof",
+                "--codex-app-review-cwd",
+                str(Path(tmp) / "different-cwd"),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App proof conflict failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must fail closed"))
+        else:
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            if engine.get("adapter") != "loom/codex-app-review" or engine.get("failure_reason") != "runtime_conflict":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not fallback to default codex"))
+            if "does not match target root" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must expose cwd mismatch"))
+            if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not emit review_record_input"))
 
         app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
         prepare_review_target(app_authoritative_target, "review run Codex App authoritative")

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,6 +118,10 @@ CODEX_APP_REVIEW_ENGINE = "codex-app-review"
 CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
 AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
+CODEX_APP_REVIEW_ENDPOINT_ENV = "LOOM_CODEX_APP_REVIEW_ENDPOINT"
+CODEX_APP_REVIEW_THREAD_ID_ENV = "LOOM_CODEX_APP_REVIEW_THREAD_ID"
+CODEX_APP_REVIEW_CWD_ENV = "LOOM_CODEX_APP_REVIEW_CWD"
+CODEX_THREAD_ID_ENV = "CODEX_THREAD_ID"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS: int | None = None
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -492,26 +496,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
         help=(
             "Optional authoritative review engine adapter for review run/record. "
-            "Default review run remains loom/default-codex."
+            "When omitted, verified Codex App sessions use loom/codex-app-review; headless/CI fallback remains loom/default-codex."
         ),
     )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
     review.add_argument(
         "--codex-app-review-app-server",
-        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App app-server/session locator. Defaults to ${CODEX_APP_REVIEW_ENDPOINT_ENV} when available.",
     )
     review.add_argument(
         "--codex-app-review-thread-id",
-        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread id. Defaults to ${CODEX_APP_REVIEW_THREAD_ID_ENV}, or ${CODEX_THREAD_ID_ENV} when an endpoint is present.",
     )
     review.add_argument(
         "--codex-app-review-cwd",
-        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread cwd proof. Defaults to ${CODEX_APP_REVIEW_CWD_ENV}.",
     )
     review.add_argument(
         "--codex-app-review-raw-file",
-        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+        help="Optional repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
     )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
@@ -4250,6 +4254,19 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def truthy_env(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def non_empty_str(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def execution_attempt_directory(target_root: Path, item_id: str) -> Path:
     return target_root / ".loom/runtime/attempts" / item_id
 
@@ -6264,8 +6281,26 @@ def run_default_review_engine(
     engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "explicit-or-legacy-default",
+            "fallback_reason": None,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=None,
+                thread_id=None,
+                thread_cwd=None,
+                reviewed_head=reviewed_head,
+                raw_file=None,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     prompt_path = runtime_root / "prompt.txt"
     result_path = runtime_root / "engine-result.json"
@@ -6313,6 +6348,7 @@ def run_default_review_engine(
                     "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
+            "engine_metadata": selection_metadata,
         }
 
     scratch_dir.mkdir(parents=True, exist_ok=True)
@@ -6403,6 +6439,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
@@ -6424,6 +6461,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     if raw_payload is not None and not result_path.exists():
@@ -6440,6 +6478,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
@@ -6462,6 +6501,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     write_json_file(findings_path, {"findings": normalized_payload["findings"]})
@@ -6471,6 +6511,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
@@ -6494,6 +6535,13 @@ def run_default_review_engine(
             "failure_reason": None,
             "reviewed_head": reviewed_head,
             "evidence": engine_evidence,
+        },
+        "engine_metadata": {
+            **selection_metadata,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "raw_result": relative_to_root(result_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "metadata": relative_to_root(metadata_path, context["target_root"]),
         },
         "review_record_input": {
             "decision": normalized_payload["decision"],
@@ -7254,6 +7302,312 @@ def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: st
     return normalized, []
 
 
+def codex_app_endpoint_socket_path(app_server: str | None) -> Path | None:
+    endpoint = non_empty_str(app_server)
+    if endpoint is None:
+        return None
+    if endpoint.startswith("unix://"):
+        path_text = endpoint.removeprefix("unix://")
+    elif endpoint.startswith("/"):
+        path_text = endpoint
+    else:
+        return None
+    if not path_text:
+        return None
+    return Path(path_text).expanduser()
+
+
+def codex_app_endpoint_is_live_capable(app_server: str | None) -> bool:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    return socket_path is not None and socket_path.exists()
+
+
+def codex_app_review_bindings_from_args_env(args: argparse.Namespace) -> dict[str, str | None]:
+    app_server = non_empty_str(args.codex_app_review_app_server) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_ENDPOINT_ENV))
+    thread_id = (
+        non_empty_str(args.codex_app_review_thread_id)
+        or non_empty_str(os.environ.get(CODEX_APP_REVIEW_THREAD_ID_ENV))
+        or (non_empty_str(os.environ.get(CODEX_THREAD_ID_ENV)) if app_server else None)
+    )
+    thread_cwd = non_empty_str(args.codex_app_review_cwd) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_CWD_ENV))
+    raw_file = non_empty_str(args.codex_app_review_raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": thread_cwd,
+        "raw_file": raw_file,
+    }
+
+
+def codex_app_binding_summary(
+    target_root: Path,
+    *,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    reviewed_head: str,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    cwd_match: bool | None = None
+    cwd_summary: str | None = thread_cwd
+    if non_empty_str(thread_cwd):
+        try:
+            cwd_path = Path(str(thread_cwd)).expanduser().resolve()
+        except OSError:
+            cwd_match = False
+        else:
+            cwd_match = cwd_path == target_root
+            cwd_summary = str(cwd_path)
+    raw_source: str | None = None
+    if non_empty_str(raw_file):
+        raw_path, raw_errors = resolve_repo_relative_path(target_root, str(raw_file), label="Codex App authoritative review raw file")
+        if raw_path is not None and not raw_errors:
+            raw_source = relative_to_root(raw_path, target_root)
+        else:
+            raw_source = str(raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_summary,
+        "thread_cwd_matches_target_root": cwd_match,
+        "target_root": str(target_root),
+        "reviewed_head": reviewed_head,
+        "raw_source": raw_source,
+        "live_endpoint_capable": codex_app_endpoint_is_live_capable(app_server),
+    }
+
+
+def select_review_adapter(
+    args: argparse.Namespace,
+    target_root: Path,
+    *,
+    reviewed_head: str,
+) -> dict[str, Any]:
+    bindings = codex_app_review_bindings_from_args_env(args)
+    explicit_adapter = non_empty_str(args.engine_adapter)
+    if explicit_adapter:
+        return {
+            "adapter": explicit_adapter,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    if truthy_env("CI") or truthy_env("CODEX_CI"):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "headless-fallback",
+            "fallback_reason": "ci-or-codex-ci",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    app_server = bindings["app_server"]
+    thread_id = bindings["thread_id"]
+    thread_cwd = bindings["thread_cwd"]
+    raw_file = bindings["raw_file"]
+    if not app_server or not thread_id or not thread_cwd:
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "missing-codex-app-host-proof",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    if not raw_file and not codex_app_endpoint_is_live_capable(app_server):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "app-server-unavailable",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    return {
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "selection_source": "codex-app-host-default",
+        "fallback_reason": None,
+        **bindings,
+        "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+    }
+
+
+def review_adapter_selection_metadata(selection: dict[str, Any], *, reviewed_head: str) -> dict[str, Any]:
+    return {
+        "selected_adapter": selection["adapter"],
+        "selection_source": selection.get("selection_source"),
+        "fallback_reason": selection.get("fallback_reason"),
+        "app_server": selection.get("app_server"),
+        "thread_id": selection.get("thread_id"),
+        "thread_cwd": selection.get("thread_cwd"),
+        "target_root": selection.get("binding_summary", {}).get("target_root")
+        if isinstance(selection.get("binding_summary"), dict)
+        else None,
+        "reviewed_head": reviewed_head,
+        "thread_target_binding": selection.get("binding_summary"),
+    }
+
+
+def jsonrpc_send_request(stdin: Any, *, request_id: int, method: str, params: dict[str, Any]) -> None:
+    stdin.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}) + "\n")
+    stdin.flush()
+
+
+def jsonrpc_read_response(stdout: Any, *, request_id: int) -> tuple[dict[str, Any] | None, list[dict[str, Any]], list[str]]:
+    notifications: list[dict[str, Any]] = []
+    while True:
+        line = stdout.readline()
+        if not line:
+            return None, notifications, [f"app-server closed before response id {request_id}"]
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("id") == request_id:
+            return payload, notifications, []
+        notifications.append(payload)
+
+
+def find_exited_review_text(payload: Any) -> str | None:
+    if isinstance(payload, dict):
+        if payload.get("type") == "exitedReviewMode" and isinstance(payload.get("review"), str):
+            return payload["review"]
+        for value in payload.values():
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    return None
+
+
+def find_normalized_review_payload(payload: Any) -> dict[str, Any] | None:
+    normalized, errors = normalize_engine_review_result(payload, relative="app-server turn/start output")
+    if normalized is not None and not errors:
+        return normalized
+    if isinstance(payload, dict):
+        for value in payload.values():
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    return None
+
+
+def app_server_proxy_command(app_server: str) -> list[str] | None:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    if socket_path is None:
+        return None
+    return ["codex", "app-server", "proxy", "--sock", str(socket_path)]
+
+
+def run_codex_app_live_review(
+    *,
+    app_server: str,
+    thread_id: str,
+    reviewed_head: str,
+    thread_cwd: str,
+    prompt_text: str,
+) -> tuple[str | None, dict[str, Any], list[str]]:
+    command = app_server_proxy_command(app_server)
+    if command is None:
+        return None, {}, [f"unsupported Codex App review endpoint: {app_server}"]
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return None, {}, [f"Codex App review endpoint is unavailable: {exc}"]
+    assert process.stdin is not None
+    assert process.stdout is not None
+    metadata: dict[str, Any] = {"review_target": {"type": "commit", "sha": reviewed_head}}
+    try:
+        jsonrpc_send_request(process.stdin, request_id=1, method="initialize", params={"clientInfo": {"name": "loom", "version": "stage3"}, "capabilities": {}})
+        initialize_response, _, initialize_errors = jsonrpc_read_response(process.stdout, request_id=1)
+        if initialize_errors:
+            return None, metadata, initialize_errors
+        if isinstance(initialize_response, dict) and isinstance(initialize_response.get("error"), dict):
+            return None, metadata, [f"Codex App initialize failed: {initialize_response['error']}"]
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=2,
+            method="review/start",
+            params={
+                "threadId": thread_id,
+                "delivery": "inline",
+                "target": {"type": "commit", "sha": reviewed_head},
+            },
+        )
+        review_response, review_notifications, review_errors = jsonrpc_read_response(process.stdout, request_id=2)
+        if review_errors:
+            return None, metadata, review_errors
+        if isinstance(review_response, dict) and isinstance(review_response.get("error"), dict):
+            return None, metadata, [f"Codex App review/start failed: {review_response['error']}"]
+        result = review_response.get("result") if isinstance(review_response, dict) else None
+        if isinstance(result, dict):
+            metadata["review_thread_id"] = result.get("reviewThreadId")
+        review_text = find_exited_review_text(result) or find_exited_review_text(review_notifications)
+        if not isinstance(review_text, str) or not review_text.strip():
+            return None, metadata, ["Codex App review/start did not return exitedReviewMode.review"]
+
+        parsed_review, parsed_errors = normalize_authoritative_codex_app_review_text(review_text, relative="app-server review/start output")
+        if parsed_review is not None and not parsed_errors:
+            metadata["normalization_source"] = "review-start-json"
+            return review_text, {**metadata, "normalized": parsed_review}, []
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=3,
+            method="turn/start",
+            params={
+                "threadId": metadata.get("review_thread_id") or thread_id,
+                "cwd": thread_cwd,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Normalize this Codex App review output into the provided JSON schema. "
+                            "Return only the structured review result.\n\n"
+                            f"{review_text}"
+                        ),
+                    }
+                ],
+                "outputSchema": load_json_file(review_engine_schema_path()),
+            },
+        )
+        turn_response, turn_notifications, turn_errors = jsonrpc_read_response(process.stdout, request_id=3)
+        if turn_errors:
+            return review_text, metadata, turn_errors
+        if isinstance(turn_response, dict) and isinstance(turn_response.get("error"), dict):
+            return review_text, metadata, [f"Codex App turn/start normalization failed: {turn_response['error']}"]
+        normalized = find_normalized_review_payload(turn_response.get("result") if isinstance(turn_response, dict) else None)
+        if normalized is None:
+            normalized = find_normalized_review_payload(turn_notifications)
+        if normalized is None:
+            return review_text, metadata, ["Codex App turn/start did not return a Loom review result"]
+        metadata["normalization_source"] = "turn-start-output-schema"
+        return review_text, {**metadata, "normalized": normalized}, []
+    finally:
+        try:
+            process.terminate()
+        except OSError:
+            pass
+
+
 def shadow_adapter_slug(adapter: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
 
@@ -7453,8 +7807,30 @@ def run_codex_app_review_authoritative_adapter(
     thread_id: str | None,
     thread_cwd: str | None,
     raw_file: str | None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            "app_server": app_server,
+            "thread_id": thread_id,
+            "thread_cwd": thread_cwd,
+            "raw_file": raw_file,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=app_server,
+                thread_id=thread_id,
+                thread_cwd=thread_cwd,
+                reviewed_head=reviewed_head,
+                raw_file=raw_file,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     raw_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
@@ -7488,7 +7864,6 @@ def run_codex_app_review_authoritative_adapter(
         ("--codex-app-review-app-server", app_server),
         ("--codex-app-review-thread-id", thread_id),
         ("--codex-app-review-cwd", thread_cwd),
-        ("--codex-app-review-raw-file", raw_file),
     ):
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(label)
@@ -7518,6 +7893,8 @@ def run_codex_app_review_authoritative_adapter(
         missing_inputs.extend(source_errors)
         if source_path is not None:
             source_relative = relative_to_root(source_path, context["target_root"])
+    elif not codex_app_endpoint_is_live_capable(app_server):
+        missing_inputs.append("--codex-app-review-raw-file or live app-server endpoint")
 
     if missing_inputs:
         write_json_file(
@@ -7527,6 +7904,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "runtime_conflict",
@@ -7553,6 +7931,7 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative or thread_cwd,
@@ -7560,17 +7939,30 @@ def run_codex_app_review_authoritative_adapter(
             },
         }
 
-    try:
-        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
-    except OSError as exc:
-        raw_text = ""
-        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
-        normalized = None
+    live_metadata: dict[str, Any] = {}
+    if source_path is not None:
+        try:
+            raw_text = source_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raw_text = ""
+            normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+            normalized = None
+        else:
+            normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+                raw_text,
+                relative=source_relative or str(raw_file),
+            )
     else:
-        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
-            raw_text,
-            relative=source_relative or str(raw_file),
+        raw_text, live_metadata, normalization_errors = run_codex_app_live_review(
+            app_server=str(app_server),
+            thread_id=str(thread_id),
+            reviewed_head=reviewed_head,
+            thread_cwd=str(thread_cwd),
+            prompt_text=instructions_path.read_text(encoding="utf-8"),
         )
+        normalized = live_metadata.get("normalized") if isinstance(live_metadata.get("normalized"), dict) else None
+        if raw_text is None:
+            raw_text = ""
 
     if normalization_errors or normalized is None:
         if raw_text:
@@ -7582,6 +7974,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "schema_drift",
@@ -7592,6 +7985,7 @@ def run_codex_app_review_authoritative_adapter(
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         )
         return {
@@ -7609,10 +8003,12 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         }
 
@@ -7623,6 +8019,7 @@ def run_codex_app_review_authoritative_adapter(
         "engine": CODEX_APP_REVIEW_ENGINE,
         "adapter": CODEX_APP_REVIEW_ADAPTER,
         "profile": engine_profile,
+        **selection_metadata,
         "context_pack": relative_to_root(context_pack_path, context["target_root"]),
         "result": "pass",
         "reviewed_head": reviewed_head,
@@ -7634,6 +8031,11 @@ def run_codex_app_review_authoritative_adapter(
         "thread_id": thread_id,
         "thread_cwd": cwd_relative,
         "raw_source": source_relative,
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "review_thread_id": live_metadata.get("review_thread_id") if live_metadata else (thread_id if source_path is not None else None),
+        **({"live_review": {key: value for key, value in live_metadata.items() if key != "normalized"}} if live_metadata else {}),
         "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
     }
     write_json_file(metadata_path, metadata)
@@ -12452,7 +12854,9 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
-        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
+        current_head = git_head_sha(target_root) or "unknown-head"
+        adapter_selection = select_review_adapter(args, target_root, reviewed_head=current_head)
+        requested_engine_adapter = str(adapter_selection["adapter"])
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
@@ -12484,9 +12888,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12524,9 +12929,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12539,10 +12945,11 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
-                app_server=args.codex_app_review_app_server,
-                thread_id=args.codex_app_review_thread_id,
-                thread_cwd=args.codex_app_review_cwd,
-                raw_file=args.codex_app_review_raw_file,
+                app_server=adapter_selection.get("app_server") if isinstance(adapter_selection.get("app_server"), str) else None,
+                thread_id=adapter_selection.get("thread_id") if isinstance(adapter_selection.get("thread_id"), str) else None,
+                thread_cwd=adapter_selection.get("thread_cwd") if isinstance(adapter_selection.get("thread_cwd"), str) else None,
+                raw_file=adapter_selection.get("raw_file") if isinstance(adapter_selection.get("raw_file"), str) else None,
+                adapter_selection=adapter_selection,
             )
         else:
             engine_payload = run_default_review_engine(
@@ -12551,6 +12958,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
+                adapter_selection=adapter_selection,
             )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,

--- a/skills/loom-resume/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-resume/.loom-runtime/loom-review/SKILL.md
@@ -42,9 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 选择安全的 authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
 
-默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
+已验证 Codex App host context 中，默认 `review run` 使用 `loom/codex-app-review`，并必须证明 app-server/session locator、thread id、cwd proof、target root 与 reviewed head 绑定一致；该路径不得启动嵌套 `codex exec`。`CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex` + `codex exec --output-schema`。proof 冲突、cwd / target / head 不匹配或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -54,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 
@@ -75,7 +75,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - review 机械基线结果
 - build gate 是否允许进入正式审查
 - review artifact 的定位与已记录结论
-- 默认 engine 的执行结果、evidence 定位与 fail-closed 原因
+- selected adapter、fallback reason、thread/target binding summary、reviewed head、evidence 定位与 fail-closed 原因
 - manual review 的回退写回入口
 - review record 中的权威 findings / disposition 摘要
 - 审查结论（`allow` / `block` / `fallback`）

--- a/skills/loom-resume/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-resume/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,7 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
-- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/review-execution.md
@@ -21,7 +21,7 @@ Loom 把 review 分成四层：
 1. `flow review`
    - 只读基线；确认是否具备进入 formal review 的条件
 2. `review run`
-   - 调用默认 Codex-backed reviewer，产出结构化 review evidence 与 Loom-normalized findings
+   - 按宿主 proof 选择 authoritative adapter，产出结构化 review evidence 与 Loom-normalized findings
 3. `review record`
    - 把 formal review 结论写入单一 authored review record
 
@@ -47,27 +47,33 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责选择安全的 authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
+默认 engine 按宿主 proof 选择：
+
+- 已验证 Codex App host context 默认选择 `loom/codex-app-review`，不启动嵌套 `codex exec`
+- `CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex`，能力来源仍是 `codex exec --output-schema`
+- 显式 `--engine-adapter` 优先级最高，继续保留 Stage 2 authoritative opt-in / fallback 调试入口
+
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-Codex App review adapter 有两种显式入口，默认均不启用：
+Codex App review adapter 有三种入口：
 
-- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
-- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- verified host default：不传 `--engine-adapter`，但必须能证明 app-server/session locator、thread id、thread cwd、target root 与 reviewed head 绑定一致
+- explicit authoritative：显式选择 `review run --engine-adapter loom/codex-app-review`，用于调试或非默认宿主
+- shadow comparison：显式选择 `review run --shadow-engine-adapter loom/codex-app-review`
 - shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
-- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
-- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
-- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof；live app-server unavailable 时默认 fallback 到 `loom/default-codex`
+- thread cwd proof 必须等于 target root；cwd / target / reviewed head 绑定冲突或 schema proof 失败时必须 fail closed
 - authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
 - authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
+- `engine_metadata` 必须记录 selected adapter、selection source、fallback reason、thread/target binding summary、reviewed head 与 evidence locators
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
@@ -77,8 +83,8 @@ Codex App review adapter 有两种显式入口，默认均不启用：
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
-- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
+- `adapter`: `loom/default-codex` 或 verified/explicit `loom/codex-app-review`
+- `engine`: `codex` 或 verified/explicit `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -3126,6 +3126,19 @@ def require_review_run_payload(
                 for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
                     if not isinstance(evidence.get(key), str) or not evidence.get(key):
                         failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
+    engine_metadata = payload.get("engine_metadata")
+    if engine_adapter == "loom/codex-app-review" and engine.get("result") == "pass":
+        if not isinstance(engine_metadata, dict):
+            failures.append(Failure(category, f"{context} app review pass must expose `engine_metadata`"))
+        else:
+            for key in ("selected_adapter", "selection_source", "app_server", "thread_id", "thread_cwd", "raw_result", "normalized_findings", "context_pack", "reviewed_head"):
+                value = engine_metadata.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} app review metadata must include non-empty `{key}`"))
+            if engine_metadata.get("selected_adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} app review metadata must bind the selected adapter"))
+            if "normalized review_record_input only" not in str(engine_metadata.get("authority_boundary", "")):
+                failures.append(Failure(category, f"{context} app review metadata must keep raw App output outside merge-ready truth"))
 
 
 def require_runtime_state_payload(
@@ -5725,7 +5738,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
 
         prepare_review_target(review_target, "review run positive chain")
         write_fake_codex(fake_bin / "codex", mode="success")
-        success_env = prepend_path_env(fake_bin)
+        success_env = prepend_path_env(fake_bin, {"CI": "", "CODEX_CI": ""})
 
         payload, error = load_command_json(
             root,
@@ -5893,6 +5906,217 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_default_target = Path(tmp) / "review-run-codex-app-default"
+        prepare_review_target(app_default_target, "review run Codex App host default")
+        app_default_raw = app_default_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_default_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_default_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App default reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-default-warn-1",
+                            "summary": "Codex App default review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_default_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-default-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-default-proof",
+                "--codex-app-review-cwd",
+                str(app_default_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App host default failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App host default",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("adapter") != "loom/codex-app-review" or engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must select the app adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review" or review_record_input.get("reviewer") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must author app adapter review_record_input"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("selection_source") != "codex-app-host-default" or metadata.get("thread_id") != "thread-stage3-default-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must expose selected adapter and thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_default_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored default app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume default Codex App raw evidence before review record is authored"))
+
+        app_ci_fallback_target = Path(tmp) / "review-run-codex-app-ci-fallback"
+        prepare_review_target(app_ci_fallback_target, "review run Codex App CI fallback")
+        app_ci_raw = app_ci_fallback_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_ci_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_ci_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_ci_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-ci-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-ci-proof",
+                "--codex-app-review-cwd",
+                str(app_ci_fallback_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=prepend_path_env(fake_bin, {"CODEX_CI": "1"}),
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App CI fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App CI fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "ci-or-codex-ci":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App CI fallback must keep the default codex exec adapter"))
+
+        app_unavailable_fallback_target = Path(tmp) / "review-run-codex-app-unavailable-fallback"
+        prepare_review_target(app_unavailable_fallback_target, "review run Codex App unavailable fallback")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_unavailable_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                f"unix://{tmp}/missing-codex-app.sock",
+                "--codex-app-review-thread-id",
+                "thread-stage3-missing-endpoint",
+                "--codex-app-review-cwd",
+                str(app_unavailable_fallback_target),
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App unavailable fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App unavailable fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "app-server-unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App unavailable fallback must record default adapter fallback"))
+
+        app_conflict_target = Path(tmp) / "review-run-codex-app-proof-conflict"
+        prepare_review_target(app_conflict_target, "review run Codex App proof conflict")
+        app_conflict_raw = app_conflict_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_conflict_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_conflict_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_conflict_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-conflict-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-conflict-proof",
+                "--codex-app-review-cwd",
+                str(Path(tmp) / "different-cwd"),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App proof conflict failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must fail closed"))
+        else:
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            if engine.get("adapter") != "loom/codex-app-review" or engine.get("failure_reason") != "runtime_conflict":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not fallback to default codex"))
+            if "does not match target root" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must expose cwd mismatch"))
+            if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not emit review_record_input"))
 
         app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
         prepare_review_target(app_authoritative_target, "review run Codex App authoritative")

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,6 +118,10 @@ CODEX_APP_REVIEW_ENGINE = "codex-app-review"
 CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
 AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
+CODEX_APP_REVIEW_ENDPOINT_ENV = "LOOM_CODEX_APP_REVIEW_ENDPOINT"
+CODEX_APP_REVIEW_THREAD_ID_ENV = "LOOM_CODEX_APP_REVIEW_THREAD_ID"
+CODEX_APP_REVIEW_CWD_ENV = "LOOM_CODEX_APP_REVIEW_CWD"
+CODEX_THREAD_ID_ENV = "CODEX_THREAD_ID"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS: int | None = None
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -492,26 +496,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
         help=(
             "Optional authoritative review engine adapter for review run/record. "
-            "Default review run remains loom/default-codex."
+            "When omitted, verified Codex App sessions use loom/codex-app-review; headless/CI fallback remains loom/default-codex."
         ),
     )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
     review.add_argument(
         "--codex-app-review-app-server",
-        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App app-server/session locator. Defaults to ${CODEX_APP_REVIEW_ENDPOINT_ENV} when available.",
     )
     review.add_argument(
         "--codex-app-review-thread-id",
-        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread id. Defaults to ${CODEX_APP_REVIEW_THREAD_ID_ENV}, or ${CODEX_THREAD_ID_ENV} when an endpoint is present.",
     )
     review.add_argument(
         "--codex-app-review-cwd",
-        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread cwd proof. Defaults to ${CODEX_APP_REVIEW_CWD_ENV}.",
     )
     review.add_argument(
         "--codex-app-review-raw-file",
-        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+        help="Optional repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
     )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
@@ -4250,6 +4254,19 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def truthy_env(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def non_empty_str(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def execution_attempt_directory(target_root: Path, item_id: str) -> Path:
     return target_root / ".loom/runtime/attempts" / item_id
 
@@ -6264,8 +6281,26 @@ def run_default_review_engine(
     engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "explicit-or-legacy-default",
+            "fallback_reason": None,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=None,
+                thread_id=None,
+                thread_cwd=None,
+                reviewed_head=reviewed_head,
+                raw_file=None,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     prompt_path = runtime_root / "prompt.txt"
     result_path = runtime_root / "engine-result.json"
@@ -6313,6 +6348,7 @@ def run_default_review_engine(
                     "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
+            "engine_metadata": selection_metadata,
         }
 
     scratch_dir.mkdir(parents=True, exist_ok=True)
@@ -6403,6 +6439,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
@@ -6424,6 +6461,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     if raw_payload is not None and not result_path.exists():
@@ -6440,6 +6478,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
@@ -6462,6 +6501,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     write_json_file(findings_path, {"findings": normalized_payload["findings"]})
@@ -6471,6 +6511,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
@@ -6494,6 +6535,13 @@ def run_default_review_engine(
             "failure_reason": None,
             "reviewed_head": reviewed_head,
             "evidence": engine_evidence,
+        },
+        "engine_metadata": {
+            **selection_metadata,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "raw_result": relative_to_root(result_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "metadata": relative_to_root(metadata_path, context["target_root"]),
         },
         "review_record_input": {
             "decision": normalized_payload["decision"],
@@ -7254,6 +7302,312 @@ def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: st
     return normalized, []
 
 
+def codex_app_endpoint_socket_path(app_server: str | None) -> Path | None:
+    endpoint = non_empty_str(app_server)
+    if endpoint is None:
+        return None
+    if endpoint.startswith("unix://"):
+        path_text = endpoint.removeprefix("unix://")
+    elif endpoint.startswith("/"):
+        path_text = endpoint
+    else:
+        return None
+    if not path_text:
+        return None
+    return Path(path_text).expanduser()
+
+
+def codex_app_endpoint_is_live_capable(app_server: str | None) -> bool:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    return socket_path is not None and socket_path.exists()
+
+
+def codex_app_review_bindings_from_args_env(args: argparse.Namespace) -> dict[str, str | None]:
+    app_server = non_empty_str(args.codex_app_review_app_server) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_ENDPOINT_ENV))
+    thread_id = (
+        non_empty_str(args.codex_app_review_thread_id)
+        or non_empty_str(os.environ.get(CODEX_APP_REVIEW_THREAD_ID_ENV))
+        or (non_empty_str(os.environ.get(CODEX_THREAD_ID_ENV)) if app_server else None)
+    )
+    thread_cwd = non_empty_str(args.codex_app_review_cwd) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_CWD_ENV))
+    raw_file = non_empty_str(args.codex_app_review_raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": thread_cwd,
+        "raw_file": raw_file,
+    }
+
+
+def codex_app_binding_summary(
+    target_root: Path,
+    *,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    reviewed_head: str,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    cwd_match: bool | None = None
+    cwd_summary: str | None = thread_cwd
+    if non_empty_str(thread_cwd):
+        try:
+            cwd_path = Path(str(thread_cwd)).expanduser().resolve()
+        except OSError:
+            cwd_match = False
+        else:
+            cwd_match = cwd_path == target_root
+            cwd_summary = str(cwd_path)
+    raw_source: str | None = None
+    if non_empty_str(raw_file):
+        raw_path, raw_errors = resolve_repo_relative_path(target_root, str(raw_file), label="Codex App authoritative review raw file")
+        if raw_path is not None and not raw_errors:
+            raw_source = relative_to_root(raw_path, target_root)
+        else:
+            raw_source = str(raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_summary,
+        "thread_cwd_matches_target_root": cwd_match,
+        "target_root": str(target_root),
+        "reviewed_head": reviewed_head,
+        "raw_source": raw_source,
+        "live_endpoint_capable": codex_app_endpoint_is_live_capable(app_server),
+    }
+
+
+def select_review_adapter(
+    args: argparse.Namespace,
+    target_root: Path,
+    *,
+    reviewed_head: str,
+) -> dict[str, Any]:
+    bindings = codex_app_review_bindings_from_args_env(args)
+    explicit_adapter = non_empty_str(args.engine_adapter)
+    if explicit_adapter:
+        return {
+            "adapter": explicit_adapter,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    if truthy_env("CI") or truthy_env("CODEX_CI"):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "headless-fallback",
+            "fallback_reason": "ci-or-codex-ci",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    app_server = bindings["app_server"]
+    thread_id = bindings["thread_id"]
+    thread_cwd = bindings["thread_cwd"]
+    raw_file = bindings["raw_file"]
+    if not app_server or not thread_id or not thread_cwd:
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "missing-codex-app-host-proof",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    if not raw_file and not codex_app_endpoint_is_live_capable(app_server):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "app-server-unavailable",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    return {
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "selection_source": "codex-app-host-default",
+        "fallback_reason": None,
+        **bindings,
+        "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+    }
+
+
+def review_adapter_selection_metadata(selection: dict[str, Any], *, reviewed_head: str) -> dict[str, Any]:
+    return {
+        "selected_adapter": selection["adapter"],
+        "selection_source": selection.get("selection_source"),
+        "fallback_reason": selection.get("fallback_reason"),
+        "app_server": selection.get("app_server"),
+        "thread_id": selection.get("thread_id"),
+        "thread_cwd": selection.get("thread_cwd"),
+        "target_root": selection.get("binding_summary", {}).get("target_root")
+        if isinstance(selection.get("binding_summary"), dict)
+        else None,
+        "reviewed_head": reviewed_head,
+        "thread_target_binding": selection.get("binding_summary"),
+    }
+
+
+def jsonrpc_send_request(stdin: Any, *, request_id: int, method: str, params: dict[str, Any]) -> None:
+    stdin.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}) + "\n")
+    stdin.flush()
+
+
+def jsonrpc_read_response(stdout: Any, *, request_id: int) -> tuple[dict[str, Any] | None, list[dict[str, Any]], list[str]]:
+    notifications: list[dict[str, Any]] = []
+    while True:
+        line = stdout.readline()
+        if not line:
+            return None, notifications, [f"app-server closed before response id {request_id}"]
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("id") == request_id:
+            return payload, notifications, []
+        notifications.append(payload)
+
+
+def find_exited_review_text(payload: Any) -> str | None:
+    if isinstance(payload, dict):
+        if payload.get("type") == "exitedReviewMode" and isinstance(payload.get("review"), str):
+            return payload["review"]
+        for value in payload.values():
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    return None
+
+
+def find_normalized_review_payload(payload: Any) -> dict[str, Any] | None:
+    normalized, errors = normalize_engine_review_result(payload, relative="app-server turn/start output")
+    if normalized is not None and not errors:
+        return normalized
+    if isinstance(payload, dict):
+        for value in payload.values():
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    return None
+
+
+def app_server_proxy_command(app_server: str) -> list[str] | None:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    if socket_path is None:
+        return None
+    return ["codex", "app-server", "proxy", "--sock", str(socket_path)]
+
+
+def run_codex_app_live_review(
+    *,
+    app_server: str,
+    thread_id: str,
+    reviewed_head: str,
+    thread_cwd: str,
+    prompt_text: str,
+) -> tuple[str | None, dict[str, Any], list[str]]:
+    command = app_server_proxy_command(app_server)
+    if command is None:
+        return None, {}, [f"unsupported Codex App review endpoint: {app_server}"]
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return None, {}, [f"Codex App review endpoint is unavailable: {exc}"]
+    assert process.stdin is not None
+    assert process.stdout is not None
+    metadata: dict[str, Any] = {"review_target": {"type": "commit", "sha": reviewed_head}}
+    try:
+        jsonrpc_send_request(process.stdin, request_id=1, method="initialize", params={"clientInfo": {"name": "loom", "version": "stage3"}, "capabilities": {}})
+        initialize_response, _, initialize_errors = jsonrpc_read_response(process.stdout, request_id=1)
+        if initialize_errors:
+            return None, metadata, initialize_errors
+        if isinstance(initialize_response, dict) and isinstance(initialize_response.get("error"), dict):
+            return None, metadata, [f"Codex App initialize failed: {initialize_response['error']}"]
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=2,
+            method="review/start",
+            params={
+                "threadId": thread_id,
+                "delivery": "inline",
+                "target": {"type": "commit", "sha": reviewed_head},
+            },
+        )
+        review_response, review_notifications, review_errors = jsonrpc_read_response(process.stdout, request_id=2)
+        if review_errors:
+            return None, metadata, review_errors
+        if isinstance(review_response, dict) and isinstance(review_response.get("error"), dict):
+            return None, metadata, [f"Codex App review/start failed: {review_response['error']}"]
+        result = review_response.get("result") if isinstance(review_response, dict) else None
+        if isinstance(result, dict):
+            metadata["review_thread_id"] = result.get("reviewThreadId")
+        review_text = find_exited_review_text(result) or find_exited_review_text(review_notifications)
+        if not isinstance(review_text, str) or not review_text.strip():
+            return None, metadata, ["Codex App review/start did not return exitedReviewMode.review"]
+
+        parsed_review, parsed_errors = normalize_authoritative_codex_app_review_text(review_text, relative="app-server review/start output")
+        if parsed_review is not None and not parsed_errors:
+            metadata["normalization_source"] = "review-start-json"
+            return review_text, {**metadata, "normalized": parsed_review}, []
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=3,
+            method="turn/start",
+            params={
+                "threadId": metadata.get("review_thread_id") or thread_id,
+                "cwd": thread_cwd,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Normalize this Codex App review output into the provided JSON schema. "
+                            "Return only the structured review result.\n\n"
+                            f"{review_text}"
+                        ),
+                    }
+                ],
+                "outputSchema": load_json_file(review_engine_schema_path()),
+            },
+        )
+        turn_response, turn_notifications, turn_errors = jsonrpc_read_response(process.stdout, request_id=3)
+        if turn_errors:
+            return review_text, metadata, turn_errors
+        if isinstance(turn_response, dict) and isinstance(turn_response.get("error"), dict):
+            return review_text, metadata, [f"Codex App turn/start normalization failed: {turn_response['error']}"]
+        normalized = find_normalized_review_payload(turn_response.get("result") if isinstance(turn_response, dict) else None)
+        if normalized is None:
+            normalized = find_normalized_review_payload(turn_notifications)
+        if normalized is None:
+            return review_text, metadata, ["Codex App turn/start did not return a Loom review result"]
+        metadata["normalization_source"] = "turn-start-output-schema"
+        return review_text, {**metadata, "normalized": normalized}, []
+    finally:
+        try:
+            process.terminate()
+        except OSError:
+            pass
+
+
 def shadow_adapter_slug(adapter: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
 
@@ -7453,8 +7807,30 @@ def run_codex_app_review_authoritative_adapter(
     thread_id: str | None,
     thread_cwd: str | None,
     raw_file: str | None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            "app_server": app_server,
+            "thread_id": thread_id,
+            "thread_cwd": thread_cwd,
+            "raw_file": raw_file,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=app_server,
+                thread_id=thread_id,
+                thread_cwd=thread_cwd,
+                reviewed_head=reviewed_head,
+                raw_file=raw_file,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     raw_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
@@ -7488,7 +7864,6 @@ def run_codex_app_review_authoritative_adapter(
         ("--codex-app-review-app-server", app_server),
         ("--codex-app-review-thread-id", thread_id),
         ("--codex-app-review-cwd", thread_cwd),
-        ("--codex-app-review-raw-file", raw_file),
     ):
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(label)
@@ -7518,6 +7893,8 @@ def run_codex_app_review_authoritative_adapter(
         missing_inputs.extend(source_errors)
         if source_path is not None:
             source_relative = relative_to_root(source_path, context["target_root"])
+    elif not codex_app_endpoint_is_live_capable(app_server):
+        missing_inputs.append("--codex-app-review-raw-file or live app-server endpoint")
 
     if missing_inputs:
         write_json_file(
@@ -7527,6 +7904,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "runtime_conflict",
@@ -7553,6 +7931,7 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative or thread_cwd,
@@ -7560,17 +7939,30 @@ def run_codex_app_review_authoritative_adapter(
             },
         }
 
-    try:
-        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
-    except OSError as exc:
-        raw_text = ""
-        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
-        normalized = None
+    live_metadata: dict[str, Any] = {}
+    if source_path is not None:
+        try:
+            raw_text = source_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raw_text = ""
+            normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+            normalized = None
+        else:
+            normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+                raw_text,
+                relative=source_relative or str(raw_file),
+            )
     else:
-        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
-            raw_text,
-            relative=source_relative or str(raw_file),
+        raw_text, live_metadata, normalization_errors = run_codex_app_live_review(
+            app_server=str(app_server),
+            thread_id=str(thread_id),
+            reviewed_head=reviewed_head,
+            thread_cwd=str(thread_cwd),
+            prompt_text=instructions_path.read_text(encoding="utf-8"),
         )
+        normalized = live_metadata.get("normalized") if isinstance(live_metadata.get("normalized"), dict) else None
+        if raw_text is None:
+            raw_text = ""
 
     if normalization_errors or normalized is None:
         if raw_text:
@@ -7582,6 +7974,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "schema_drift",
@@ -7592,6 +7985,7 @@ def run_codex_app_review_authoritative_adapter(
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         )
         return {
@@ -7609,10 +8003,12 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         }
 
@@ -7623,6 +8019,7 @@ def run_codex_app_review_authoritative_adapter(
         "engine": CODEX_APP_REVIEW_ENGINE,
         "adapter": CODEX_APP_REVIEW_ADAPTER,
         "profile": engine_profile,
+        **selection_metadata,
         "context_pack": relative_to_root(context_pack_path, context["target_root"]),
         "result": "pass",
         "reviewed_head": reviewed_head,
@@ -7634,6 +8031,11 @@ def run_codex_app_review_authoritative_adapter(
         "thread_id": thread_id,
         "thread_cwd": cwd_relative,
         "raw_source": source_relative,
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "review_thread_id": live_metadata.get("review_thread_id") if live_metadata else (thread_id if source_path is not None else None),
+        **({"live_review": {key: value for key, value in live_metadata.items() if key != "normalized"}} if live_metadata else {}),
         "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
     }
     write_json_file(metadata_path, metadata)
@@ -12452,7 +12854,9 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
-        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
+        current_head = git_head_sha(target_root) or "unknown-head"
+        adapter_selection = select_review_adapter(args, target_root, reviewed_head=current_head)
+        requested_engine_adapter = str(adapter_selection["adapter"])
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
@@ -12484,9 +12888,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12524,9 +12929,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12539,10 +12945,11 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
-                app_server=args.codex_app_review_app_server,
-                thread_id=args.codex_app_review_thread_id,
-                thread_cwd=args.codex_app_review_cwd,
-                raw_file=args.codex_app_review_raw_file,
+                app_server=adapter_selection.get("app_server") if isinstance(adapter_selection.get("app_server"), str) else None,
+                thread_id=adapter_selection.get("thread_id") if isinstance(adapter_selection.get("thread_id"), str) else None,
+                thread_cwd=adapter_selection.get("thread_cwd") if isinstance(adapter_selection.get("thread_cwd"), str) else None,
+                raw_file=adapter_selection.get("raw_file") if isinstance(adapter_selection.get("raw_file"), str) else None,
+                adapter_selection=adapter_selection,
             )
         else:
             engine_payload = run_default_review_engine(
@@ -12551,6 +12958,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
+                adapter_selection=adapter_selection,
             )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,

--- a/skills/loom-retire/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-retire/.loom-runtime/loom-review/SKILL.md
@@ -42,9 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 选择安全的 authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
 
-默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
+已验证 Codex App host context 中，默认 `review run` 使用 `loom/codex-app-review`，并必须证明 app-server/session locator、thread id、cwd proof、target root 与 reviewed head 绑定一致；该路径不得启动嵌套 `codex exec`。`CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex` + `codex exec --output-schema`。proof 冲突、cwd / target / head 不匹配或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -54,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 
@@ -75,7 +75,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - review 机械基线结果
 - build gate 是否允许进入正式审查
 - review artifact 的定位与已记录结论
-- 默认 engine 的执行结果、evidence 定位与 fail-closed 原因
+- selected adapter、fallback reason、thread/target binding summary、reviewed head、evidence 定位与 fail-closed 原因
 - manual review 的回退写回入口
 - review record 中的权威 findings / disposition 摘要
 - 审查结论（`allow` / `block` / `fallback`）

--- a/skills/loom-retire/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-retire/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,7 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
-- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/review-execution.md
@@ -21,7 +21,7 @@ Loom 把 review 分成四层：
 1. `flow review`
    - 只读基线；确认是否具备进入 formal review 的条件
 2. `review run`
-   - 调用默认 Codex-backed reviewer，产出结构化 review evidence 与 Loom-normalized findings
+   - 按宿主 proof 选择 authoritative adapter，产出结构化 review evidence 与 Loom-normalized findings
 3. `review record`
    - 把 formal review 结论写入单一 authored review record
 
@@ -47,27 +47,33 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责选择安全的 authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
+默认 engine 按宿主 proof 选择：
+
+- 已验证 Codex App host context 默认选择 `loom/codex-app-review`，不启动嵌套 `codex exec`
+- `CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex`，能力来源仍是 `codex exec --output-schema`
+- 显式 `--engine-adapter` 优先级最高，继续保留 Stage 2 authoritative opt-in / fallback 调试入口
+
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-Codex App review adapter 有两种显式入口，默认均不启用：
+Codex App review adapter 有三种入口：
 
-- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
-- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- verified host default：不传 `--engine-adapter`，但必须能证明 app-server/session locator、thread id、thread cwd、target root 与 reviewed head 绑定一致
+- explicit authoritative：显式选择 `review run --engine-adapter loom/codex-app-review`，用于调试或非默认宿主
+- shadow comparison：显式选择 `review run --shadow-engine-adapter loom/codex-app-review`
 - shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
-- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
-- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
-- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof；live app-server unavailable 时默认 fallback 到 `loom/default-codex`
+- thread cwd proof 必须等于 target root；cwd / target / reviewed head 绑定冲突或 schema proof 失败时必须 fail closed
 - authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
 - authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
+- `engine_metadata` 必须记录 selected adapter、selection source、fallback reason、thread/target binding summary、reviewed head 与 evidence locators
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
@@ -77,8 +83,8 @@ Codex App review adapter 有两种显式入口，默认均不启用：
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
-- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
+- `adapter`: `loom/default-codex` 或 verified/explicit `loom/codex-app-review`
+- `engine`: `codex` 或 verified/explicit `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -3126,6 +3126,19 @@ def require_review_run_payload(
                 for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
                     if not isinstance(evidence.get(key), str) or not evidence.get(key):
                         failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
+    engine_metadata = payload.get("engine_metadata")
+    if engine_adapter == "loom/codex-app-review" and engine.get("result") == "pass":
+        if not isinstance(engine_metadata, dict):
+            failures.append(Failure(category, f"{context} app review pass must expose `engine_metadata`"))
+        else:
+            for key in ("selected_adapter", "selection_source", "app_server", "thread_id", "thread_cwd", "raw_result", "normalized_findings", "context_pack", "reviewed_head"):
+                value = engine_metadata.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} app review metadata must include non-empty `{key}`"))
+            if engine_metadata.get("selected_adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} app review metadata must bind the selected adapter"))
+            if "normalized review_record_input only" not in str(engine_metadata.get("authority_boundary", "")):
+                failures.append(Failure(category, f"{context} app review metadata must keep raw App output outside merge-ready truth"))
 
 
 def require_runtime_state_payload(
@@ -5725,7 +5738,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
 
         prepare_review_target(review_target, "review run positive chain")
         write_fake_codex(fake_bin / "codex", mode="success")
-        success_env = prepend_path_env(fake_bin)
+        success_env = prepend_path_env(fake_bin, {"CI": "", "CODEX_CI": ""})
 
         payload, error = load_command_json(
             root,
@@ -5893,6 +5906,217 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_default_target = Path(tmp) / "review-run-codex-app-default"
+        prepare_review_target(app_default_target, "review run Codex App host default")
+        app_default_raw = app_default_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_default_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_default_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App default reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-default-warn-1",
+                            "summary": "Codex App default review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_default_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-default-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-default-proof",
+                "--codex-app-review-cwd",
+                str(app_default_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App host default failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App host default",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("adapter") != "loom/codex-app-review" or engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must select the app adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review" or review_record_input.get("reviewer") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must author app adapter review_record_input"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("selection_source") != "codex-app-host-default" or metadata.get("thread_id") != "thread-stage3-default-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must expose selected adapter and thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_default_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored default app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume default Codex App raw evidence before review record is authored"))
+
+        app_ci_fallback_target = Path(tmp) / "review-run-codex-app-ci-fallback"
+        prepare_review_target(app_ci_fallback_target, "review run Codex App CI fallback")
+        app_ci_raw = app_ci_fallback_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_ci_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_ci_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_ci_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-ci-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-ci-proof",
+                "--codex-app-review-cwd",
+                str(app_ci_fallback_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=prepend_path_env(fake_bin, {"CODEX_CI": "1"}),
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App CI fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App CI fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "ci-or-codex-ci":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App CI fallback must keep the default codex exec adapter"))
+
+        app_unavailable_fallback_target = Path(tmp) / "review-run-codex-app-unavailable-fallback"
+        prepare_review_target(app_unavailable_fallback_target, "review run Codex App unavailable fallback")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_unavailable_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                f"unix://{tmp}/missing-codex-app.sock",
+                "--codex-app-review-thread-id",
+                "thread-stage3-missing-endpoint",
+                "--codex-app-review-cwd",
+                str(app_unavailable_fallback_target),
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App unavailable fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App unavailable fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "app-server-unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App unavailable fallback must record default adapter fallback"))
+
+        app_conflict_target = Path(tmp) / "review-run-codex-app-proof-conflict"
+        prepare_review_target(app_conflict_target, "review run Codex App proof conflict")
+        app_conflict_raw = app_conflict_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_conflict_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_conflict_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_conflict_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-conflict-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-conflict-proof",
+                "--codex-app-review-cwd",
+                str(Path(tmp) / "different-cwd"),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App proof conflict failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must fail closed"))
+        else:
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            if engine.get("adapter") != "loom/codex-app-review" or engine.get("failure_reason") != "runtime_conflict":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not fallback to default codex"))
+            if "does not match target root" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must expose cwd mismatch"))
+            if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not emit review_record_input"))
 
         app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
         prepare_review_target(app_authoritative_target, "review run Codex App authoritative")

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,6 +118,10 @@ CODEX_APP_REVIEW_ENGINE = "codex-app-review"
 CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
 AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
+CODEX_APP_REVIEW_ENDPOINT_ENV = "LOOM_CODEX_APP_REVIEW_ENDPOINT"
+CODEX_APP_REVIEW_THREAD_ID_ENV = "LOOM_CODEX_APP_REVIEW_THREAD_ID"
+CODEX_APP_REVIEW_CWD_ENV = "LOOM_CODEX_APP_REVIEW_CWD"
+CODEX_THREAD_ID_ENV = "CODEX_THREAD_ID"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS: int | None = None
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -492,26 +496,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
         help=(
             "Optional authoritative review engine adapter for review run/record. "
-            "Default review run remains loom/default-codex."
+            "When omitted, verified Codex App sessions use loom/codex-app-review; headless/CI fallback remains loom/default-codex."
         ),
     )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
     review.add_argument(
         "--codex-app-review-app-server",
-        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App app-server/session locator. Defaults to ${CODEX_APP_REVIEW_ENDPOINT_ENV} when available.",
     )
     review.add_argument(
         "--codex-app-review-thread-id",
-        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread id. Defaults to ${CODEX_APP_REVIEW_THREAD_ID_ENV}, or ${CODEX_THREAD_ID_ENV} when an endpoint is present.",
     )
     review.add_argument(
         "--codex-app-review-cwd",
-        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread cwd proof. Defaults to ${CODEX_APP_REVIEW_CWD_ENV}.",
     )
     review.add_argument(
         "--codex-app-review-raw-file",
-        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+        help="Optional repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
     )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
@@ -4250,6 +4254,19 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def truthy_env(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def non_empty_str(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def execution_attempt_directory(target_root: Path, item_id: str) -> Path:
     return target_root / ".loom/runtime/attempts" / item_id
 
@@ -6264,8 +6281,26 @@ def run_default_review_engine(
     engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "explicit-or-legacy-default",
+            "fallback_reason": None,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=None,
+                thread_id=None,
+                thread_cwd=None,
+                reviewed_head=reviewed_head,
+                raw_file=None,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     prompt_path = runtime_root / "prompt.txt"
     result_path = runtime_root / "engine-result.json"
@@ -6313,6 +6348,7 @@ def run_default_review_engine(
                     "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
+            "engine_metadata": selection_metadata,
         }
 
     scratch_dir.mkdir(parents=True, exist_ok=True)
@@ -6403,6 +6439,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
@@ -6424,6 +6461,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     if raw_payload is not None and not result_path.exists():
@@ -6440,6 +6478,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
@@ -6462,6 +6501,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     write_json_file(findings_path, {"findings": normalized_payload["findings"]})
@@ -6471,6 +6511,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
@@ -6494,6 +6535,13 @@ def run_default_review_engine(
             "failure_reason": None,
             "reviewed_head": reviewed_head,
             "evidence": engine_evidence,
+        },
+        "engine_metadata": {
+            **selection_metadata,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "raw_result": relative_to_root(result_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "metadata": relative_to_root(metadata_path, context["target_root"]),
         },
         "review_record_input": {
             "decision": normalized_payload["decision"],
@@ -7254,6 +7302,312 @@ def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: st
     return normalized, []
 
 
+def codex_app_endpoint_socket_path(app_server: str | None) -> Path | None:
+    endpoint = non_empty_str(app_server)
+    if endpoint is None:
+        return None
+    if endpoint.startswith("unix://"):
+        path_text = endpoint.removeprefix("unix://")
+    elif endpoint.startswith("/"):
+        path_text = endpoint
+    else:
+        return None
+    if not path_text:
+        return None
+    return Path(path_text).expanduser()
+
+
+def codex_app_endpoint_is_live_capable(app_server: str | None) -> bool:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    return socket_path is not None and socket_path.exists()
+
+
+def codex_app_review_bindings_from_args_env(args: argparse.Namespace) -> dict[str, str | None]:
+    app_server = non_empty_str(args.codex_app_review_app_server) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_ENDPOINT_ENV))
+    thread_id = (
+        non_empty_str(args.codex_app_review_thread_id)
+        or non_empty_str(os.environ.get(CODEX_APP_REVIEW_THREAD_ID_ENV))
+        or (non_empty_str(os.environ.get(CODEX_THREAD_ID_ENV)) if app_server else None)
+    )
+    thread_cwd = non_empty_str(args.codex_app_review_cwd) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_CWD_ENV))
+    raw_file = non_empty_str(args.codex_app_review_raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": thread_cwd,
+        "raw_file": raw_file,
+    }
+
+
+def codex_app_binding_summary(
+    target_root: Path,
+    *,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    reviewed_head: str,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    cwd_match: bool | None = None
+    cwd_summary: str | None = thread_cwd
+    if non_empty_str(thread_cwd):
+        try:
+            cwd_path = Path(str(thread_cwd)).expanduser().resolve()
+        except OSError:
+            cwd_match = False
+        else:
+            cwd_match = cwd_path == target_root
+            cwd_summary = str(cwd_path)
+    raw_source: str | None = None
+    if non_empty_str(raw_file):
+        raw_path, raw_errors = resolve_repo_relative_path(target_root, str(raw_file), label="Codex App authoritative review raw file")
+        if raw_path is not None and not raw_errors:
+            raw_source = relative_to_root(raw_path, target_root)
+        else:
+            raw_source = str(raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_summary,
+        "thread_cwd_matches_target_root": cwd_match,
+        "target_root": str(target_root),
+        "reviewed_head": reviewed_head,
+        "raw_source": raw_source,
+        "live_endpoint_capable": codex_app_endpoint_is_live_capable(app_server),
+    }
+
+
+def select_review_adapter(
+    args: argparse.Namespace,
+    target_root: Path,
+    *,
+    reviewed_head: str,
+) -> dict[str, Any]:
+    bindings = codex_app_review_bindings_from_args_env(args)
+    explicit_adapter = non_empty_str(args.engine_adapter)
+    if explicit_adapter:
+        return {
+            "adapter": explicit_adapter,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    if truthy_env("CI") or truthy_env("CODEX_CI"):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "headless-fallback",
+            "fallback_reason": "ci-or-codex-ci",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    app_server = bindings["app_server"]
+    thread_id = bindings["thread_id"]
+    thread_cwd = bindings["thread_cwd"]
+    raw_file = bindings["raw_file"]
+    if not app_server or not thread_id or not thread_cwd:
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "missing-codex-app-host-proof",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    if not raw_file and not codex_app_endpoint_is_live_capable(app_server):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "app-server-unavailable",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    return {
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "selection_source": "codex-app-host-default",
+        "fallback_reason": None,
+        **bindings,
+        "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+    }
+
+
+def review_adapter_selection_metadata(selection: dict[str, Any], *, reviewed_head: str) -> dict[str, Any]:
+    return {
+        "selected_adapter": selection["adapter"],
+        "selection_source": selection.get("selection_source"),
+        "fallback_reason": selection.get("fallback_reason"),
+        "app_server": selection.get("app_server"),
+        "thread_id": selection.get("thread_id"),
+        "thread_cwd": selection.get("thread_cwd"),
+        "target_root": selection.get("binding_summary", {}).get("target_root")
+        if isinstance(selection.get("binding_summary"), dict)
+        else None,
+        "reviewed_head": reviewed_head,
+        "thread_target_binding": selection.get("binding_summary"),
+    }
+
+
+def jsonrpc_send_request(stdin: Any, *, request_id: int, method: str, params: dict[str, Any]) -> None:
+    stdin.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}) + "\n")
+    stdin.flush()
+
+
+def jsonrpc_read_response(stdout: Any, *, request_id: int) -> tuple[dict[str, Any] | None, list[dict[str, Any]], list[str]]:
+    notifications: list[dict[str, Any]] = []
+    while True:
+        line = stdout.readline()
+        if not line:
+            return None, notifications, [f"app-server closed before response id {request_id}"]
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("id") == request_id:
+            return payload, notifications, []
+        notifications.append(payload)
+
+
+def find_exited_review_text(payload: Any) -> str | None:
+    if isinstance(payload, dict):
+        if payload.get("type") == "exitedReviewMode" and isinstance(payload.get("review"), str):
+            return payload["review"]
+        for value in payload.values():
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    return None
+
+
+def find_normalized_review_payload(payload: Any) -> dict[str, Any] | None:
+    normalized, errors = normalize_engine_review_result(payload, relative="app-server turn/start output")
+    if normalized is not None and not errors:
+        return normalized
+    if isinstance(payload, dict):
+        for value in payload.values():
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    return None
+
+
+def app_server_proxy_command(app_server: str) -> list[str] | None:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    if socket_path is None:
+        return None
+    return ["codex", "app-server", "proxy", "--sock", str(socket_path)]
+
+
+def run_codex_app_live_review(
+    *,
+    app_server: str,
+    thread_id: str,
+    reviewed_head: str,
+    thread_cwd: str,
+    prompt_text: str,
+) -> tuple[str | None, dict[str, Any], list[str]]:
+    command = app_server_proxy_command(app_server)
+    if command is None:
+        return None, {}, [f"unsupported Codex App review endpoint: {app_server}"]
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return None, {}, [f"Codex App review endpoint is unavailable: {exc}"]
+    assert process.stdin is not None
+    assert process.stdout is not None
+    metadata: dict[str, Any] = {"review_target": {"type": "commit", "sha": reviewed_head}}
+    try:
+        jsonrpc_send_request(process.stdin, request_id=1, method="initialize", params={"clientInfo": {"name": "loom", "version": "stage3"}, "capabilities": {}})
+        initialize_response, _, initialize_errors = jsonrpc_read_response(process.stdout, request_id=1)
+        if initialize_errors:
+            return None, metadata, initialize_errors
+        if isinstance(initialize_response, dict) and isinstance(initialize_response.get("error"), dict):
+            return None, metadata, [f"Codex App initialize failed: {initialize_response['error']}"]
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=2,
+            method="review/start",
+            params={
+                "threadId": thread_id,
+                "delivery": "inline",
+                "target": {"type": "commit", "sha": reviewed_head},
+            },
+        )
+        review_response, review_notifications, review_errors = jsonrpc_read_response(process.stdout, request_id=2)
+        if review_errors:
+            return None, metadata, review_errors
+        if isinstance(review_response, dict) and isinstance(review_response.get("error"), dict):
+            return None, metadata, [f"Codex App review/start failed: {review_response['error']}"]
+        result = review_response.get("result") if isinstance(review_response, dict) else None
+        if isinstance(result, dict):
+            metadata["review_thread_id"] = result.get("reviewThreadId")
+        review_text = find_exited_review_text(result) or find_exited_review_text(review_notifications)
+        if not isinstance(review_text, str) or not review_text.strip():
+            return None, metadata, ["Codex App review/start did not return exitedReviewMode.review"]
+
+        parsed_review, parsed_errors = normalize_authoritative_codex_app_review_text(review_text, relative="app-server review/start output")
+        if parsed_review is not None and not parsed_errors:
+            metadata["normalization_source"] = "review-start-json"
+            return review_text, {**metadata, "normalized": parsed_review}, []
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=3,
+            method="turn/start",
+            params={
+                "threadId": metadata.get("review_thread_id") or thread_id,
+                "cwd": thread_cwd,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Normalize this Codex App review output into the provided JSON schema. "
+                            "Return only the structured review result.\n\n"
+                            f"{review_text}"
+                        ),
+                    }
+                ],
+                "outputSchema": load_json_file(review_engine_schema_path()),
+            },
+        )
+        turn_response, turn_notifications, turn_errors = jsonrpc_read_response(process.stdout, request_id=3)
+        if turn_errors:
+            return review_text, metadata, turn_errors
+        if isinstance(turn_response, dict) and isinstance(turn_response.get("error"), dict):
+            return review_text, metadata, [f"Codex App turn/start normalization failed: {turn_response['error']}"]
+        normalized = find_normalized_review_payload(turn_response.get("result") if isinstance(turn_response, dict) else None)
+        if normalized is None:
+            normalized = find_normalized_review_payload(turn_notifications)
+        if normalized is None:
+            return review_text, metadata, ["Codex App turn/start did not return a Loom review result"]
+        metadata["normalization_source"] = "turn-start-output-schema"
+        return review_text, {**metadata, "normalized": normalized}, []
+    finally:
+        try:
+            process.terminate()
+        except OSError:
+            pass
+
+
 def shadow_adapter_slug(adapter: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
 
@@ -7453,8 +7807,30 @@ def run_codex_app_review_authoritative_adapter(
     thread_id: str | None,
     thread_cwd: str | None,
     raw_file: str | None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            "app_server": app_server,
+            "thread_id": thread_id,
+            "thread_cwd": thread_cwd,
+            "raw_file": raw_file,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=app_server,
+                thread_id=thread_id,
+                thread_cwd=thread_cwd,
+                reviewed_head=reviewed_head,
+                raw_file=raw_file,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     raw_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
@@ -7488,7 +7864,6 @@ def run_codex_app_review_authoritative_adapter(
         ("--codex-app-review-app-server", app_server),
         ("--codex-app-review-thread-id", thread_id),
         ("--codex-app-review-cwd", thread_cwd),
-        ("--codex-app-review-raw-file", raw_file),
     ):
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(label)
@@ -7518,6 +7893,8 @@ def run_codex_app_review_authoritative_adapter(
         missing_inputs.extend(source_errors)
         if source_path is not None:
             source_relative = relative_to_root(source_path, context["target_root"])
+    elif not codex_app_endpoint_is_live_capable(app_server):
+        missing_inputs.append("--codex-app-review-raw-file or live app-server endpoint")
 
     if missing_inputs:
         write_json_file(
@@ -7527,6 +7904,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "runtime_conflict",
@@ -7553,6 +7931,7 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative or thread_cwd,
@@ -7560,17 +7939,30 @@ def run_codex_app_review_authoritative_adapter(
             },
         }
 
-    try:
-        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
-    except OSError as exc:
-        raw_text = ""
-        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
-        normalized = None
+    live_metadata: dict[str, Any] = {}
+    if source_path is not None:
+        try:
+            raw_text = source_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raw_text = ""
+            normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+            normalized = None
+        else:
+            normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+                raw_text,
+                relative=source_relative or str(raw_file),
+            )
     else:
-        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
-            raw_text,
-            relative=source_relative or str(raw_file),
+        raw_text, live_metadata, normalization_errors = run_codex_app_live_review(
+            app_server=str(app_server),
+            thread_id=str(thread_id),
+            reviewed_head=reviewed_head,
+            thread_cwd=str(thread_cwd),
+            prompt_text=instructions_path.read_text(encoding="utf-8"),
         )
+        normalized = live_metadata.get("normalized") if isinstance(live_metadata.get("normalized"), dict) else None
+        if raw_text is None:
+            raw_text = ""
 
     if normalization_errors or normalized is None:
         if raw_text:
@@ -7582,6 +7974,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "schema_drift",
@@ -7592,6 +7985,7 @@ def run_codex_app_review_authoritative_adapter(
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         )
         return {
@@ -7609,10 +8003,12 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         }
 
@@ -7623,6 +8019,7 @@ def run_codex_app_review_authoritative_adapter(
         "engine": CODEX_APP_REVIEW_ENGINE,
         "adapter": CODEX_APP_REVIEW_ADAPTER,
         "profile": engine_profile,
+        **selection_metadata,
         "context_pack": relative_to_root(context_pack_path, context["target_root"]),
         "result": "pass",
         "reviewed_head": reviewed_head,
@@ -7634,6 +8031,11 @@ def run_codex_app_review_authoritative_adapter(
         "thread_id": thread_id,
         "thread_cwd": cwd_relative,
         "raw_source": source_relative,
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "review_thread_id": live_metadata.get("review_thread_id") if live_metadata else (thread_id if source_path is not None else None),
+        **({"live_review": {key: value for key, value in live_metadata.items() if key != "normalized"}} if live_metadata else {}),
         "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
     }
     write_json_file(metadata_path, metadata)
@@ -12452,7 +12854,9 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
-        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
+        current_head = git_head_sha(target_root) or "unknown-head"
+        adapter_selection = select_review_adapter(args, target_root, reviewed_head=current_head)
+        requested_engine_adapter = str(adapter_selection["adapter"])
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
@@ -12484,9 +12888,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12524,9 +12929,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12539,10 +12945,11 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
-                app_server=args.codex_app_review_app_server,
-                thread_id=args.codex_app_review_thread_id,
-                thread_cwd=args.codex_app_review_cwd,
-                raw_file=args.codex_app_review_raw_file,
+                app_server=adapter_selection.get("app_server") if isinstance(adapter_selection.get("app_server"), str) else None,
+                thread_id=adapter_selection.get("thread_id") if isinstance(adapter_selection.get("thread_id"), str) else None,
+                thread_cwd=adapter_selection.get("thread_cwd") if isinstance(adapter_selection.get("thread_cwd"), str) else None,
+                raw_file=adapter_selection.get("raw_file") if isinstance(adapter_selection.get("raw_file"), str) else None,
+                adapter_selection=adapter_selection,
             )
         else:
             engine_payload = run_default_review_engine(
@@ -12551,6 +12958,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
+                adapter_selection=adapter_selection,
             )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,

--- a/skills/loom-review/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-review/.loom-runtime/loom-review/SKILL.md
@@ -42,9 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 选择安全的 authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
 
-默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
+已验证 Codex App host context 中，默认 `review run` 使用 `loom/codex-app-review`，并必须证明 app-server/session locator、thread id、cwd proof、target root 与 reviewed head 绑定一致；该路径不得启动嵌套 `codex exec`。`CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex` + `codex exec --output-schema`。proof 冲突、cwd / target / head 不匹配或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -54,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 
@@ -75,7 +75,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - review 机械基线结果
 - build gate 是否允许进入正式审查
 - review artifact 的定位与已记录结论
-- 默认 engine 的执行结果、evidence 定位与 fail-closed 原因
+- selected adapter、fallback reason、thread/target binding summary、reviewed head、evidence 定位与 fail-closed 原因
 - manual review 的回退写回入口
 - review record 中的权威 findings / disposition 摘要
 - 审查结论（`allow` / `block` / `fallback`）

--- a/skills/loom-review/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-review/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,7 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
-- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-review/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/review-execution.md
@@ -21,7 +21,7 @@ Loom 把 review 分成四层：
 1. `flow review`
    - 只读基线；确认是否具备进入 formal review 的条件
 2. `review run`
-   - 调用默认 Codex-backed reviewer，产出结构化 review evidence 与 Loom-normalized findings
+   - 按宿主 proof 选择 authoritative adapter，产出结构化 review evidence 与 Loom-normalized findings
 3. `review record`
    - 把 formal review 结论写入单一 authored review record
 
@@ -47,27 +47,33 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责选择安全的 authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
+默认 engine 按宿主 proof 选择：
+
+- 已验证 Codex App host context 默认选择 `loom/codex-app-review`，不启动嵌套 `codex exec`
+- `CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex`，能力来源仍是 `codex exec --output-schema`
+- 显式 `--engine-adapter` 优先级最高，继续保留 Stage 2 authoritative opt-in / fallback 调试入口
+
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-Codex App review adapter 有两种显式入口，默认均不启用：
+Codex App review adapter 有三种入口：
 
-- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
-- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- verified host default：不传 `--engine-adapter`，但必须能证明 app-server/session locator、thread id、thread cwd、target root 与 reviewed head 绑定一致
+- explicit authoritative：显式选择 `review run --engine-adapter loom/codex-app-review`，用于调试或非默认宿主
+- shadow comparison：显式选择 `review run --shadow-engine-adapter loom/codex-app-review`
 - shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
-- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
-- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
-- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof；live app-server unavailable 时默认 fallback 到 `loom/default-codex`
+- thread cwd proof 必须等于 target root；cwd / target / reviewed head 绑定冲突或 schema proof 失败时必须 fail closed
 - authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
 - authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
+- `engine_metadata` 必须记录 selected adapter、selection source、fallback reason、thread/target binding summary、reviewed head 与 evidence locators
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
@@ -77,8 +83,8 @@ Codex App review adapter 有两种显式入口，默认均不启用：
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
-- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
+- `adapter`: `loom/default-codex` 或 verified/explicit `loom/codex-app-review`
+- `engine`: `codex` 或 verified/explicit `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -3126,6 +3126,19 @@ def require_review_run_payload(
                 for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
                     if not isinstance(evidence.get(key), str) or not evidence.get(key):
                         failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
+    engine_metadata = payload.get("engine_metadata")
+    if engine_adapter == "loom/codex-app-review" and engine.get("result") == "pass":
+        if not isinstance(engine_metadata, dict):
+            failures.append(Failure(category, f"{context} app review pass must expose `engine_metadata`"))
+        else:
+            for key in ("selected_adapter", "selection_source", "app_server", "thread_id", "thread_cwd", "raw_result", "normalized_findings", "context_pack", "reviewed_head"):
+                value = engine_metadata.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} app review metadata must include non-empty `{key}`"))
+            if engine_metadata.get("selected_adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} app review metadata must bind the selected adapter"))
+            if "normalized review_record_input only" not in str(engine_metadata.get("authority_boundary", "")):
+                failures.append(Failure(category, f"{context} app review metadata must keep raw App output outside merge-ready truth"))
 
 
 def require_runtime_state_payload(
@@ -5725,7 +5738,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
 
         prepare_review_target(review_target, "review run positive chain")
         write_fake_codex(fake_bin / "codex", mode="success")
-        success_env = prepend_path_env(fake_bin)
+        success_env = prepend_path_env(fake_bin, {"CI": "", "CODEX_CI": ""})
 
         payload, error = load_command_json(
             root,
@@ -5893,6 +5906,217 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_default_target = Path(tmp) / "review-run-codex-app-default"
+        prepare_review_target(app_default_target, "review run Codex App host default")
+        app_default_raw = app_default_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_default_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_default_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App default reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-default-warn-1",
+                            "summary": "Codex App default review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_default_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-default-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-default-proof",
+                "--codex-app-review-cwd",
+                str(app_default_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App host default failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App host default",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("adapter") != "loom/codex-app-review" or engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must select the app adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review" or review_record_input.get("reviewer") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must author app adapter review_record_input"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("selection_source") != "codex-app-host-default" or metadata.get("thread_id") != "thread-stage3-default-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must expose selected adapter and thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_default_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored default app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume default Codex App raw evidence before review record is authored"))
+
+        app_ci_fallback_target = Path(tmp) / "review-run-codex-app-ci-fallback"
+        prepare_review_target(app_ci_fallback_target, "review run Codex App CI fallback")
+        app_ci_raw = app_ci_fallback_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_ci_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_ci_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_ci_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-ci-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-ci-proof",
+                "--codex-app-review-cwd",
+                str(app_ci_fallback_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=prepend_path_env(fake_bin, {"CODEX_CI": "1"}),
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App CI fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App CI fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "ci-or-codex-ci":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App CI fallback must keep the default codex exec adapter"))
+
+        app_unavailable_fallback_target = Path(tmp) / "review-run-codex-app-unavailable-fallback"
+        prepare_review_target(app_unavailable_fallback_target, "review run Codex App unavailable fallback")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_unavailable_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                f"unix://{tmp}/missing-codex-app.sock",
+                "--codex-app-review-thread-id",
+                "thread-stage3-missing-endpoint",
+                "--codex-app-review-cwd",
+                str(app_unavailable_fallback_target),
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App unavailable fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App unavailable fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "app-server-unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App unavailable fallback must record default adapter fallback"))
+
+        app_conflict_target = Path(tmp) / "review-run-codex-app-proof-conflict"
+        prepare_review_target(app_conflict_target, "review run Codex App proof conflict")
+        app_conflict_raw = app_conflict_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_conflict_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_conflict_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_conflict_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-conflict-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-conflict-proof",
+                "--codex-app-review-cwd",
+                str(Path(tmp) / "different-cwd"),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App proof conflict failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must fail closed"))
+        else:
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            if engine.get("adapter") != "loom/codex-app-review" or engine.get("failure_reason") != "runtime_conflict":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not fallback to default codex"))
+            if "does not match target root" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must expose cwd mismatch"))
+            if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not emit review_record_input"))
 
         app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
         prepare_review_target(app_authoritative_target, "review run Codex App authoritative")

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,6 +118,10 @@ CODEX_APP_REVIEW_ENGINE = "codex-app-review"
 CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
 AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
+CODEX_APP_REVIEW_ENDPOINT_ENV = "LOOM_CODEX_APP_REVIEW_ENDPOINT"
+CODEX_APP_REVIEW_THREAD_ID_ENV = "LOOM_CODEX_APP_REVIEW_THREAD_ID"
+CODEX_APP_REVIEW_CWD_ENV = "LOOM_CODEX_APP_REVIEW_CWD"
+CODEX_THREAD_ID_ENV = "CODEX_THREAD_ID"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS: int | None = None
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -492,26 +496,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
         help=(
             "Optional authoritative review engine adapter for review run/record. "
-            "Default review run remains loom/default-codex."
+            "When omitted, verified Codex App sessions use loom/codex-app-review; headless/CI fallback remains loom/default-codex."
         ),
     )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
     review.add_argument(
         "--codex-app-review-app-server",
-        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App app-server/session locator. Defaults to ${CODEX_APP_REVIEW_ENDPOINT_ENV} when available.",
     )
     review.add_argument(
         "--codex-app-review-thread-id",
-        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread id. Defaults to ${CODEX_APP_REVIEW_THREAD_ID_ENV}, or ${CODEX_THREAD_ID_ENV} when an endpoint is present.",
     )
     review.add_argument(
         "--codex-app-review-cwd",
-        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread cwd proof. Defaults to ${CODEX_APP_REVIEW_CWD_ENV}.",
     )
     review.add_argument(
         "--codex-app-review-raw-file",
-        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+        help="Optional repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
     )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
@@ -4250,6 +4254,19 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def truthy_env(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def non_empty_str(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def execution_attempt_directory(target_root: Path, item_id: str) -> Path:
     return target_root / ".loom/runtime/attempts" / item_id
 
@@ -6264,8 +6281,26 @@ def run_default_review_engine(
     engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "explicit-or-legacy-default",
+            "fallback_reason": None,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=None,
+                thread_id=None,
+                thread_cwd=None,
+                reviewed_head=reviewed_head,
+                raw_file=None,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     prompt_path = runtime_root / "prompt.txt"
     result_path = runtime_root / "engine-result.json"
@@ -6313,6 +6348,7 @@ def run_default_review_engine(
                     "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
+            "engine_metadata": selection_metadata,
         }
 
     scratch_dir.mkdir(parents=True, exist_ok=True)
@@ -6403,6 +6439,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
@@ -6424,6 +6461,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     if raw_payload is not None and not result_path.exists():
@@ -6440,6 +6478,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
@@ -6462,6 +6501,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     write_json_file(findings_path, {"findings": normalized_payload["findings"]})
@@ -6471,6 +6511,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
@@ -6494,6 +6535,13 @@ def run_default_review_engine(
             "failure_reason": None,
             "reviewed_head": reviewed_head,
             "evidence": engine_evidence,
+        },
+        "engine_metadata": {
+            **selection_metadata,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "raw_result": relative_to_root(result_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "metadata": relative_to_root(metadata_path, context["target_root"]),
         },
         "review_record_input": {
             "decision": normalized_payload["decision"],
@@ -7254,6 +7302,312 @@ def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: st
     return normalized, []
 
 
+def codex_app_endpoint_socket_path(app_server: str | None) -> Path | None:
+    endpoint = non_empty_str(app_server)
+    if endpoint is None:
+        return None
+    if endpoint.startswith("unix://"):
+        path_text = endpoint.removeprefix("unix://")
+    elif endpoint.startswith("/"):
+        path_text = endpoint
+    else:
+        return None
+    if not path_text:
+        return None
+    return Path(path_text).expanduser()
+
+
+def codex_app_endpoint_is_live_capable(app_server: str | None) -> bool:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    return socket_path is not None and socket_path.exists()
+
+
+def codex_app_review_bindings_from_args_env(args: argparse.Namespace) -> dict[str, str | None]:
+    app_server = non_empty_str(args.codex_app_review_app_server) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_ENDPOINT_ENV))
+    thread_id = (
+        non_empty_str(args.codex_app_review_thread_id)
+        or non_empty_str(os.environ.get(CODEX_APP_REVIEW_THREAD_ID_ENV))
+        or (non_empty_str(os.environ.get(CODEX_THREAD_ID_ENV)) if app_server else None)
+    )
+    thread_cwd = non_empty_str(args.codex_app_review_cwd) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_CWD_ENV))
+    raw_file = non_empty_str(args.codex_app_review_raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": thread_cwd,
+        "raw_file": raw_file,
+    }
+
+
+def codex_app_binding_summary(
+    target_root: Path,
+    *,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    reviewed_head: str,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    cwd_match: bool | None = None
+    cwd_summary: str | None = thread_cwd
+    if non_empty_str(thread_cwd):
+        try:
+            cwd_path = Path(str(thread_cwd)).expanduser().resolve()
+        except OSError:
+            cwd_match = False
+        else:
+            cwd_match = cwd_path == target_root
+            cwd_summary = str(cwd_path)
+    raw_source: str | None = None
+    if non_empty_str(raw_file):
+        raw_path, raw_errors = resolve_repo_relative_path(target_root, str(raw_file), label="Codex App authoritative review raw file")
+        if raw_path is not None and not raw_errors:
+            raw_source = relative_to_root(raw_path, target_root)
+        else:
+            raw_source = str(raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_summary,
+        "thread_cwd_matches_target_root": cwd_match,
+        "target_root": str(target_root),
+        "reviewed_head": reviewed_head,
+        "raw_source": raw_source,
+        "live_endpoint_capable": codex_app_endpoint_is_live_capable(app_server),
+    }
+
+
+def select_review_adapter(
+    args: argparse.Namespace,
+    target_root: Path,
+    *,
+    reviewed_head: str,
+) -> dict[str, Any]:
+    bindings = codex_app_review_bindings_from_args_env(args)
+    explicit_adapter = non_empty_str(args.engine_adapter)
+    if explicit_adapter:
+        return {
+            "adapter": explicit_adapter,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    if truthy_env("CI") or truthy_env("CODEX_CI"):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "headless-fallback",
+            "fallback_reason": "ci-or-codex-ci",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    app_server = bindings["app_server"]
+    thread_id = bindings["thread_id"]
+    thread_cwd = bindings["thread_cwd"]
+    raw_file = bindings["raw_file"]
+    if not app_server or not thread_id or not thread_cwd:
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "missing-codex-app-host-proof",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    if not raw_file and not codex_app_endpoint_is_live_capable(app_server):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "app-server-unavailable",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    return {
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "selection_source": "codex-app-host-default",
+        "fallback_reason": None,
+        **bindings,
+        "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+    }
+
+
+def review_adapter_selection_metadata(selection: dict[str, Any], *, reviewed_head: str) -> dict[str, Any]:
+    return {
+        "selected_adapter": selection["adapter"],
+        "selection_source": selection.get("selection_source"),
+        "fallback_reason": selection.get("fallback_reason"),
+        "app_server": selection.get("app_server"),
+        "thread_id": selection.get("thread_id"),
+        "thread_cwd": selection.get("thread_cwd"),
+        "target_root": selection.get("binding_summary", {}).get("target_root")
+        if isinstance(selection.get("binding_summary"), dict)
+        else None,
+        "reviewed_head": reviewed_head,
+        "thread_target_binding": selection.get("binding_summary"),
+    }
+
+
+def jsonrpc_send_request(stdin: Any, *, request_id: int, method: str, params: dict[str, Any]) -> None:
+    stdin.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}) + "\n")
+    stdin.flush()
+
+
+def jsonrpc_read_response(stdout: Any, *, request_id: int) -> tuple[dict[str, Any] | None, list[dict[str, Any]], list[str]]:
+    notifications: list[dict[str, Any]] = []
+    while True:
+        line = stdout.readline()
+        if not line:
+            return None, notifications, [f"app-server closed before response id {request_id}"]
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("id") == request_id:
+            return payload, notifications, []
+        notifications.append(payload)
+
+
+def find_exited_review_text(payload: Any) -> str | None:
+    if isinstance(payload, dict):
+        if payload.get("type") == "exitedReviewMode" and isinstance(payload.get("review"), str):
+            return payload["review"]
+        for value in payload.values():
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    return None
+
+
+def find_normalized_review_payload(payload: Any) -> dict[str, Any] | None:
+    normalized, errors = normalize_engine_review_result(payload, relative="app-server turn/start output")
+    if normalized is not None and not errors:
+        return normalized
+    if isinstance(payload, dict):
+        for value in payload.values():
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    return None
+
+
+def app_server_proxy_command(app_server: str) -> list[str] | None:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    if socket_path is None:
+        return None
+    return ["codex", "app-server", "proxy", "--sock", str(socket_path)]
+
+
+def run_codex_app_live_review(
+    *,
+    app_server: str,
+    thread_id: str,
+    reviewed_head: str,
+    thread_cwd: str,
+    prompt_text: str,
+) -> tuple[str | None, dict[str, Any], list[str]]:
+    command = app_server_proxy_command(app_server)
+    if command is None:
+        return None, {}, [f"unsupported Codex App review endpoint: {app_server}"]
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return None, {}, [f"Codex App review endpoint is unavailable: {exc}"]
+    assert process.stdin is not None
+    assert process.stdout is not None
+    metadata: dict[str, Any] = {"review_target": {"type": "commit", "sha": reviewed_head}}
+    try:
+        jsonrpc_send_request(process.stdin, request_id=1, method="initialize", params={"clientInfo": {"name": "loom", "version": "stage3"}, "capabilities": {}})
+        initialize_response, _, initialize_errors = jsonrpc_read_response(process.stdout, request_id=1)
+        if initialize_errors:
+            return None, metadata, initialize_errors
+        if isinstance(initialize_response, dict) and isinstance(initialize_response.get("error"), dict):
+            return None, metadata, [f"Codex App initialize failed: {initialize_response['error']}"]
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=2,
+            method="review/start",
+            params={
+                "threadId": thread_id,
+                "delivery": "inline",
+                "target": {"type": "commit", "sha": reviewed_head},
+            },
+        )
+        review_response, review_notifications, review_errors = jsonrpc_read_response(process.stdout, request_id=2)
+        if review_errors:
+            return None, metadata, review_errors
+        if isinstance(review_response, dict) and isinstance(review_response.get("error"), dict):
+            return None, metadata, [f"Codex App review/start failed: {review_response['error']}"]
+        result = review_response.get("result") if isinstance(review_response, dict) else None
+        if isinstance(result, dict):
+            metadata["review_thread_id"] = result.get("reviewThreadId")
+        review_text = find_exited_review_text(result) or find_exited_review_text(review_notifications)
+        if not isinstance(review_text, str) or not review_text.strip():
+            return None, metadata, ["Codex App review/start did not return exitedReviewMode.review"]
+
+        parsed_review, parsed_errors = normalize_authoritative_codex_app_review_text(review_text, relative="app-server review/start output")
+        if parsed_review is not None and not parsed_errors:
+            metadata["normalization_source"] = "review-start-json"
+            return review_text, {**metadata, "normalized": parsed_review}, []
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=3,
+            method="turn/start",
+            params={
+                "threadId": metadata.get("review_thread_id") or thread_id,
+                "cwd": thread_cwd,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Normalize this Codex App review output into the provided JSON schema. "
+                            "Return only the structured review result.\n\n"
+                            f"{review_text}"
+                        ),
+                    }
+                ],
+                "outputSchema": load_json_file(review_engine_schema_path()),
+            },
+        )
+        turn_response, turn_notifications, turn_errors = jsonrpc_read_response(process.stdout, request_id=3)
+        if turn_errors:
+            return review_text, metadata, turn_errors
+        if isinstance(turn_response, dict) and isinstance(turn_response.get("error"), dict):
+            return review_text, metadata, [f"Codex App turn/start normalization failed: {turn_response['error']}"]
+        normalized = find_normalized_review_payload(turn_response.get("result") if isinstance(turn_response, dict) else None)
+        if normalized is None:
+            normalized = find_normalized_review_payload(turn_notifications)
+        if normalized is None:
+            return review_text, metadata, ["Codex App turn/start did not return a Loom review result"]
+        metadata["normalization_source"] = "turn-start-output-schema"
+        return review_text, {**metadata, "normalized": normalized}, []
+    finally:
+        try:
+            process.terminate()
+        except OSError:
+            pass
+
+
 def shadow_adapter_slug(adapter: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
 
@@ -7453,8 +7807,30 @@ def run_codex_app_review_authoritative_adapter(
     thread_id: str | None,
     thread_cwd: str | None,
     raw_file: str | None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            "app_server": app_server,
+            "thread_id": thread_id,
+            "thread_cwd": thread_cwd,
+            "raw_file": raw_file,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=app_server,
+                thread_id=thread_id,
+                thread_cwd=thread_cwd,
+                reviewed_head=reviewed_head,
+                raw_file=raw_file,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     raw_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
@@ -7488,7 +7864,6 @@ def run_codex_app_review_authoritative_adapter(
         ("--codex-app-review-app-server", app_server),
         ("--codex-app-review-thread-id", thread_id),
         ("--codex-app-review-cwd", thread_cwd),
-        ("--codex-app-review-raw-file", raw_file),
     ):
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(label)
@@ -7518,6 +7893,8 @@ def run_codex_app_review_authoritative_adapter(
         missing_inputs.extend(source_errors)
         if source_path is not None:
             source_relative = relative_to_root(source_path, context["target_root"])
+    elif not codex_app_endpoint_is_live_capable(app_server):
+        missing_inputs.append("--codex-app-review-raw-file or live app-server endpoint")
 
     if missing_inputs:
         write_json_file(
@@ -7527,6 +7904,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "runtime_conflict",
@@ -7553,6 +7931,7 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative or thread_cwd,
@@ -7560,17 +7939,30 @@ def run_codex_app_review_authoritative_adapter(
             },
         }
 
-    try:
-        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
-    except OSError as exc:
-        raw_text = ""
-        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
-        normalized = None
+    live_metadata: dict[str, Any] = {}
+    if source_path is not None:
+        try:
+            raw_text = source_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raw_text = ""
+            normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+            normalized = None
+        else:
+            normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+                raw_text,
+                relative=source_relative or str(raw_file),
+            )
     else:
-        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
-            raw_text,
-            relative=source_relative or str(raw_file),
+        raw_text, live_metadata, normalization_errors = run_codex_app_live_review(
+            app_server=str(app_server),
+            thread_id=str(thread_id),
+            reviewed_head=reviewed_head,
+            thread_cwd=str(thread_cwd),
+            prompt_text=instructions_path.read_text(encoding="utf-8"),
         )
+        normalized = live_metadata.get("normalized") if isinstance(live_metadata.get("normalized"), dict) else None
+        if raw_text is None:
+            raw_text = ""
 
     if normalization_errors or normalized is None:
         if raw_text:
@@ -7582,6 +7974,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "schema_drift",
@@ -7592,6 +7985,7 @@ def run_codex_app_review_authoritative_adapter(
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         )
         return {
@@ -7609,10 +8003,12 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         }
 
@@ -7623,6 +8019,7 @@ def run_codex_app_review_authoritative_adapter(
         "engine": CODEX_APP_REVIEW_ENGINE,
         "adapter": CODEX_APP_REVIEW_ADAPTER,
         "profile": engine_profile,
+        **selection_metadata,
         "context_pack": relative_to_root(context_pack_path, context["target_root"]),
         "result": "pass",
         "reviewed_head": reviewed_head,
@@ -7634,6 +8031,11 @@ def run_codex_app_review_authoritative_adapter(
         "thread_id": thread_id,
         "thread_cwd": cwd_relative,
         "raw_source": source_relative,
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "review_thread_id": live_metadata.get("review_thread_id") if live_metadata else (thread_id if source_path is not None else None),
+        **({"live_review": {key: value for key, value in live_metadata.items() if key != "normalized"}} if live_metadata else {}),
         "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
     }
     write_json_file(metadata_path, metadata)
@@ -12452,7 +12854,9 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
-        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
+        current_head = git_head_sha(target_root) or "unknown-head"
+        adapter_selection = select_review_adapter(args, target_root, reviewed_head=current_head)
+        requested_engine_adapter = str(adapter_selection["adapter"])
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
@@ -12484,9 +12888,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12524,9 +12929,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12539,10 +12945,11 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
-                app_server=args.codex_app_review_app_server,
-                thread_id=args.codex_app_review_thread_id,
-                thread_cwd=args.codex_app_review_cwd,
-                raw_file=args.codex_app_review_raw_file,
+                app_server=adapter_selection.get("app_server") if isinstance(adapter_selection.get("app_server"), str) else None,
+                thread_id=adapter_selection.get("thread_id") if isinstance(adapter_selection.get("thread_id"), str) else None,
+                thread_cwd=adapter_selection.get("thread_cwd") if isinstance(adapter_selection.get("thread_cwd"), str) else None,
+                raw_file=adapter_selection.get("raw_file") if isinstance(adapter_selection.get("raw_file"), str) else None,
+                adapter_selection=adapter_selection,
             )
         else:
             engine_payload = run_default_review_engine(
@@ -12551,6 +12958,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
+                adapter_selection=adapter_selection,
             )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,

--- a/skills/loom-review/SKILL.md
+++ b/skills/loom-review/SKILL.md
@@ -42,9 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 选择安全的 authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
 
-默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
+已验证 Codex App host context 中，默认 `review run` 使用 `loom/codex-app-review`，并必须证明 app-server/session locator、thread id、cwd proof、target root 与 reviewed head 绑定一致；该路径不得启动嵌套 `codex exec`。`CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex` + `codex exec --output-schema`。proof 冲突、cwd / target / head 不匹配或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -54,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 
@@ -75,7 +75,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - review 机械基线结果
 - build gate 是否允许进入正式审查
 - review artifact 的定位与已记录结论
-- 默认 engine 的执行结果、evidence 定位与 fail-closed 原因
+- selected adapter、fallback reason、thread/target binding summary、reviewed head、evidence 定位与 fail-closed 原因
 - manual review 的回退写回入口
 - review record 中的权威 findings / disposition 摘要
 - 审查结论（`allow` / `block` / `fallback`）

--- a/skills/loom-spec-review/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-review/SKILL.md
@@ -42,9 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 选择安全的 authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
 
-默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
+已验证 Codex App host context 中，默认 `review run` 使用 `loom/codex-app-review`，并必须证明 app-server/session locator、thread id、cwd proof、target root 与 reviewed head 绑定一致；该路径不得启动嵌套 `codex exec`。`CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex` + `codex exec --output-schema`。proof 冲突、cwd / target / head 不匹配或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -54,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 
@@ -75,7 +75,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - review 机械基线结果
 - build gate 是否允许进入正式审查
 - review artifact 的定位与已记录结论
-- 默认 engine 的执行结果、evidence 定位与 fail-closed 原因
+- selected adapter、fallback reason、thread/target binding summary、reviewed head、evidence 定位与 fail-closed 原因
 - manual review 的回退写回入口
 - review record 中的权威 findings / disposition 摘要
 - 审查结论（`allow` / `block` / `fallback`）

--- a/skills/loom-spec-review/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,7 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
-- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/review-execution.md
@@ -21,7 +21,7 @@ Loom 把 review 分成四层：
 1. `flow review`
    - 只读基线；确认是否具备进入 formal review 的条件
 2. `review run`
-   - 调用默认 Codex-backed reviewer，产出结构化 review evidence 与 Loom-normalized findings
+   - 按宿主 proof 选择 authoritative adapter，产出结构化 review evidence 与 Loom-normalized findings
 3. `review record`
    - 把 formal review 结论写入单一 authored review record
 
@@ -47,27 +47,33 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责选择安全的 authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
+默认 engine 按宿主 proof 选择：
+
+- 已验证 Codex App host context 默认选择 `loom/codex-app-review`，不启动嵌套 `codex exec`
+- `CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex`，能力来源仍是 `codex exec --output-schema`
+- 显式 `--engine-adapter` 优先级最高，继续保留 Stage 2 authoritative opt-in / fallback 调试入口
+
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-Codex App review adapter 有两种显式入口，默认均不启用：
+Codex App review adapter 有三种入口：
 
-- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
-- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- verified host default：不传 `--engine-adapter`，但必须能证明 app-server/session locator、thread id、thread cwd、target root 与 reviewed head 绑定一致
+- explicit authoritative：显式选择 `review run --engine-adapter loom/codex-app-review`，用于调试或非默认宿主
+- shadow comparison：显式选择 `review run --shadow-engine-adapter loom/codex-app-review`
 - shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
-- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
-- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
-- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof；live app-server unavailable 时默认 fallback 到 `loom/default-codex`
+- thread cwd proof 必须等于 target root；cwd / target / reviewed head 绑定冲突或 schema proof 失败时必须 fail closed
 - authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
 - authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
+- `engine_metadata` 必须记录 selected adapter、selection source、fallback reason、thread/target binding summary、reviewed head 与 evidence locators
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
@@ -77,8 +83,8 @@ Codex App review adapter 有两种显式入口，默认均不启用：
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
-- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
+- `adapter`: `loom/default-codex` 或 verified/explicit `loom/codex-app-review`
+- `engine`: `codex` 或 verified/explicit `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -3126,6 +3126,19 @@ def require_review_run_payload(
                 for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
                     if not isinstance(evidence.get(key), str) or not evidence.get(key):
                         failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
+    engine_metadata = payload.get("engine_metadata")
+    if engine_adapter == "loom/codex-app-review" and engine.get("result") == "pass":
+        if not isinstance(engine_metadata, dict):
+            failures.append(Failure(category, f"{context} app review pass must expose `engine_metadata`"))
+        else:
+            for key in ("selected_adapter", "selection_source", "app_server", "thread_id", "thread_cwd", "raw_result", "normalized_findings", "context_pack", "reviewed_head"):
+                value = engine_metadata.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} app review metadata must include non-empty `{key}`"))
+            if engine_metadata.get("selected_adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} app review metadata must bind the selected adapter"))
+            if "normalized review_record_input only" not in str(engine_metadata.get("authority_boundary", "")):
+                failures.append(Failure(category, f"{context} app review metadata must keep raw App output outside merge-ready truth"))
 
 
 def require_runtime_state_payload(
@@ -5725,7 +5738,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
 
         prepare_review_target(review_target, "review run positive chain")
         write_fake_codex(fake_bin / "codex", mode="success")
-        success_env = prepend_path_env(fake_bin)
+        success_env = prepend_path_env(fake_bin, {"CI": "", "CODEX_CI": ""})
 
         payload, error = load_command_json(
             root,
@@ -5893,6 +5906,217 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_default_target = Path(tmp) / "review-run-codex-app-default"
+        prepare_review_target(app_default_target, "review run Codex App host default")
+        app_default_raw = app_default_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_default_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_default_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App default reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-default-warn-1",
+                            "summary": "Codex App default review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_default_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-default-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-default-proof",
+                "--codex-app-review-cwd",
+                str(app_default_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App host default failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App host default",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("adapter") != "loom/codex-app-review" or engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must select the app adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review" or review_record_input.get("reviewer") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must author app adapter review_record_input"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("selection_source") != "codex-app-host-default" or metadata.get("thread_id") != "thread-stage3-default-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must expose selected adapter and thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_default_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored default app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume default Codex App raw evidence before review record is authored"))
+
+        app_ci_fallback_target = Path(tmp) / "review-run-codex-app-ci-fallback"
+        prepare_review_target(app_ci_fallback_target, "review run Codex App CI fallback")
+        app_ci_raw = app_ci_fallback_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_ci_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_ci_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_ci_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-ci-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-ci-proof",
+                "--codex-app-review-cwd",
+                str(app_ci_fallback_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=prepend_path_env(fake_bin, {"CODEX_CI": "1"}),
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App CI fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App CI fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "ci-or-codex-ci":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App CI fallback must keep the default codex exec adapter"))
+
+        app_unavailable_fallback_target = Path(tmp) / "review-run-codex-app-unavailable-fallback"
+        prepare_review_target(app_unavailable_fallback_target, "review run Codex App unavailable fallback")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_unavailable_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                f"unix://{tmp}/missing-codex-app.sock",
+                "--codex-app-review-thread-id",
+                "thread-stage3-missing-endpoint",
+                "--codex-app-review-cwd",
+                str(app_unavailable_fallback_target),
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App unavailable fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App unavailable fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "app-server-unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App unavailable fallback must record default adapter fallback"))
+
+        app_conflict_target = Path(tmp) / "review-run-codex-app-proof-conflict"
+        prepare_review_target(app_conflict_target, "review run Codex App proof conflict")
+        app_conflict_raw = app_conflict_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_conflict_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_conflict_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_conflict_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-conflict-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-conflict-proof",
+                "--codex-app-review-cwd",
+                str(Path(tmp) / "different-cwd"),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App proof conflict failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must fail closed"))
+        else:
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            if engine.get("adapter") != "loom/codex-app-review" or engine.get("failure_reason") != "runtime_conflict":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not fallback to default codex"))
+            if "does not match target root" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must expose cwd mismatch"))
+            if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not emit review_record_input"))
 
         app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
         prepare_review_target(app_authoritative_target, "review run Codex App authoritative")

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,6 +118,10 @@ CODEX_APP_REVIEW_ENGINE = "codex-app-review"
 CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
 AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
+CODEX_APP_REVIEW_ENDPOINT_ENV = "LOOM_CODEX_APP_REVIEW_ENDPOINT"
+CODEX_APP_REVIEW_THREAD_ID_ENV = "LOOM_CODEX_APP_REVIEW_THREAD_ID"
+CODEX_APP_REVIEW_CWD_ENV = "LOOM_CODEX_APP_REVIEW_CWD"
+CODEX_THREAD_ID_ENV = "CODEX_THREAD_ID"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS: int | None = None
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -492,26 +496,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
         help=(
             "Optional authoritative review engine adapter for review run/record. "
-            "Default review run remains loom/default-codex."
+            "When omitted, verified Codex App sessions use loom/codex-app-review; headless/CI fallback remains loom/default-codex."
         ),
     )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
     review.add_argument(
         "--codex-app-review-app-server",
-        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App app-server/session locator. Defaults to ${CODEX_APP_REVIEW_ENDPOINT_ENV} when available.",
     )
     review.add_argument(
         "--codex-app-review-thread-id",
-        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread id. Defaults to ${CODEX_APP_REVIEW_THREAD_ID_ENV}, or ${CODEX_THREAD_ID_ENV} when an endpoint is present.",
     )
     review.add_argument(
         "--codex-app-review-cwd",
-        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread cwd proof. Defaults to ${CODEX_APP_REVIEW_CWD_ENV}.",
     )
     review.add_argument(
         "--codex-app-review-raw-file",
-        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+        help="Optional repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
     )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
@@ -4250,6 +4254,19 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def truthy_env(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def non_empty_str(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def execution_attempt_directory(target_root: Path, item_id: str) -> Path:
     return target_root / ".loom/runtime/attempts" / item_id
 
@@ -6264,8 +6281,26 @@ def run_default_review_engine(
     engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "explicit-or-legacy-default",
+            "fallback_reason": None,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=None,
+                thread_id=None,
+                thread_cwd=None,
+                reviewed_head=reviewed_head,
+                raw_file=None,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     prompt_path = runtime_root / "prompt.txt"
     result_path = runtime_root / "engine-result.json"
@@ -6313,6 +6348,7 @@ def run_default_review_engine(
                     "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
+            "engine_metadata": selection_metadata,
         }
 
     scratch_dir.mkdir(parents=True, exist_ok=True)
@@ -6403,6 +6439,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
@@ -6424,6 +6461,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     if raw_payload is not None and not result_path.exists():
@@ -6440,6 +6478,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
@@ -6462,6 +6501,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     write_json_file(findings_path, {"findings": normalized_payload["findings"]})
@@ -6471,6 +6511,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
@@ -6494,6 +6535,13 @@ def run_default_review_engine(
             "failure_reason": None,
             "reviewed_head": reviewed_head,
             "evidence": engine_evidence,
+        },
+        "engine_metadata": {
+            **selection_metadata,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "raw_result": relative_to_root(result_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "metadata": relative_to_root(metadata_path, context["target_root"]),
         },
         "review_record_input": {
             "decision": normalized_payload["decision"],
@@ -7254,6 +7302,312 @@ def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: st
     return normalized, []
 
 
+def codex_app_endpoint_socket_path(app_server: str | None) -> Path | None:
+    endpoint = non_empty_str(app_server)
+    if endpoint is None:
+        return None
+    if endpoint.startswith("unix://"):
+        path_text = endpoint.removeprefix("unix://")
+    elif endpoint.startswith("/"):
+        path_text = endpoint
+    else:
+        return None
+    if not path_text:
+        return None
+    return Path(path_text).expanduser()
+
+
+def codex_app_endpoint_is_live_capable(app_server: str | None) -> bool:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    return socket_path is not None and socket_path.exists()
+
+
+def codex_app_review_bindings_from_args_env(args: argparse.Namespace) -> dict[str, str | None]:
+    app_server = non_empty_str(args.codex_app_review_app_server) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_ENDPOINT_ENV))
+    thread_id = (
+        non_empty_str(args.codex_app_review_thread_id)
+        or non_empty_str(os.environ.get(CODEX_APP_REVIEW_THREAD_ID_ENV))
+        or (non_empty_str(os.environ.get(CODEX_THREAD_ID_ENV)) if app_server else None)
+    )
+    thread_cwd = non_empty_str(args.codex_app_review_cwd) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_CWD_ENV))
+    raw_file = non_empty_str(args.codex_app_review_raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": thread_cwd,
+        "raw_file": raw_file,
+    }
+
+
+def codex_app_binding_summary(
+    target_root: Path,
+    *,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    reviewed_head: str,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    cwd_match: bool | None = None
+    cwd_summary: str | None = thread_cwd
+    if non_empty_str(thread_cwd):
+        try:
+            cwd_path = Path(str(thread_cwd)).expanduser().resolve()
+        except OSError:
+            cwd_match = False
+        else:
+            cwd_match = cwd_path == target_root
+            cwd_summary = str(cwd_path)
+    raw_source: str | None = None
+    if non_empty_str(raw_file):
+        raw_path, raw_errors = resolve_repo_relative_path(target_root, str(raw_file), label="Codex App authoritative review raw file")
+        if raw_path is not None and not raw_errors:
+            raw_source = relative_to_root(raw_path, target_root)
+        else:
+            raw_source = str(raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_summary,
+        "thread_cwd_matches_target_root": cwd_match,
+        "target_root": str(target_root),
+        "reviewed_head": reviewed_head,
+        "raw_source": raw_source,
+        "live_endpoint_capable": codex_app_endpoint_is_live_capable(app_server),
+    }
+
+
+def select_review_adapter(
+    args: argparse.Namespace,
+    target_root: Path,
+    *,
+    reviewed_head: str,
+) -> dict[str, Any]:
+    bindings = codex_app_review_bindings_from_args_env(args)
+    explicit_adapter = non_empty_str(args.engine_adapter)
+    if explicit_adapter:
+        return {
+            "adapter": explicit_adapter,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    if truthy_env("CI") or truthy_env("CODEX_CI"):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "headless-fallback",
+            "fallback_reason": "ci-or-codex-ci",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    app_server = bindings["app_server"]
+    thread_id = bindings["thread_id"]
+    thread_cwd = bindings["thread_cwd"]
+    raw_file = bindings["raw_file"]
+    if not app_server or not thread_id or not thread_cwd:
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "missing-codex-app-host-proof",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    if not raw_file and not codex_app_endpoint_is_live_capable(app_server):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "app-server-unavailable",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    return {
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "selection_source": "codex-app-host-default",
+        "fallback_reason": None,
+        **bindings,
+        "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+    }
+
+
+def review_adapter_selection_metadata(selection: dict[str, Any], *, reviewed_head: str) -> dict[str, Any]:
+    return {
+        "selected_adapter": selection["adapter"],
+        "selection_source": selection.get("selection_source"),
+        "fallback_reason": selection.get("fallback_reason"),
+        "app_server": selection.get("app_server"),
+        "thread_id": selection.get("thread_id"),
+        "thread_cwd": selection.get("thread_cwd"),
+        "target_root": selection.get("binding_summary", {}).get("target_root")
+        if isinstance(selection.get("binding_summary"), dict)
+        else None,
+        "reviewed_head": reviewed_head,
+        "thread_target_binding": selection.get("binding_summary"),
+    }
+
+
+def jsonrpc_send_request(stdin: Any, *, request_id: int, method: str, params: dict[str, Any]) -> None:
+    stdin.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}) + "\n")
+    stdin.flush()
+
+
+def jsonrpc_read_response(stdout: Any, *, request_id: int) -> tuple[dict[str, Any] | None, list[dict[str, Any]], list[str]]:
+    notifications: list[dict[str, Any]] = []
+    while True:
+        line = stdout.readline()
+        if not line:
+            return None, notifications, [f"app-server closed before response id {request_id}"]
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("id") == request_id:
+            return payload, notifications, []
+        notifications.append(payload)
+
+
+def find_exited_review_text(payload: Any) -> str | None:
+    if isinstance(payload, dict):
+        if payload.get("type") == "exitedReviewMode" and isinstance(payload.get("review"), str):
+            return payload["review"]
+        for value in payload.values():
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    return None
+
+
+def find_normalized_review_payload(payload: Any) -> dict[str, Any] | None:
+    normalized, errors = normalize_engine_review_result(payload, relative="app-server turn/start output")
+    if normalized is not None and not errors:
+        return normalized
+    if isinstance(payload, dict):
+        for value in payload.values():
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    return None
+
+
+def app_server_proxy_command(app_server: str) -> list[str] | None:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    if socket_path is None:
+        return None
+    return ["codex", "app-server", "proxy", "--sock", str(socket_path)]
+
+
+def run_codex_app_live_review(
+    *,
+    app_server: str,
+    thread_id: str,
+    reviewed_head: str,
+    thread_cwd: str,
+    prompt_text: str,
+) -> tuple[str | None, dict[str, Any], list[str]]:
+    command = app_server_proxy_command(app_server)
+    if command is None:
+        return None, {}, [f"unsupported Codex App review endpoint: {app_server}"]
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return None, {}, [f"Codex App review endpoint is unavailable: {exc}"]
+    assert process.stdin is not None
+    assert process.stdout is not None
+    metadata: dict[str, Any] = {"review_target": {"type": "commit", "sha": reviewed_head}}
+    try:
+        jsonrpc_send_request(process.stdin, request_id=1, method="initialize", params={"clientInfo": {"name": "loom", "version": "stage3"}, "capabilities": {}})
+        initialize_response, _, initialize_errors = jsonrpc_read_response(process.stdout, request_id=1)
+        if initialize_errors:
+            return None, metadata, initialize_errors
+        if isinstance(initialize_response, dict) and isinstance(initialize_response.get("error"), dict):
+            return None, metadata, [f"Codex App initialize failed: {initialize_response['error']}"]
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=2,
+            method="review/start",
+            params={
+                "threadId": thread_id,
+                "delivery": "inline",
+                "target": {"type": "commit", "sha": reviewed_head},
+            },
+        )
+        review_response, review_notifications, review_errors = jsonrpc_read_response(process.stdout, request_id=2)
+        if review_errors:
+            return None, metadata, review_errors
+        if isinstance(review_response, dict) and isinstance(review_response.get("error"), dict):
+            return None, metadata, [f"Codex App review/start failed: {review_response['error']}"]
+        result = review_response.get("result") if isinstance(review_response, dict) else None
+        if isinstance(result, dict):
+            metadata["review_thread_id"] = result.get("reviewThreadId")
+        review_text = find_exited_review_text(result) or find_exited_review_text(review_notifications)
+        if not isinstance(review_text, str) or not review_text.strip():
+            return None, metadata, ["Codex App review/start did not return exitedReviewMode.review"]
+
+        parsed_review, parsed_errors = normalize_authoritative_codex_app_review_text(review_text, relative="app-server review/start output")
+        if parsed_review is not None and not parsed_errors:
+            metadata["normalization_source"] = "review-start-json"
+            return review_text, {**metadata, "normalized": parsed_review}, []
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=3,
+            method="turn/start",
+            params={
+                "threadId": metadata.get("review_thread_id") or thread_id,
+                "cwd": thread_cwd,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Normalize this Codex App review output into the provided JSON schema. "
+                            "Return only the structured review result.\n\n"
+                            f"{review_text}"
+                        ),
+                    }
+                ],
+                "outputSchema": load_json_file(review_engine_schema_path()),
+            },
+        )
+        turn_response, turn_notifications, turn_errors = jsonrpc_read_response(process.stdout, request_id=3)
+        if turn_errors:
+            return review_text, metadata, turn_errors
+        if isinstance(turn_response, dict) and isinstance(turn_response.get("error"), dict):
+            return review_text, metadata, [f"Codex App turn/start normalization failed: {turn_response['error']}"]
+        normalized = find_normalized_review_payload(turn_response.get("result") if isinstance(turn_response, dict) else None)
+        if normalized is None:
+            normalized = find_normalized_review_payload(turn_notifications)
+        if normalized is None:
+            return review_text, metadata, ["Codex App turn/start did not return a Loom review result"]
+        metadata["normalization_source"] = "turn-start-output-schema"
+        return review_text, {**metadata, "normalized": normalized}, []
+    finally:
+        try:
+            process.terminate()
+        except OSError:
+            pass
+
+
 def shadow_adapter_slug(adapter: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
 
@@ -7453,8 +7807,30 @@ def run_codex_app_review_authoritative_adapter(
     thread_id: str | None,
     thread_cwd: str | None,
     raw_file: str | None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            "app_server": app_server,
+            "thread_id": thread_id,
+            "thread_cwd": thread_cwd,
+            "raw_file": raw_file,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=app_server,
+                thread_id=thread_id,
+                thread_cwd=thread_cwd,
+                reviewed_head=reviewed_head,
+                raw_file=raw_file,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     raw_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
@@ -7488,7 +7864,6 @@ def run_codex_app_review_authoritative_adapter(
         ("--codex-app-review-app-server", app_server),
         ("--codex-app-review-thread-id", thread_id),
         ("--codex-app-review-cwd", thread_cwd),
-        ("--codex-app-review-raw-file", raw_file),
     ):
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(label)
@@ -7518,6 +7893,8 @@ def run_codex_app_review_authoritative_adapter(
         missing_inputs.extend(source_errors)
         if source_path is not None:
             source_relative = relative_to_root(source_path, context["target_root"])
+    elif not codex_app_endpoint_is_live_capable(app_server):
+        missing_inputs.append("--codex-app-review-raw-file or live app-server endpoint")
 
     if missing_inputs:
         write_json_file(
@@ -7527,6 +7904,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "runtime_conflict",
@@ -7553,6 +7931,7 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative or thread_cwd,
@@ -7560,17 +7939,30 @@ def run_codex_app_review_authoritative_adapter(
             },
         }
 
-    try:
-        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
-    except OSError as exc:
-        raw_text = ""
-        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
-        normalized = None
+    live_metadata: dict[str, Any] = {}
+    if source_path is not None:
+        try:
+            raw_text = source_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raw_text = ""
+            normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+            normalized = None
+        else:
+            normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+                raw_text,
+                relative=source_relative or str(raw_file),
+            )
     else:
-        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
-            raw_text,
-            relative=source_relative or str(raw_file),
+        raw_text, live_metadata, normalization_errors = run_codex_app_live_review(
+            app_server=str(app_server),
+            thread_id=str(thread_id),
+            reviewed_head=reviewed_head,
+            thread_cwd=str(thread_cwd),
+            prompt_text=instructions_path.read_text(encoding="utf-8"),
         )
+        normalized = live_metadata.get("normalized") if isinstance(live_metadata.get("normalized"), dict) else None
+        if raw_text is None:
+            raw_text = ""
 
     if normalization_errors or normalized is None:
         if raw_text:
@@ -7582,6 +7974,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "schema_drift",
@@ -7592,6 +7985,7 @@ def run_codex_app_review_authoritative_adapter(
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         )
         return {
@@ -7609,10 +8003,12 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         }
 
@@ -7623,6 +8019,7 @@ def run_codex_app_review_authoritative_adapter(
         "engine": CODEX_APP_REVIEW_ENGINE,
         "adapter": CODEX_APP_REVIEW_ADAPTER,
         "profile": engine_profile,
+        **selection_metadata,
         "context_pack": relative_to_root(context_pack_path, context["target_root"]),
         "result": "pass",
         "reviewed_head": reviewed_head,
@@ -7634,6 +8031,11 @@ def run_codex_app_review_authoritative_adapter(
         "thread_id": thread_id,
         "thread_cwd": cwd_relative,
         "raw_source": source_relative,
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "review_thread_id": live_metadata.get("review_thread_id") if live_metadata else (thread_id if source_path is not None else None),
+        **({"live_review": {key: value for key, value in live_metadata.items() if key != "normalized"}} if live_metadata else {}),
         "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
     }
     write_json_file(metadata_path, metadata)
@@ -12452,7 +12854,9 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
-        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
+        current_head = git_head_sha(target_root) or "unknown-head"
+        adapter_selection = select_review_adapter(args, target_root, reviewed_head=current_head)
+        requested_engine_adapter = str(adapter_selection["adapter"])
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
@@ -12484,9 +12888,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12524,9 +12929,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12539,10 +12945,11 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
-                app_server=args.codex_app_review_app_server,
-                thread_id=args.codex_app_review_thread_id,
-                thread_cwd=args.codex_app_review_cwd,
-                raw_file=args.codex_app_review_raw_file,
+                app_server=adapter_selection.get("app_server") if isinstance(adapter_selection.get("app_server"), str) else None,
+                thread_id=adapter_selection.get("thread_id") if isinstance(adapter_selection.get("thread_id"), str) else None,
+                thread_cwd=adapter_selection.get("thread_cwd") if isinstance(adapter_selection.get("thread_cwd"), str) else None,
+                raw_file=adapter_selection.get("raw_file") if isinstance(adapter_selection.get("raw_file"), str) else None,
+                adapter_selection=adapter_selection,
             )
         else:
             engine_payload = run_default_review_engine(
@@ -12551,6 +12958,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
+                adapter_selection=adapter_selection,
             )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,

--- a/skills/loom-spec-review/SKILL.md
+++ b/skills/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,7 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
-- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-story/.loom-runtime/loom-review/SKILL.md
+++ b/skills/loom-story/.loom-runtime/loom-review/SKILL.md
@@ -42,9 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 选择安全的 authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
 
-默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
+已验证 Codex App host context 中，默认 `review run` 使用 `loom/codex-app-review`，并必须证明 app-server/session locator、thread id、cwd proof、target root 与 reviewed head 绑定一致；该路径不得启动嵌套 `codex exec`。`CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex` + `codex exec --output-schema`。proof 冲突、cwd / target / head 不匹配或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -54,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 
@@ -75,7 +75,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - review 机械基线结果
 - build gate 是否允许进入正式审查
 - review artifact 的定位与已记录结论
-- 默认 engine 的执行结果、evidence 定位与 fail-closed 原因
+- selected adapter、fallback reason、thread/target binding summary、reviewed head、evidence 定位与 fail-closed 原因
 - manual review 的回退写回入口
 - review record 中的权威 findings / disposition 摘要
 - 审查结论（`allow` / `block` / `fallback`）

--- a/skills/loom-story/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-story/.loom-runtime/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,7 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
-- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/skills/loom-story/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-story/.loom-runtime/shared/references/harness/review-execution.md
@@ -21,7 +21,7 @@ Loom 把 review 分成四层：
 1. `flow review`
    - 只读基线；确认是否具备进入 formal review 的条件
 2. `review run`
-   - 调用默认 Codex-backed reviewer，产出结构化 review evidence 与 Loom-normalized findings
+   - 按宿主 proof 选择 authoritative adapter，产出结构化 review evidence 与 Loom-normalized findings
 3. `review record`
    - 把 formal review 结论写入单一 authored review record
 
@@ -47,27 +47,33 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责选择安全的 authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
+默认 engine 按宿主 proof 选择：
+
+- 已验证 Codex App host context 默认选择 `loom/codex-app-review`，不启动嵌套 `codex exec`
+- `CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex`，能力来源仍是 `codex exec --output-schema`
+- 显式 `--engine-adapter` 优先级最高，继续保留 Stage 2 authoritative opt-in / fallback 调试入口
+
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-Codex App review adapter 有两种显式入口，默认均不启用：
+Codex App review adapter 有三种入口：
 
-- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
-- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- verified host default：不传 `--engine-adapter`，但必须能证明 app-server/session locator、thread id、thread cwd、target root 与 reviewed head 绑定一致
+- explicit authoritative：显式选择 `review run --engine-adapter loom/codex-app-review`，用于调试或非默认宿主
+- shadow comparison：显式选择 `review run --shadow-engine-adapter loom/codex-app-review`
 - shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
-- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
-- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
-- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof；live app-server unavailable 时默认 fallback 到 `loom/default-codex`
+- thread cwd proof 必须等于 target root；cwd / target / reviewed head 绑定冲突或 schema proof 失败时必须 fail closed
 - authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
 - authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
+- `engine_metadata` 必须记录 selected adapter、selection source、fallback reason、thread/target binding summary、reviewed head 与 evidence locators
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
@@ -77,8 +83,8 @@ Codex App review adapter 有两种显式入口，默认均不启用：
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
-- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
+- `adapter`: `loom/default-codex` 或 verified/explicit `loom/codex-app-review`
+- `engine`: `codex` 或 verified/explicit `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
@@ -3126,6 +3126,19 @@ def require_review_run_payload(
                 for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
                     if not isinstance(evidence.get(key), str) or not evidence.get(key):
                         failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
+    engine_metadata = payload.get("engine_metadata")
+    if engine_adapter == "loom/codex-app-review" and engine.get("result") == "pass":
+        if not isinstance(engine_metadata, dict):
+            failures.append(Failure(category, f"{context} app review pass must expose `engine_metadata`"))
+        else:
+            for key in ("selected_adapter", "selection_source", "app_server", "thread_id", "thread_cwd", "raw_result", "normalized_findings", "context_pack", "reviewed_head"):
+                value = engine_metadata.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} app review metadata must include non-empty `{key}`"))
+            if engine_metadata.get("selected_adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} app review metadata must bind the selected adapter"))
+            if "normalized review_record_input only" not in str(engine_metadata.get("authority_boundary", "")):
+                failures.append(Failure(category, f"{context} app review metadata must keep raw App output outside merge-ready truth"))
 
 
 def require_runtime_state_payload(
@@ -5725,7 +5738,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
 
         prepare_review_target(review_target, "review run positive chain")
         write_fake_codex(fake_bin / "codex", mode="success")
-        success_env = prepend_path_env(fake_bin)
+        success_env = prepend_path_env(fake_bin, {"CI": "", "CODEX_CI": ""})
 
         payload, error = load_command_json(
             root,
@@ -5893,6 +5906,217 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_default_target = Path(tmp) / "review-run-codex-app-default"
+        prepare_review_target(app_default_target, "review run Codex App host default")
+        app_default_raw = app_default_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_default_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_default_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App default reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-default-warn-1",
+                            "summary": "Codex App default review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_default_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-default-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-default-proof",
+                "--codex-app-review-cwd",
+                str(app_default_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App host default failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App host default",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("adapter") != "loom/codex-app-review" or engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must select the app adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review" or review_record_input.get("reviewer") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must author app adapter review_record_input"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("selection_source") != "codex-app-host-default" or metadata.get("thread_id") != "thread-stage3-default-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must expose selected adapter and thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_default_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored default app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume default Codex App raw evidence before review record is authored"))
+
+        app_ci_fallback_target = Path(tmp) / "review-run-codex-app-ci-fallback"
+        prepare_review_target(app_ci_fallback_target, "review run Codex App CI fallback")
+        app_ci_raw = app_ci_fallback_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_ci_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_ci_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_ci_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-ci-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-ci-proof",
+                "--codex-app-review-cwd",
+                str(app_ci_fallback_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=prepend_path_env(fake_bin, {"CODEX_CI": "1"}),
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App CI fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App CI fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "ci-or-codex-ci":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App CI fallback must keep the default codex exec adapter"))
+
+        app_unavailable_fallback_target = Path(tmp) / "review-run-codex-app-unavailable-fallback"
+        prepare_review_target(app_unavailable_fallback_target, "review run Codex App unavailable fallback")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_unavailable_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                f"unix://{tmp}/missing-codex-app.sock",
+                "--codex-app-review-thread-id",
+                "thread-stage3-missing-endpoint",
+                "--codex-app-review-cwd",
+                str(app_unavailable_fallback_target),
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App unavailable fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App unavailable fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "app-server-unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App unavailable fallback must record default adapter fallback"))
+
+        app_conflict_target = Path(tmp) / "review-run-codex-app-proof-conflict"
+        prepare_review_target(app_conflict_target, "review run Codex App proof conflict")
+        app_conflict_raw = app_conflict_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_conflict_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_conflict_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_conflict_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-conflict-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-conflict-proof",
+                "--codex-app-review-cwd",
+                str(Path(tmp) / "different-cwd"),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App proof conflict failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must fail closed"))
+        else:
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            if engine.get("adapter") != "loom/codex-app-review" or engine.get("failure_reason") != "runtime_conflict":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not fallback to default codex"))
+            if "does not match target root" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must expose cwd mismatch"))
+            if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not emit review_record_input"))
 
         app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
         prepare_review_target(app_authoritative_target, "review run Codex App authoritative")

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,6 +118,10 @@ CODEX_APP_REVIEW_ENGINE = "codex-app-review"
 CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
 AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
+CODEX_APP_REVIEW_ENDPOINT_ENV = "LOOM_CODEX_APP_REVIEW_ENDPOINT"
+CODEX_APP_REVIEW_THREAD_ID_ENV = "LOOM_CODEX_APP_REVIEW_THREAD_ID"
+CODEX_APP_REVIEW_CWD_ENV = "LOOM_CODEX_APP_REVIEW_CWD"
+CODEX_THREAD_ID_ENV = "CODEX_THREAD_ID"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS: int | None = None
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -492,26 +496,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
         help=(
             "Optional authoritative review engine adapter for review run/record. "
-            "Default review run remains loom/default-codex."
+            "When omitted, verified Codex App sessions use loom/codex-app-review; headless/CI fallback remains loom/default-codex."
         ),
     )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
     review.add_argument(
         "--codex-app-review-app-server",
-        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App app-server/session locator. Defaults to ${CODEX_APP_REVIEW_ENDPOINT_ENV} when available.",
     )
     review.add_argument(
         "--codex-app-review-thread-id",
-        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread id. Defaults to ${CODEX_APP_REVIEW_THREAD_ID_ENV}, or ${CODEX_THREAD_ID_ENV} when an endpoint is present.",
     )
     review.add_argument(
         "--codex-app-review-cwd",
-        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread cwd proof. Defaults to ${CODEX_APP_REVIEW_CWD_ENV}.",
     )
     review.add_argument(
         "--codex-app-review-raw-file",
-        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+        help="Optional repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
     )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
@@ -4250,6 +4254,19 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def truthy_env(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def non_empty_str(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def execution_attempt_directory(target_root: Path, item_id: str) -> Path:
     return target_root / ".loom/runtime/attempts" / item_id
 
@@ -6264,8 +6281,26 @@ def run_default_review_engine(
     engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "explicit-or-legacy-default",
+            "fallback_reason": None,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=None,
+                thread_id=None,
+                thread_cwd=None,
+                reviewed_head=reviewed_head,
+                raw_file=None,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     prompt_path = runtime_root / "prompt.txt"
     result_path = runtime_root / "engine-result.json"
@@ -6313,6 +6348,7 @@ def run_default_review_engine(
                     "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
+            "engine_metadata": selection_metadata,
         }
 
     scratch_dir.mkdir(parents=True, exist_ok=True)
@@ -6403,6 +6439,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
@@ -6424,6 +6461,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     if raw_payload is not None and not result_path.exists():
@@ -6440,6 +6478,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
@@ -6462,6 +6501,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     write_json_file(findings_path, {"findings": normalized_payload["findings"]})
@@ -6471,6 +6511,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
@@ -6494,6 +6535,13 @@ def run_default_review_engine(
             "failure_reason": None,
             "reviewed_head": reviewed_head,
             "evidence": engine_evidence,
+        },
+        "engine_metadata": {
+            **selection_metadata,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "raw_result": relative_to_root(result_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "metadata": relative_to_root(metadata_path, context["target_root"]),
         },
         "review_record_input": {
             "decision": normalized_payload["decision"],
@@ -7254,6 +7302,312 @@ def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: st
     return normalized, []
 
 
+def codex_app_endpoint_socket_path(app_server: str | None) -> Path | None:
+    endpoint = non_empty_str(app_server)
+    if endpoint is None:
+        return None
+    if endpoint.startswith("unix://"):
+        path_text = endpoint.removeprefix("unix://")
+    elif endpoint.startswith("/"):
+        path_text = endpoint
+    else:
+        return None
+    if not path_text:
+        return None
+    return Path(path_text).expanduser()
+
+
+def codex_app_endpoint_is_live_capable(app_server: str | None) -> bool:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    return socket_path is not None and socket_path.exists()
+
+
+def codex_app_review_bindings_from_args_env(args: argparse.Namespace) -> dict[str, str | None]:
+    app_server = non_empty_str(args.codex_app_review_app_server) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_ENDPOINT_ENV))
+    thread_id = (
+        non_empty_str(args.codex_app_review_thread_id)
+        or non_empty_str(os.environ.get(CODEX_APP_REVIEW_THREAD_ID_ENV))
+        or (non_empty_str(os.environ.get(CODEX_THREAD_ID_ENV)) if app_server else None)
+    )
+    thread_cwd = non_empty_str(args.codex_app_review_cwd) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_CWD_ENV))
+    raw_file = non_empty_str(args.codex_app_review_raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": thread_cwd,
+        "raw_file": raw_file,
+    }
+
+
+def codex_app_binding_summary(
+    target_root: Path,
+    *,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    reviewed_head: str,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    cwd_match: bool | None = None
+    cwd_summary: str | None = thread_cwd
+    if non_empty_str(thread_cwd):
+        try:
+            cwd_path = Path(str(thread_cwd)).expanduser().resolve()
+        except OSError:
+            cwd_match = False
+        else:
+            cwd_match = cwd_path == target_root
+            cwd_summary = str(cwd_path)
+    raw_source: str | None = None
+    if non_empty_str(raw_file):
+        raw_path, raw_errors = resolve_repo_relative_path(target_root, str(raw_file), label="Codex App authoritative review raw file")
+        if raw_path is not None and not raw_errors:
+            raw_source = relative_to_root(raw_path, target_root)
+        else:
+            raw_source = str(raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_summary,
+        "thread_cwd_matches_target_root": cwd_match,
+        "target_root": str(target_root),
+        "reviewed_head": reviewed_head,
+        "raw_source": raw_source,
+        "live_endpoint_capable": codex_app_endpoint_is_live_capable(app_server),
+    }
+
+
+def select_review_adapter(
+    args: argparse.Namespace,
+    target_root: Path,
+    *,
+    reviewed_head: str,
+) -> dict[str, Any]:
+    bindings = codex_app_review_bindings_from_args_env(args)
+    explicit_adapter = non_empty_str(args.engine_adapter)
+    if explicit_adapter:
+        return {
+            "adapter": explicit_adapter,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    if truthy_env("CI") or truthy_env("CODEX_CI"):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "headless-fallback",
+            "fallback_reason": "ci-or-codex-ci",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    app_server = bindings["app_server"]
+    thread_id = bindings["thread_id"]
+    thread_cwd = bindings["thread_cwd"]
+    raw_file = bindings["raw_file"]
+    if not app_server or not thread_id or not thread_cwd:
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "missing-codex-app-host-proof",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    if not raw_file and not codex_app_endpoint_is_live_capable(app_server):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "app-server-unavailable",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    return {
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "selection_source": "codex-app-host-default",
+        "fallback_reason": None,
+        **bindings,
+        "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+    }
+
+
+def review_adapter_selection_metadata(selection: dict[str, Any], *, reviewed_head: str) -> dict[str, Any]:
+    return {
+        "selected_adapter": selection["adapter"],
+        "selection_source": selection.get("selection_source"),
+        "fallback_reason": selection.get("fallback_reason"),
+        "app_server": selection.get("app_server"),
+        "thread_id": selection.get("thread_id"),
+        "thread_cwd": selection.get("thread_cwd"),
+        "target_root": selection.get("binding_summary", {}).get("target_root")
+        if isinstance(selection.get("binding_summary"), dict)
+        else None,
+        "reviewed_head": reviewed_head,
+        "thread_target_binding": selection.get("binding_summary"),
+    }
+
+
+def jsonrpc_send_request(stdin: Any, *, request_id: int, method: str, params: dict[str, Any]) -> None:
+    stdin.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}) + "\n")
+    stdin.flush()
+
+
+def jsonrpc_read_response(stdout: Any, *, request_id: int) -> tuple[dict[str, Any] | None, list[dict[str, Any]], list[str]]:
+    notifications: list[dict[str, Any]] = []
+    while True:
+        line = stdout.readline()
+        if not line:
+            return None, notifications, [f"app-server closed before response id {request_id}"]
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("id") == request_id:
+            return payload, notifications, []
+        notifications.append(payload)
+
+
+def find_exited_review_text(payload: Any) -> str | None:
+    if isinstance(payload, dict):
+        if payload.get("type") == "exitedReviewMode" and isinstance(payload.get("review"), str):
+            return payload["review"]
+        for value in payload.values():
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    return None
+
+
+def find_normalized_review_payload(payload: Any) -> dict[str, Any] | None:
+    normalized, errors = normalize_engine_review_result(payload, relative="app-server turn/start output")
+    if normalized is not None and not errors:
+        return normalized
+    if isinstance(payload, dict):
+        for value in payload.values():
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    return None
+
+
+def app_server_proxy_command(app_server: str) -> list[str] | None:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    if socket_path is None:
+        return None
+    return ["codex", "app-server", "proxy", "--sock", str(socket_path)]
+
+
+def run_codex_app_live_review(
+    *,
+    app_server: str,
+    thread_id: str,
+    reviewed_head: str,
+    thread_cwd: str,
+    prompt_text: str,
+) -> tuple[str | None, dict[str, Any], list[str]]:
+    command = app_server_proxy_command(app_server)
+    if command is None:
+        return None, {}, [f"unsupported Codex App review endpoint: {app_server}"]
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return None, {}, [f"Codex App review endpoint is unavailable: {exc}"]
+    assert process.stdin is not None
+    assert process.stdout is not None
+    metadata: dict[str, Any] = {"review_target": {"type": "commit", "sha": reviewed_head}}
+    try:
+        jsonrpc_send_request(process.stdin, request_id=1, method="initialize", params={"clientInfo": {"name": "loom", "version": "stage3"}, "capabilities": {}})
+        initialize_response, _, initialize_errors = jsonrpc_read_response(process.stdout, request_id=1)
+        if initialize_errors:
+            return None, metadata, initialize_errors
+        if isinstance(initialize_response, dict) and isinstance(initialize_response.get("error"), dict):
+            return None, metadata, [f"Codex App initialize failed: {initialize_response['error']}"]
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=2,
+            method="review/start",
+            params={
+                "threadId": thread_id,
+                "delivery": "inline",
+                "target": {"type": "commit", "sha": reviewed_head},
+            },
+        )
+        review_response, review_notifications, review_errors = jsonrpc_read_response(process.stdout, request_id=2)
+        if review_errors:
+            return None, metadata, review_errors
+        if isinstance(review_response, dict) and isinstance(review_response.get("error"), dict):
+            return None, metadata, [f"Codex App review/start failed: {review_response['error']}"]
+        result = review_response.get("result") if isinstance(review_response, dict) else None
+        if isinstance(result, dict):
+            metadata["review_thread_id"] = result.get("reviewThreadId")
+        review_text = find_exited_review_text(result) or find_exited_review_text(review_notifications)
+        if not isinstance(review_text, str) or not review_text.strip():
+            return None, metadata, ["Codex App review/start did not return exitedReviewMode.review"]
+
+        parsed_review, parsed_errors = normalize_authoritative_codex_app_review_text(review_text, relative="app-server review/start output")
+        if parsed_review is not None and not parsed_errors:
+            metadata["normalization_source"] = "review-start-json"
+            return review_text, {**metadata, "normalized": parsed_review}, []
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=3,
+            method="turn/start",
+            params={
+                "threadId": metadata.get("review_thread_id") or thread_id,
+                "cwd": thread_cwd,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Normalize this Codex App review output into the provided JSON schema. "
+                            "Return only the structured review result.\n\n"
+                            f"{review_text}"
+                        ),
+                    }
+                ],
+                "outputSchema": load_json_file(review_engine_schema_path()),
+            },
+        )
+        turn_response, turn_notifications, turn_errors = jsonrpc_read_response(process.stdout, request_id=3)
+        if turn_errors:
+            return review_text, metadata, turn_errors
+        if isinstance(turn_response, dict) and isinstance(turn_response.get("error"), dict):
+            return review_text, metadata, [f"Codex App turn/start normalization failed: {turn_response['error']}"]
+        normalized = find_normalized_review_payload(turn_response.get("result") if isinstance(turn_response, dict) else None)
+        if normalized is None:
+            normalized = find_normalized_review_payload(turn_notifications)
+        if normalized is None:
+            return review_text, metadata, ["Codex App turn/start did not return a Loom review result"]
+        metadata["normalization_source"] = "turn-start-output-schema"
+        return review_text, {**metadata, "normalized": normalized}, []
+    finally:
+        try:
+            process.terminate()
+        except OSError:
+            pass
+
+
 def shadow_adapter_slug(adapter: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
 
@@ -7453,8 +7807,30 @@ def run_codex_app_review_authoritative_adapter(
     thread_id: str | None,
     thread_cwd: str | None,
     raw_file: str | None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            "app_server": app_server,
+            "thread_id": thread_id,
+            "thread_cwd": thread_cwd,
+            "raw_file": raw_file,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=app_server,
+                thread_id=thread_id,
+                thread_cwd=thread_cwd,
+                reviewed_head=reviewed_head,
+                raw_file=raw_file,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     raw_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
@@ -7488,7 +7864,6 @@ def run_codex_app_review_authoritative_adapter(
         ("--codex-app-review-app-server", app_server),
         ("--codex-app-review-thread-id", thread_id),
         ("--codex-app-review-cwd", thread_cwd),
-        ("--codex-app-review-raw-file", raw_file),
     ):
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(label)
@@ -7518,6 +7893,8 @@ def run_codex_app_review_authoritative_adapter(
         missing_inputs.extend(source_errors)
         if source_path is not None:
             source_relative = relative_to_root(source_path, context["target_root"])
+    elif not codex_app_endpoint_is_live_capable(app_server):
+        missing_inputs.append("--codex-app-review-raw-file or live app-server endpoint")
 
     if missing_inputs:
         write_json_file(
@@ -7527,6 +7904,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "runtime_conflict",
@@ -7553,6 +7931,7 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative or thread_cwd,
@@ -7560,17 +7939,30 @@ def run_codex_app_review_authoritative_adapter(
             },
         }
 
-    try:
-        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
-    except OSError as exc:
-        raw_text = ""
-        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
-        normalized = None
+    live_metadata: dict[str, Any] = {}
+    if source_path is not None:
+        try:
+            raw_text = source_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raw_text = ""
+            normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+            normalized = None
+        else:
+            normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+                raw_text,
+                relative=source_relative or str(raw_file),
+            )
     else:
-        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
-            raw_text,
-            relative=source_relative or str(raw_file),
+        raw_text, live_metadata, normalization_errors = run_codex_app_live_review(
+            app_server=str(app_server),
+            thread_id=str(thread_id),
+            reviewed_head=reviewed_head,
+            thread_cwd=str(thread_cwd),
+            prompt_text=instructions_path.read_text(encoding="utf-8"),
         )
+        normalized = live_metadata.get("normalized") if isinstance(live_metadata.get("normalized"), dict) else None
+        if raw_text is None:
+            raw_text = ""
 
     if normalization_errors or normalized is None:
         if raw_text:
@@ -7582,6 +7974,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "schema_drift",
@@ -7592,6 +7985,7 @@ def run_codex_app_review_authoritative_adapter(
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         )
         return {
@@ -7609,10 +8003,12 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         }
 
@@ -7623,6 +8019,7 @@ def run_codex_app_review_authoritative_adapter(
         "engine": CODEX_APP_REVIEW_ENGINE,
         "adapter": CODEX_APP_REVIEW_ADAPTER,
         "profile": engine_profile,
+        **selection_metadata,
         "context_pack": relative_to_root(context_pack_path, context["target_root"]),
         "result": "pass",
         "reviewed_head": reviewed_head,
@@ -7634,6 +8031,11 @@ def run_codex_app_review_authoritative_adapter(
         "thread_id": thread_id,
         "thread_cwd": cwd_relative,
         "raw_source": source_relative,
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "review_thread_id": live_metadata.get("review_thread_id") if live_metadata else (thread_id if source_path is not None else None),
+        **({"live_review": {key: value for key, value in live_metadata.items() if key != "normalized"}} if live_metadata else {}),
         "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
     }
     write_json_file(metadata_path, metadata)
@@ -12452,7 +12854,9 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
-        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
+        current_head = git_head_sha(target_root) or "unknown-head"
+        adapter_selection = select_review_adapter(args, target_root, reviewed_head=current_head)
+        requested_engine_adapter = str(adapter_selection["adapter"])
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
@@ -12484,9 +12888,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12524,9 +12929,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12539,10 +12945,11 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
-                app_server=args.codex_app_review_app_server,
-                thread_id=args.codex_app_review_thread_id,
-                thread_cwd=args.codex_app_review_cwd,
-                raw_file=args.codex_app_review_raw_file,
+                app_server=adapter_selection.get("app_server") if isinstance(adapter_selection.get("app_server"), str) else None,
+                thread_id=adapter_selection.get("thread_id") if isinstance(adapter_selection.get("thread_id"), str) else None,
+                thread_cwd=adapter_selection.get("thread_cwd") if isinstance(adapter_selection.get("thread_cwd"), str) else None,
+                raw_file=adapter_selection.get("raw_file") if isinstance(adapter_selection.get("raw_file"), str) else None,
+                adapter_selection=adapter_selection,
             )
         else:
             engine_payload = run_default_review_engine(
@@ -12551,6 +12958,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
+                adapter_selection=adapter_selection,
             )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,

--- a/skills/shared/references/harness/review-execution.md
+++ b/skills/shared/references/harness/review-execution.md
@@ -21,7 +21,7 @@ Loom 把 review 分成四层：
 1. `flow review`
    - 只读基线；确认是否具备进入 formal review 的条件
 2. `review run`
-   - 调用默认 Codex-backed reviewer，产出结构化 review evidence 与 Loom-normalized findings
+   - 按宿主 proof 选择 authoritative adapter，产出结构化 review evidence 与 Loom-normalized findings
 3. `review record`
    - 把 formal review 结论写入单一 authored review record
 
@@ -47,27 +47,33 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责选择安全的 authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
+默认 engine 按宿主 proof 选择：
+
+- 已验证 Codex App host context 默认选择 `loom/codex-app-review`，不启动嵌套 `codex exec`
+- `CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex`，能力来源仍是 `codex exec --output-schema`
+- 显式 `--engine-adapter` 优先级最高，继续保留 Stage 2 authoritative opt-in / fallback 调试入口
+
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-Codex App review adapter 有两种显式入口，默认均不启用：
+Codex App review adapter 有三种入口：
 
-- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
-- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- verified host default：不传 `--engine-adapter`，但必须能证明 app-server/session locator、thread id、thread cwd、target root 与 reviewed head 绑定一致
+- explicit authoritative：显式选择 `review run --engine-adapter loom/codex-app-review`，用于调试或非默认宿主
+- shadow comparison：显式选择 `review run --shadow-engine-adapter loom/codex-app-review`
 - shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
-- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
-- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
-- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof；live app-server unavailable 时默认 fallback 到 `loom/default-codex`
+- thread cwd proof 必须等于 target root；cwd / target / reviewed head 绑定冲突或 schema proof 失败时必须 fail closed
 - authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
 - authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
+- `engine_metadata` 必须记录 selected adapter、selection source、fallback reason、thread/target binding summary、reviewed head 与 evidence locators
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
@@ -77,8 +83,8 @@ Codex App review adapter 有两种显式入口，默认均不启用：
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
-- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
+- `adapter`: `loom/default-codex` 或 verified/explicit `loom/codex-app-review`
+- `engine`: `codex` 或 verified/explicit `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -3126,6 +3126,19 @@ def require_review_run_payload(
                 for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
                     if not isinstance(evidence.get(key), str) or not evidence.get(key):
                         failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
+    engine_metadata = payload.get("engine_metadata")
+    if engine_adapter == "loom/codex-app-review" and engine.get("result") == "pass":
+        if not isinstance(engine_metadata, dict):
+            failures.append(Failure(category, f"{context} app review pass must expose `engine_metadata`"))
+        else:
+            for key in ("selected_adapter", "selection_source", "app_server", "thread_id", "thread_cwd", "raw_result", "normalized_findings", "context_pack", "reviewed_head"):
+                value = engine_metadata.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} app review metadata must include non-empty `{key}`"))
+            if engine_metadata.get("selected_adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} app review metadata must bind the selected adapter"))
+            if "normalized review_record_input only" not in str(engine_metadata.get("authority_boundary", "")):
+                failures.append(Failure(category, f"{context} app review metadata must keep raw App output outside merge-ready truth"))
 
 
 def require_runtime_state_payload(
@@ -5725,7 +5738,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
 
         prepare_review_target(review_target, "review run positive chain")
         write_fake_codex(fake_bin / "codex", mode="success")
-        success_env = prepend_path_env(fake_bin)
+        success_env = prepend_path_env(fake_bin, {"CI": "", "CODEX_CI": ""})
 
         payload, error = load_command_json(
             root,
@@ -5893,6 +5906,217 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_default_target = Path(tmp) / "review-run-codex-app-default"
+        prepare_review_target(app_default_target, "review run Codex App host default")
+        app_default_raw = app_default_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_default_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_default_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App default reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-default-warn-1",
+                            "summary": "Codex App default review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_default_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-default-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-default-proof",
+                "--codex-app-review-cwd",
+                str(app_default_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App host default failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App host default",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("adapter") != "loom/codex-app-review" or engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must select the app adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review" or review_record_input.get("reviewer") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must author app adapter review_record_input"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("selection_source") != "codex-app-host-default" or metadata.get("thread_id") != "thread-stage3-default-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must expose selected adapter and thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_default_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored default app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume default Codex App raw evidence before review record is authored"))
+
+        app_ci_fallback_target = Path(tmp) / "review-run-codex-app-ci-fallback"
+        prepare_review_target(app_ci_fallback_target, "review run Codex App CI fallback")
+        app_ci_raw = app_ci_fallback_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_ci_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_ci_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_ci_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-ci-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-ci-proof",
+                "--codex-app-review-cwd",
+                str(app_ci_fallback_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=prepend_path_env(fake_bin, {"CODEX_CI": "1"}),
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App CI fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App CI fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "ci-or-codex-ci":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App CI fallback must keep the default codex exec adapter"))
+
+        app_unavailable_fallback_target = Path(tmp) / "review-run-codex-app-unavailable-fallback"
+        prepare_review_target(app_unavailable_fallback_target, "review run Codex App unavailable fallback")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_unavailable_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                f"unix://{tmp}/missing-codex-app.sock",
+                "--codex-app-review-thread-id",
+                "thread-stage3-missing-endpoint",
+                "--codex-app-review-cwd",
+                str(app_unavailable_fallback_target),
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App unavailable fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App unavailable fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "app-server-unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App unavailable fallback must record default adapter fallback"))
+
+        app_conflict_target = Path(tmp) / "review-run-codex-app-proof-conflict"
+        prepare_review_target(app_conflict_target, "review run Codex App proof conflict")
+        app_conflict_raw = app_conflict_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_conflict_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_conflict_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_conflict_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-conflict-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-conflict-proof",
+                "--codex-app-review-cwd",
+                str(Path(tmp) / "different-cwd"),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App proof conflict failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must fail closed"))
+        else:
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            if engine.get("adapter") != "loom/codex-app-review" or engine.get("failure_reason") != "runtime_conflict":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not fallback to default codex"))
+            if "does not match target root" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must expose cwd mismatch"))
+            if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not emit review_record_input"))
 
         app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
         prepare_review_target(app_authoritative_target, "review run Codex App authoritative")

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -118,6 +118,10 @@ CODEX_APP_REVIEW_ENGINE = "codex-app-review"
 CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
 AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
+CODEX_APP_REVIEW_ENDPOINT_ENV = "LOOM_CODEX_APP_REVIEW_ENDPOINT"
+CODEX_APP_REVIEW_THREAD_ID_ENV = "LOOM_CODEX_APP_REVIEW_THREAD_ID"
+CODEX_APP_REVIEW_CWD_ENV = "LOOM_CODEX_APP_REVIEW_CWD"
+CODEX_THREAD_ID_ENV = "CODEX_THREAD_ID"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS: int | None = None
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -492,26 +496,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
         help=(
             "Optional authoritative review engine adapter for review run/record. "
-            "Default review run remains loom/default-codex."
+            "When omitted, verified Codex App sessions use loom/codex-app-review; headless/CI fallback remains loom/default-codex."
         ),
     )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
     review.add_argument(
         "--codex-app-review-app-server",
-        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App app-server/session locator. Defaults to ${CODEX_APP_REVIEW_ENDPOINT_ENV} when available.",
     )
     review.add_argument(
         "--codex-app-review-thread-id",
-        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread id. Defaults to ${CODEX_APP_REVIEW_THREAD_ID_ENV}, or ${CODEX_THREAD_ID_ENV} when an endpoint is present.",
     )
     review.add_argument(
         "--codex-app-review-cwd",
-        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread cwd proof. Defaults to ${CODEX_APP_REVIEW_CWD_ENV}.",
     )
     review.add_argument(
         "--codex-app-review-raw-file",
-        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+        help="Optional repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
     )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
@@ -4250,6 +4254,19 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def truthy_env(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def non_empty_str(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def execution_attempt_directory(target_root: Path, item_id: str) -> Path:
     return target_root / ".loom/runtime/attempts" / item_id
 
@@ -6264,8 +6281,26 @@ def run_default_review_engine(
     engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "explicit-or-legacy-default",
+            "fallback_reason": None,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=None,
+                thread_id=None,
+                thread_cwd=None,
+                reviewed_head=reviewed_head,
+                raw_file=None,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     prompt_path = runtime_root / "prompt.txt"
     result_path = runtime_root / "engine-result.json"
@@ -6313,6 +6348,7 @@ def run_default_review_engine(
                     "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
+            "engine_metadata": selection_metadata,
         }
 
     scratch_dir.mkdir(parents=True, exist_ok=True)
@@ -6403,6 +6439,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
@@ -6424,6 +6461,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     if raw_payload is not None and not result_path.exists():
@@ -6440,6 +6478,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
@@ -6462,6 +6501,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     write_json_file(findings_path, {"findings": normalized_payload["findings"]})
@@ -6471,6 +6511,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
@@ -6494,6 +6535,13 @@ def run_default_review_engine(
             "failure_reason": None,
             "reviewed_head": reviewed_head,
             "evidence": engine_evidence,
+        },
+        "engine_metadata": {
+            **selection_metadata,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "raw_result": relative_to_root(result_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "metadata": relative_to_root(metadata_path, context["target_root"]),
         },
         "review_record_input": {
             "decision": normalized_payload["decision"],
@@ -7254,6 +7302,312 @@ def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: st
     return normalized, []
 
 
+def codex_app_endpoint_socket_path(app_server: str | None) -> Path | None:
+    endpoint = non_empty_str(app_server)
+    if endpoint is None:
+        return None
+    if endpoint.startswith("unix://"):
+        path_text = endpoint.removeprefix("unix://")
+    elif endpoint.startswith("/"):
+        path_text = endpoint
+    else:
+        return None
+    if not path_text:
+        return None
+    return Path(path_text).expanduser()
+
+
+def codex_app_endpoint_is_live_capable(app_server: str | None) -> bool:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    return socket_path is not None and socket_path.exists()
+
+
+def codex_app_review_bindings_from_args_env(args: argparse.Namespace) -> dict[str, str | None]:
+    app_server = non_empty_str(args.codex_app_review_app_server) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_ENDPOINT_ENV))
+    thread_id = (
+        non_empty_str(args.codex_app_review_thread_id)
+        or non_empty_str(os.environ.get(CODEX_APP_REVIEW_THREAD_ID_ENV))
+        or (non_empty_str(os.environ.get(CODEX_THREAD_ID_ENV)) if app_server else None)
+    )
+    thread_cwd = non_empty_str(args.codex_app_review_cwd) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_CWD_ENV))
+    raw_file = non_empty_str(args.codex_app_review_raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": thread_cwd,
+        "raw_file": raw_file,
+    }
+
+
+def codex_app_binding_summary(
+    target_root: Path,
+    *,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    reviewed_head: str,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    cwd_match: bool | None = None
+    cwd_summary: str | None = thread_cwd
+    if non_empty_str(thread_cwd):
+        try:
+            cwd_path = Path(str(thread_cwd)).expanduser().resolve()
+        except OSError:
+            cwd_match = False
+        else:
+            cwd_match = cwd_path == target_root
+            cwd_summary = str(cwd_path)
+    raw_source: str | None = None
+    if non_empty_str(raw_file):
+        raw_path, raw_errors = resolve_repo_relative_path(target_root, str(raw_file), label="Codex App authoritative review raw file")
+        if raw_path is not None and not raw_errors:
+            raw_source = relative_to_root(raw_path, target_root)
+        else:
+            raw_source = str(raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_summary,
+        "thread_cwd_matches_target_root": cwd_match,
+        "target_root": str(target_root),
+        "reviewed_head": reviewed_head,
+        "raw_source": raw_source,
+        "live_endpoint_capable": codex_app_endpoint_is_live_capable(app_server),
+    }
+
+
+def select_review_adapter(
+    args: argparse.Namespace,
+    target_root: Path,
+    *,
+    reviewed_head: str,
+) -> dict[str, Any]:
+    bindings = codex_app_review_bindings_from_args_env(args)
+    explicit_adapter = non_empty_str(args.engine_adapter)
+    if explicit_adapter:
+        return {
+            "adapter": explicit_adapter,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    if truthy_env("CI") or truthy_env("CODEX_CI"):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "headless-fallback",
+            "fallback_reason": "ci-or-codex-ci",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    app_server = bindings["app_server"]
+    thread_id = bindings["thread_id"]
+    thread_cwd = bindings["thread_cwd"]
+    raw_file = bindings["raw_file"]
+    if not app_server or not thread_id or not thread_cwd:
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "missing-codex-app-host-proof",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    if not raw_file and not codex_app_endpoint_is_live_capable(app_server):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "app-server-unavailable",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    return {
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "selection_source": "codex-app-host-default",
+        "fallback_reason": None,
+        **bindings,
+        "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+    }
+
+
+def review_adapter_selection_metadata(selection: dict[str, Any], *, reviewed_head: str) -> dict[str, Any]:
+    return {
+        "selected_adapter": selection["adapter"],
+        "selection_source": selection.get("selection_source"),
+        "fallback_reason": selection.get("fallback_reason"),
+        "app_server": selection.get("app_server"),
+        "thread_id": selection.get("thread_id"),
+        "thread_cwd": selection.get("thread_cwd"),
+        "target_root": selection.get("binding_summary", {}).get("target_root")
+        if isinstance(selection.get("binding_summary"), dict)
+        else None,
+        "reviewed_head": reviewed_head,
+        "thread_target_binding": selection.get("binding_summary"),
+    }
+
+
+def jsonrpc_send_request(stdin: Any, *, request_id: int, method: str, params: dict[str, Any]) -> None:
+    stdin.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}) + "\n")
+    stdin.flush()
+
+
+def jsonrpc_read_response(stdout: Any, *, request_id: int) -> tuple[dict[str, Any] | None, list[dict[str, Any]], list[str]]:
+    notifications: list[dict[str, Any]] = []
+    while True:
+        line = stdout.readline()
+        if not line:
+            return None, notifications, [f"app-server closed before response id {request_id}"]
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("id") == request_id:
+            return payload, notifications, []
+        notifications.append(payload)
+
+
+def find_exited_review_text(payload: Any) -> str | None:
+    if isinstance(payload, dict):
+        if payload.get("type") == "exitedReviewMode" and isinstance(payload.get("review"), str):
+            return payload["review"]
+        for value in payload.values():
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    return None
+
+
+def find_normalized_review_payload(payload: Any) -> dict[str, Any] | None:
+    normalized, errors = normalize_engine_review_result(payload, relative="app-server turn/start output")
+    if normalized is not None and not errors:
+        return normalized
+    if isinstance(payload, dict):
+        for value in payload.values():
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    return None
+
+
+def app_server_proxy_command(app_server: str) -> list[str] | None:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    if socket_path is None:
+        return None
+    return ["codex", "app-server", "proxy", "--sock", str(socket_path)]
+
+
+def run_codex_app_live_review(
+    *,
+    app_server: str,
+    thread_id: str,
+    reviewed_head: str,
+    thread_cwd: str,
+    prompt_text: str,
+) -> tuple[str | None, dict[str, Any], list[str]]:
+    command = app_server_proxy_command(app_server)
+    if command is None:
+        return None, {}, [f"unsupported Codex App review endpoint: {app_server}"]
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return None, {}, [f"Codex App review endpoint is unavailable: {exc}"]
+    assert process.stdin is not None
+    assert process.stdout is not None
+    metadata: dict[str, Any] = {"review_target": {"type": "commit", "sha": reviewed_head}}
+    try:
+        jsonrpc_send_request(process.stdin, request_id=1, method="initialize", params={"clientInfo": {"name": "loom", "version": "stage3"}, "capabilities": {}})
+        initialize_response, _, initialize_errors = jsonrpc_read_response(process.stdout, request_id=1)
+        if initialize_errors:
+            return None, metadata, initialize_errors
+        if isinstance(initialize_response, dict) and isinstance(initialize_response.get("error"), dict):
+            return None, metadata, [f"Codex App initialize failed: {initialize_response['error']}"]
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=2,
+            method="review/start",
+            params={
+                "threadId": thread_id,
+                "delivery": "inline",
+                "target": {"type": "commit", "sha": reviewed_head},
+            },
+        )
+        review_response, review_notifications, review_errors = jsonrpc_read_response(process.stdout, request_id=2)
+        if review_errors:
+            return None, metadata, review_errors
+        if isinstance(review_response, dict) and isinstance(review_response.get("error"), dict):
+            return None, metadata, [f"Codex App review/start failed: {review_response['error']}"]
+        result = review_response.get("result") if isinstance(review_response, dict) else None
+        if isinstance(result, dict):
+            metadata["review_thread_id"] = result.get("reviewThreadId")
+        review_text = find_exited_review_text(result) or find_exited_review_text(review_notifications)
+        if not isinstance(review_text, str) or not review_text.strip():
+            return None, metadata, ["Codex App review/start did not return exitedReviewMode.review"]
+
+        parsed_review, parsed_errors = normalize_authoritative_codex_app_review_text(review_text, relative="app-server review/start output")
+        if parsed_review is not None and not parsed_errors:
+            metadata["normalization_source"] = "review-start-json"
+            return review_text, {**metadata, "normalized": parsed_review}, []
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=3,
+            method="turn/start",
+            params={
+                "threadId": metadata.get("review_thread_id") or thread_id,
+                "cwd": thread_cwd,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Normalize this Codex App review output into the provided JSON schema. "
+                            "Return only the structured review result.\n\n"
+                            f"{review_text}"
+                        ),
+                    }
+                ],
+                "outputSchema": load_json_file(review_engine_schema_path()),
+            },
+        )
+        turn_response, turn_notifications, turn_errors = jsonrpc_read_response(process.stdout, request_id=3)
+        if turn_errors:
+            return review_text, metadata, turn_errors
+        if isinstance(turn_response, dict) and isinstance(turn_response.get("error"), dict):
+            return review_text, metadata, [f"Codex App turn/start normalization failed: {turn_response['error']}"]
+        normalized = find_normalized_review_payload(turn_response.get("result") if isinstance(turn_response, dict) else None)
+        if normalized is None:
+            normalized = find_normalized_review_payload(turn_notifications)
+        if normalized is None:
+            return review_text, metadata, ["Codex App turn/start did not return a Loom review result"]
+        metadata["normalization_source"] = "turn-start-output-schema"
+        return review_text, {**metadata, "normalized": normalized}, []
+    finally:
+        try:
+            process.terminate()
+        except OSError:
+            pass
+
+
 def shadow_adapter_slug(adapter: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
 
@@ -7453,8 +7807,30 @@ def run_codex_app_review_authoritative_adapter(
     thread_id: str | None,
     thread_cwd: str | None,
     raw_file: str | None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            "app_server": app_server,
+            "thread_id": thread_id,
+            "thread_cwd": thread_cwd,
+            "raw_file": raw_file,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=app_server,
+                thread_id=thread_id,
+                thread_cwd=thread_cwd,
+                reviewed_head=reviewed_head,
+                raw_file=raw_file,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     raw_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
@@ -7488,7 +7864,6 @@ def run_codex_app_review_authoritative_adapter(
         ("--codex-app-review-app-server", app_server),
         ("--codex-app-review-thread-id", thread_id),
         ("--codex-app-review-cwd", thread_cwd),
-        ("--codex-app-review-raw-file", raw_file),
     ):
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(label)
@@ -7518,6 +7893,8 @@ def run_codex_app_review_authoritative_adapter(
         missing_inputs.extend(source_errors)
         if source_path is not None:
             source_relative = relative_to_root(source_path, context["target_root"])
+    elif not codex_app_endpoint_is_live_capable(app_server):
+        missing_inputs.append("--codex-app-review-raw-file or live app-server endpoint")
 
     if missing_inputs:
         write_json_file(
@@ -7527,6 +7904,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "runtime_conflict",
@@ -7553,6 +7931,7 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative or thread_cwd,
@@ -7560,17 +7939,30 @@ def run_codex_app_review_authoritative_adapter(
             },
         }
 
-    try:
-        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
-    except OSError as exc:
-        raw_text = ""
-        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
-        normalized = None
+    live_metadata: dict[str, Any] = {}
+    if source_path is not None:
+        try:
+            raw_text = source_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raw_text = ""
+            normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+            normalized = None
+        else:
+            normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+                raw_text,
+                relative=source_relative or str(raw_file),
+            )
     else:
-        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
-            raw_text,
-            relative=source_relative or str(raw_file),
+        raw_text, live_metadata, normalization_errors = run_codex_app_live_review(
+            app_server=str(app_server),
+            thread_id=str(thread_id),
+            reviewed_head=reviewed_head,
+            thread_cwd=str(thread_cwd),
+            prompt_text=instructions_path.read_text(encoding="utf-8"),
         )
+        normalized = live_metadata.get("normalized") if isinstance(live_metadata.get("normalized"), dict) else None
+        if raw_text is None:
+            raw_text = ""
 
     if normalization_errors or normalized is None:
         if raw_text:
@@ -7582,6 +7974,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "schema_drift",
@@ -7592,6 +7985,7 @@ def run_codex_app_review_authoritative_adapter(
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         )
         return {
@@ -7609,10 +8003,12 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         }
 
@@ -7623,6 +8019,7 @@ def run_codex_app_review_authoritative_adapter(
         "engine": CODEX_APP_REVIEW_ENGINE,
         "adapter": CODEX_APP_REVIEW_ADAPTER,
         "profile": engine_profile,
+        **selection_metadata,
         "context_pack": relative_to_root(context_pack_path, context["target_root"]),
         "result": "pass",
         "reviewed_head": reviewed_head,
@@ -7634,6 +8031,11 @@ def run_codex_app_review_authoritative_adapter(
         "thread_id": thread_id,
         "thread_cwd": cwd_relative,
         "raw_source": source_relative,
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "review_thread_id": live_metadata.get("review_thread_id") if live_metadata else (thread_id if source_path is not None else None),
+        **({"live_review": {key: value for key, value in live_metadata.items() if key != "normalized"}} if live_metadata else {}),
         "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
     }
     write_json_file(metadata_path, metadata)
@@ -12452,7 +12854,9 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
-        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
+        current_head = git_head_sha(target_root) or "unknown-head"
+        adapter_selection = select_review_adapter(args, target_root, reviewed_head=current_head)
+        requested_engine_adapter = str(adapter_selection["adapter"])
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
@@ -12484,9 +12888,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12524,9 +12929,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12539,10 +12945,11 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
-                app_server=args.codex_app_review_app_server,
-                thread_id=args.codex_app_review_thread_id,
-                thread_cwd=args.codex_app_review_cwd,
-                raw_file=args.codex_app_review_raw_file,
+                app_server=adapter_selection.get("app_server") if isinstance(adapter_selection.get("app_server"), str) else None,
+                thread_id=adapter_selection.get("thread_id") if isinstance(adapter_selection.get("thread_id"), str) else None,
+                thread_cwd=adapter_selection.get("thread_cwd") if isinstance(adapter_selection.get("thread_cwd"), str) else None,
+                raw_file=adapter_selection.get("raw_file") if isinstance(adapter_selection.get("raw_file"), str) else None,
+                adapter_selection=adapter_selection,
             )
         else:
             engine_payload = run_default_review_engine(
@@ -12551,6 +12958,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
+                adapter_selection=adapter_selection,
             )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,

--- a/src/skills/loom-review/SKILL.md
+++ b/src/skills/loom-review/SKILL.md
@@ -42,9 +42,9 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
-这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 触发默认 Codex reviewer 或显式 opt-in authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
+这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review run` 选择安全的 authoritative adapter 并生成 Loom-normalized findings，最后用 `review record` 把审查结论写成可消费载体。
 
-默认 `review run` 必须保持 `loom/default-codex` + `codex exec --output-schema`。只有明确传入 `--engine-adapter loom/codex-app-review`，并同时提供 app-server/session locator、thread id、cwd proof 和 normalized raw review output 时，Codex App review 才能作为 authoritative adapter 进入；缺任一 proof 或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
+已验证 Codex App host context 中，默认 `review run` 使用 `loom/codex-app-review`，并必须证明 app-server/session locator、thread id、cwd proof、target root 与 reviewed head 绑定一致；该路径不得启动嵌套 `codex exec`。`CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex` + `codex exec --output-schema`。proof 冲突、cwd / target / head 不匹配或 schema normalization 失败时必须 fail closed 并回到 manual review 写同一 review record。
 
 安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
@@ -54,7 +54,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 1. 运行 `flow review`，确认当前事项是否具备进入正式审查的最小条件
 2. 若 `flow review` 非 `pass`，直接返回 `block` 或 `fallback`，不伪造审查结论
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 执行 formal review，并把 raw output 收敛为 Loom evidence 与 normalized findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，并把 raw output 收敛为 Loom evidence 与 normalized findings
 4. 若 `review run` fail-closed，显式回到 manual review 写回同一 `review record`
 5. 用 `review record` 写入正式 review 结论，让 `merge gate` 可机械消费
 
@@ -75,7 +75,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - review 机械基线结果
 - build gate 是否允许进入正式审查
 - review artifact 的定位与已记录结论
-- 默认 engine 的执行结果、evidence 定位与 fail-closed 原因
+- selected adapter、fallback reason、thread/target binding summary、reviewed head、evidence 定位与 fail-closed 原因
 - manual review 的回退写回入口
 - review record 中的权威 findings / disposition 摘要
 - 审查结论（`allow` / `block` / `fallback`）

--- a/src/skills/loom-spec-review/SKILL.md
+++ b/src/skills/loom-spec-review/SKILL.md
@@ -46,7 +46,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 
 1. 运行 `flow spec-review`，确认 formal spec 路径、build checkpoint 与 runtime 读面齐全
 2. 若 `flow spec-review` 非 `pass`，直接返回 `block` 或 `fallback`
-3. 运行 `review run`，用默认 Codex adapter 或显式 opt-in Codex App authoritative adapter 生成 Loom-normalized spec findings
+3. 运行 `review run`，在 verified Codex App host default、显式 authoritative adapter 或 headless fallback 中选择安全路径，生成 Loom-normalized spec findings
 4. 若 `review run` fail-closed，回到 manual review 写回同一 spec review record
 5. 用 `review record` 写入 `kind = spec_review` 的正式结论
 
@@ -56,7 +56,7 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不替代 merge-ready 放行判断
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
-- 不把 Codex App raw review output 直接升级成 spec review authored truth；显式 opt-in Codex App path 仍必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
 
 ## 4. 输出要求
 

--- a/src/skills/shared/references/harness/review-execution.md
+++ b/src/skills/shared/references/harness/review-execution.md
@@ -21,7 +21,7 @@ Loom 把 review 分成四层：
 1. `flow review`
    - 只读基线；确认是否具备进入 formal review 的条件
 2. `review run`
-   - 调用默认 Codex-backed reviewer，产出结构化 review evidence 与 Loom-normalized findings
+   - 按宿主 proof 选择 authoritative adapter，产出结构化 review evidence 与 Loom-normalized findings
 3. `review record`
    - 把 formal review 结论写入单一 authored review record
 
@@ -47,27 +47,33 @@ Loom 把 review 分成四层：
 其中：
 
 - `flow review` 固定保持只读，不触发 engine，也不产生副作用
-- `review run` 只负责运行默认 reviewer 或显式 opt-in authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
+- `review run` 只负责选择安全的 authoritative adapter、落盘 evidence、生成 normalized findings，并显式 fail-closed
 - `review record` 仍只写入单一 `review_entry` 指向的 JSON
 - 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
 - `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
 
-默认 engine 当前固定为 `loom/default-codex`，能力来源是 `codex exec --output-schema`。
+默认 engine 按宿主 proof 选择：
+
+- 已验证 Codex App host context 默认选择 `loom/codex-app-review`，不启动嵌套 `codex exec`
+- `CI` / `CODEX_CI`、headless、host proof 缺失或 app-server unavailable 时 fallback 到 `loom/default-codex`，能力来源仍是 `codex exec --output-schema`
+- 显式 `--engine-adapter` 优先级最高，继续保留 Stage 2 authoritative opt-in / fallback 调试入口
+
 若 engine 不可用、schema 漂移、runtime 冲突或运行后改动了 tracked repo 内容，`review run` 必须返回 `block`，并指向 manual review 继续写回同一 `review record`；不得把这类失败伪装成 gate fallback。
 
-Codex App review adapter 有两种显式入口，默认均不启用：
+Codex App review adapter 有三种入口：
 
-- 触发必须显式，例如 `review run --shadow-engine-adapter loom/codex-app-review`
-- 默认 `loom/default-codex` / `codex exec --output-schema` 路径不得改变
+- verified host default：不传 `--engine-adapter`，但必须能证明 app-server/session locator、thread id、thread cwd、target root 与 reviewed head 绑定一致
+- explicit authoritative：显式选择 `review run --engine-adapter loom/codex-app-review`，用于调试或非默认宿主
+- shadow comparison：显式选择 `review run --shadow-engine-adapter loom/codex-app-review`
 - shadow evidence 只能写入 `.loom/runtime/review/<item>/<head>/shadow/<adapter>/`
 - shadow 输出可以包含 raw review、normalized findings、metadata 与 parity diff
 - shadow 输出不得 author `review_entry`，不得替代 `review_record_input.engine_adapter`
 - shadow unavailable / failure 不得阻断 default review run，也不得被 merge-ready 直接消费
-- Stage 2 authoritative opt-in 必须显式选择 `review run --engine-adapter loom/codex-app-review`
-- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof 和 repo-relative normalized raw review output
-- thread cwd proof 必须等于 target root；缺 app-server、thread、cwd、raw output 或 schema proof 时必须 fail closed
+- authoritative Codex App path 必须提供 app-server/session locator、thread id、thread cwd proof；live app-server unavailable 时默认 fallback 到 `loom/default-codex`
+- thread cwd proof 必须等于 target root；cwd / target / reviewed head 绑定冲突或 schema proof 失败时必须 fail closed
 - authoritative Codex App raw output 只作为 runtime evidence 保留；只有归一化后的 `review_record_input` 可被 `review record` 写入单一 authored truth
 - authoritative Codex App runtime files 使用与默认 engine 相同的 `.loom/runtime/review/<item>/<head>/engine-result.json`、`normalized-findings.json`、`engine-metadata.json` 和 `context-pack.json` 边界，保证历史 review context pack 可以继续读取 prior findings
+- `engine_metadata` 必须记录 selected adapter、selection source、fallback reason、thread/target binding summary、reviewed head 与 evidence locators
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
@@ -77,8 +83,8 @@ Codex App review adapter 有两种显式入口，默认均不启用：
 
 Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
 
-- `adapter`: `loom/default-codex` 或显式 opt-in 的 `loom/codex-app-review`
-- `engine`: `codex` 或显式 opt-in 的 `codex-app-review`
+- `adapter`: `loom/default-codex` 或 verified/explicit `loom/codex-app-review`
+- `engine`: `codex` 或 verified/explicit `codex-app-review`
 - `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
 - `model`: 显式传给 engine 的 model
 - `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -3126,6 +3126,19 @@ def require_review_run_payload(
                 for key in ("runtime_root", "raw_review", "normalized_findings", "metadata", "parity_diff"):
                     if not isinstance(evidence.get(key), str) or not evidence.get(key):
                         failures.append(Failure(category, f"{context} shadow_engine evidence must include non-empty `{key}`"))
+    engine_metadata = payload.get("engine_metadata")
+    if engine_adapter == "loom/codex-app-review" and engine.get("result") == "pass":
+        if not isinstance(engine_metadata, dict):
+            failures.append(Failure(category, f"{context} app review pass must expose `engine_metadata`"))
+        else:
+            for key in ("selected_adapter", "selection_source", "app_server", "thread_id", "thread_cwd", "raw_result", "normalized_findings", "context_pack", "reviewed_head"):
+                value = engine_metadata.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} app review metadata must include non-empty `{key}`"))
+            if engine_metadata.get("selected_adapter") != "loom/codex-app-review":
+                failures.append(Failure(category, f"{context} app review metadata must bind the selected adapter"))
+            if "normalized review_record_input only" not in str(engine_metadata.get("authority_boundary", "")):
+                failures.append(Failure(category, f"{context} app review metadata must keep raw App output outside merge-ready truth"))
 
 
 def require_runtime_state_payload(
@@ -5725,7 +5738,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
 
         prepare_review_target(review_target, "review run positive chain")
         write_fake_codex(fake_bin / "codex", mode="success")
-        success_env = prepend_path_env(fake_bin)
+        success_env = prepend_path_env(fake_bin, {"CI": "", "CODEX_CI": ""})
 
         payload, error = load_command_json(
             root,
@@ -5893,6 +5906,217 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             review_record_input = payload.get("review_record_input") if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict) else {}
             if review_record_input.get("engine_adapter") != "loom/default-codex":
                 failures.append(Failure("daily-execution-cli", "`review run` shadow unavailable must preserve the default review record input"))
+
+        app_default_target = Path(tmp) / "review-run-codex-app-default"
+        prepare_review_target(app_default_target, "review run Codex App host default")
+        app_default_raw = app_default_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_default_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_default_raw.write_text(
+            json.dumps(
+                {
+                    "decision": "allow",
+                    "summary": "Codex App default reviewer found the item ready.",
+                    "findings": [
+                        {
+                            "id": "codex-app-default-warn-1",
+                            "summary": "Codex App default review noted a tracked follow-up.",
+                            "severity": "warn",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "accepted",
+                                "summary": "The finding is recorded through the single review record boundary.",
+                            },
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_default_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-default-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-default-proof",
+                "--codex-app-review-cwd",
+                str(app_default_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App host default failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App host default",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            if isinstance(payload, dict):
+                engine = payload.get("engine") if isinstance(payload.get("engine"), dict) else {}
+                if engine.get("adapter") != "loom/codex-app-review" or engine.get("engine") != "codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must select the app adapter"))
+                review_record_input = payload.get("review_record_input") if isinstance(payload.get("review_record_input"), dict) else {}
+                if review_record_input.get("engine_adapter") != "loom/codex-app-review" or review_record_input.get("reviewer") != "loom/codex-app-review":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must author app adapter review_record_input"))
+                metadata = payload.get("engine_metadata") if isinstance(payload.get("engine_metadata"), dict) else {}
+                if metadata.get("selection_source") != "codex-app-host-default" or metadata.get("thread_id") != "thread-stage3-default-proof":
+                    failures.append(Failure("daily-execution-cli", "`review run` Codex App host default must expose selected adapter and thread proof metadata"))
+                merge_payload, merge_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        "tools/loom_flow.py",
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(app_default_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if merge_error:
+                    failures.append(Failure("daily-execution-cli", f"`merge-ready before authored default app review record` failed: {merge_error}"))
+                elif merge_payload.get("result") == "pass":
+                    failures.append(Failure("daily-execution-cli", "`merge-ready` must not consume default Codex App raw evidence before review record is authored"))
+
+        app_ci_fallback_target = Path(tmp) / "review-run-codex-app-ci-fallback"
+        prepare_review_target(app_ci_fallback_target, "review run Codex App CI fallback")
+        app_ci_raw = app_ci_fallback_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_ci_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_ci_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_ci_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-ci-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-ci-proof",
+                "--codex-app-review-cwd",
+                str(app_ci_fallback_target),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=prepend_path_env(fake_bin, {"CODEX_CI": "1"}),
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App CI fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App CI fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "ci-or-codex-ci":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App CI fallback must keep the default codex exec adapter"))
+
+        app_unavailable_fallback_target = Path(tmp) / "review-run-codex-app-unavailable-fallback"
+        prepare_review_target(app_unavailable_fallback_target, "review run Codex App unavailable fallback")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_unavailable_fallback_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                f"unix://{tmp}/missing-codex-app.sock",
+                "--codex-app-review-thread-id",
+                "thread-stage3-missing-endpoint",
+                "--codex-app-review-cwd",
+                str(app_unavailable_fallback_target),
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App unavailable fallback failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` Codex App unavailable fallback",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            metadata = payload.get("engine_metadata") if isinstance(payload, dict) and isinstance(payload.get("engine_metadata"), dict) else {}
+            if engine.get("adapter") != "loom/default-codex" or metadata.get("fallback_reason") != "app-server-unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App unavailable fallback must record default adapter fallback"))
+
+        app_conflict_target = Path(tmp) / "review-run-codex-app-proof-conflict"
+        prepare_review_target(app_conflict_target, "review run Codex App proof conflict")
+        app_conflict_raw = app_conflict_target / ".loom/runtime/tmp/codex-app-review-normalized.json"
+        app_conflict_raw.parent.mkdir(parents=True, exist_ok=True)
+        app_conflict_raw.write_text(app_default_raw.read_text(encoding="utf-8"), encoding="utf-8")
+        write_fake_codex(fake_bin / "codex", mode="fail_if_called")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(app_conflict_target),
+                "--item",
+                "INIT-0001",
+                "--codex-app-review-app-server",
+                "stdio://stage3-conflict-proof",
+                "--codex-app-review-thread-id",
+                "thread-stage3-conflict-proof",
+                "--codex-app-review-cwd",
+                str(Path(tmp) / "different-cwd"),
+                "--codex-app-review-raw-file",
+                ".loom/runtime/tmp/codex-app-review-normalized.json",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` Codex App proof conflict failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must fail closed"))
+        else:
+            engine = payload.get("engine") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else {}
+            if engine.get("adapter") != "loom/codex-app-review" or engine.get("failure_reason") != "runtime_conflict":
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not fallback to default codex"))
+            if "does not match target root" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must expose cwd mismatch"))
+            if isinstance(payload, dict) and isinstance(payload.get("review_record_input"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` Codex App proof conflict must not emit review_record_input"))
 
         app_authoritative_target = Path(tmp) / "review-run-codex-app-authoritative"
         prepare_review_target(app_authoritative_target, "review run Codex App authoritative")

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -118,6 +118,10 @@ CODEX_APP_REVIEW_ENGINE = "codex-app-review"
 CODEX_APP_REVIEW_SHADOW_ADAPTER = CODEX_APP_REVIEW_ADAPTER
 AUTHORITATIVE_REVIEW_ADAPTERS = {DEFAULT_REVIEW_ADAPTER, CODEX_APP_REVIEW_ADAPTER}
 SHADOW_REVIEW_ADAPTERS = {CODEX_APP_REVIEW_SHADOW_ADAPTER}
+CODEX_APP_REVIEW_ENDPOINT_ENV = "LOOM_CODEX_APP_REVIEW_ENDPOINT"
+CODEX_APP_REVIEW_THREAD_ID_ENV = "LOOM_CODEX_APP_REVIEW_THREAD_ID"
+CODEX_APP_REVIEW_CWD_ENV = "LOOM_CODEX_APP_REVIEW_CWD"
+CODEX_THREAD_ID_ENV = "CODEX_THREAD_ID"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS: int | None = None
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
@@ -492,26 +496,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=tuple(sorted(AUTHORITATIVE_REVIEW_ADAPTERS)),
         help=(
             "Optional authoritative review engine adapter for review run/record. "
-            "Default review run remains loom/default-codex."
+            "When omitted, verified Codex App sessions use loom/codex-app-review; headless/CI fallback remains loom/default-codex."
         ),
     )
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
     review.add_argument(
         "--codex-app-review-app-server",
-        help="Required explicit app-server/session locator when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App app-server/session locator. Defaults to ${CODEX_APP_REVIEW_ENDPOINT_ENV} when available.",
     )
     review.add_argument(
         "--codex-app-review-thread-id",
-        help="Required Codex App thread id when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread id. Defaults to ${CODEX_APP_REVIEW_THREAD_ID_ENV}, or ${CODEX_THREAD_ID_ENV} when an endpoint is present.",
     )
     review.add_argument(
         "--codex-app-review-cwd",
-        help="Required Codex App thread cwd proof when --engine-adapter loom/codex-app-review is authoritative.",
+        help=f"Codex App thread cwd proof. Defaults to ${CODEX_APP_REVIEW_CWD_ENV}.",
     )
     review.add_argument(
         "--codex-app-review-raw-file",
-        help="Required repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
+        help="Optional repo-relative Codex App normalized review output captured from review/start or same-thread normalization.",
     )
     review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
     review.add_argument("--engine-model", help="Optional review engine model override for review run")
@@ -4250,6 +4254,19 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def truthy_env(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def non_empty_str(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def execution_attempt_directory(target_root: Path, item_id: str) -> Path:
     return target_root / ".loom/runtime/attempts" / item_id
 
@@ -6264,8 +6281,26 @@ def run_default_review_engine(
     engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "explicit-or-legacy-default",
+            "fallback_reason": None,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=None,
+                thread_id=None,
+                thread_cwd=None,
+                reviewed_head=reviewed_head,
+                raw_file=None,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     prompt_path = runtime_root / "prompt.txt"
     result_path = runtime_root / "engine-result.json"
@@ -6313,6 +6348,7 @@ def run_default_review_engine(
                     "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
+            "engine_metadata": selection_metadata,
         }
 
     scratch_dir.mkdir(parents=True, exist_ok=True)
@@ -6403,6 +6439,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
@@ -6424,6 +6461,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     if raw_payload is not None and not result_path.exists():
@@ -6440,6 +6478,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
@@ -6462,6 +6501,7 @@ def run_default_review_engine(
                 "reviewed_head": reviewed_head,
                 "evidence": engine_evidence,
             },
+            "engine_metadata": selection_metadata,
         }
 
     write_json_file(findings_path, {"findings": normalized_payload["findings"]})
@@ -6471,6 +6511,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
@@ -6494,6 +6535,13 @@ def run_default_review_engine(
             "failure_reason": None,
             "reviewed_head": reviewed_head,
             "evidence": engine_evidence,
+        },
+        "engine_metadata": {
+            **selection_metadata,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
+            "raw_result": relative_to_root(result_path, context["target_root"]),
+            "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "metadata": relative_to_root(metadata_path, context["target_root"]),
         },
         "review_record_input": {
             "decision": normalized_payload["decision"],
@@ -7254,6 +7302,312 @@ def normalize_authoritative_codex_app_review_text(raw_text: str, *, relative: st
     return normalized, []
 
 
+def codex_app_endpoint_socket_path(app_server: str | None) -> Path | None:
+    endpoint = non_empty_str(app_server)
+    if endpoint is None:
+        return None
+    if endpoint.startswith("unix://"):
+        path_text = endpoint.removeprefix("unix://")
+    elif endpoint.startswith("/"):
+        path_text = endpoint
+    else:
+        return None
+    if not path_text:
+        return None
+    return Path(path_text).expanduser()
+
+
+def codex_app_endpoint_is_live_capable(app_server: str | None) -> bool:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    return socket_path is not None and socket_path.exists()
+
+
+def codex_app_review_bindings_from_args_env(args: argparse.Namespace) -> dict[str, str | None]:
+    app_server = non_empty_str(args.codex_app_review_app_server) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_ENDPOINT_ENV))
+    thread_id = (
+        non_empty_str(args.codex_app_review_thread_id)
+        or non_empty_str(os.environ.get(CODEX_APP_REVIEW_THREAD_ID_ENV))
+        or (non_empty_str(os.environ.get(CODEX_THREAD_ID_ENV)) if app_server else None)
+    )
+    thread_cwd = non_empty_str(args.codex_app_review_cwd) or non_empty_str(os.environ.get(CODEX_APP_REVIEW_CWD_ENV))
+    raw_file = non_empty_str(args.codex_app_review_raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": thread_cwd,
+        "raw_file": raw_file,
+    }
+
+
+def codex_app_binding_summary(
+    target_root: Path,
+    *,
+    app_server: str | None,
+    thread_id: str | None,
+    thread_cwd: str | None,
+    reviewed_head: str,
+    raw_file: str | None,
+) -> dict[str, Any]:
+    cwd_match: bool | None = None
+    cwd_summary: str | None = thread_cwd
+    if non_empty_str(thread_cwd):
+        try:
+            cwd_path = Path(str(thread_cwd)).expanduser().resolve()
+        except OSError:
+            cwd_match = False
+        else:
+            cwd_match = cwd_path == target_root
+            cwd_summary = str(cwd_path)
+    raw_source: str | None = None
+    if non_empty_str(raw_file):
+        raw_path, raw_errors = resolve_repo_relative_path(target_root, str(raw_file), label="Codex App authoritative review raw file")
+        if raw_path is not None and not raw_errors:
+            raw_source = relative_to_root(raw_path, target_root)
+        else:
+            raw_source = str(raw_file)
+    return {
+        "app_server": app_server,
+        "thread_id": thread_id,
+        "thread_cwd": cwd_summary,
+        "thread_cwd_matches_target_root": cwd_match,
+        "target_root": str(target_root),
+        "reviewed_head": reviewed_head,
+        "raw_source": raw_source,
+        "live_endpoint_capable": codex_app_endpoint_is_live_capable(app_server),
+    }
+
+
+def select_review_adapter(
+    args: argparse.Namespace,
+    target_root: Path,
+    *,
+    reviewed_head: str,
+) -> dict[str, Any]:
+    bindings = codex_app_review_bindings_from_args_env(args)
+    explicit_adapter = non_empty_str(args.engine_adapter)
+    if explicit_adapter:
+        return {
+            "adapter": explicit_adapter,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    if truthy_env("CI") or truthy_env("CODEX_CI"):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "headless-fallback",
+            "fallback_reason": "ci-or-codex-ci",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+
+    app_server = bindings["app_server"]
+    thread_id = bindings["thread_id"]
+    thread_cwd = bindings["thread_cwd"]
+    raw_file = bindings["raw_file"]
+    if not app_server or not thread_id or not thread_cwd:
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "missing-codex-app-host-proof",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    if not raw_file and not codex_app_endpoint_is_live_capable(app_server):
+        return {
+            "adapter": DEFAULT_REVIEW_ADAPTER,
+            "selection_source": "host-proof-fallback",
+            "fallback_reason": "app-server-unavailable",
+            **bindings,
+            "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+        }
+    return {
+        "adapter": CODEX_APP_REVIEW_ADAPTER,
+        "selection_source": "codex-app-host-default",
+        "fallback_reason": None,
+        **bindings,
+        "binding_summary": codex_app_binding_summary(target_root, reviewed_head=reviewed_head, **bindings),
+    }
+
+
+def review_adapter_selection_metadata(selection: dict[str, Any], *, reviewed_head: str) -> dict[str, Any]:
+    return {
+        "selected_adapter": selection["adapter"],
+        "selection_source": selection.get("selection_source"),
+        "fallback_reason": selection.get("fallback_reason"),
+        "app_server": selection.get("app_server"),
+        "thread_id": selection.get("thread_id"),
+        "thread_cwd": selection.get("thread_cwd"),
+        "target_root": selection.get("binding_summary", {}).get("target_root")
+        if isinstance(selection.get("binding_summary"), dict)
+        else None,
+        "reviewed_head": reviewed_head,
+        "thread_target_binding": selection.get("binding_summary"),
+    }
+
+
+def jsonrpc_send_request(stdin: Any, *, request_id: int, method: str, params: dict[str, Any]) -> None:
+    stdin.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}) + "\n")
+    stdin.flush()
+
+
+def jsonrpc_read_response(stdout: Any, *, request_id: int) -> tuple[dict[str, Any] | None, list[dict[str, Any]], list[str]]:
+    notifications: list[dict[str, Any]] = []
+    while True:
+        line = stdout.readline()
+        if not line:
+            return None, notifications, [f"app-server closed before response id {request_id}"]
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("id") == request_id:
+            return payload, notifications, []
+        notifications.append(payload)
+
+
+def find_exited_review_text(payload: Any) -> str | None:
+    if isinstance(payload, dict):
+        if payload.get("type") == "exitedReviewMode" and isinstance(payload.get("review"), str):
+            return payload["review"]
+        for value in payload.values():
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_exited_review_text(value)
+            if found is not None:
+                return found
+    return None
+
+
+def find_normalized_review_payload(payload: Any) -> dict[str, Any] | None:
+    normalized, errors = normalize_engine_review_result(payload, relative="app-server turn/start output")
+    if normalized is not None and not errors:
+        return normalized
+    if isinstance(payload, dict):
+        for value in payload.values():
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = find_normalized_review_payload(value)
+            if found is not None:
+                return found
+    return None
+
+
+def app_server_proxy_command(app_server: str) -> list[str] | None:
+    socket_path = codex_app_endpoint_socket_path(app_server)
+    if socket_path is None:
+        return None
+    return ["codex", "app-server", "proxy", "--sock", str(socket_path)]
+
+
+def run_codex_app_live_review(
+    *,
+    app_server: str,
+    thread_id: str,
+    reviewed_head: str,
+    thread_cwd: str,
+    prompt_text: str,
+) -> tuple[str | None, dict[str, Any], list[str]]:
+    command = app_server_proxy_command(app_server)
+    if command is None:
+        return None, {}, [f"unsupported Codex App review endpoint: {app_server}"]
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return None, {}, [f"Codex App review endpoint is unavailable: {exc}"]
+    assert process.stdin is not None
+    assert process.stdout is not None
+    metadata: dict[str, Any] = {"review_target": {"type": "commit", "sha": reviewed_head}}
+    try:
+        jsonrpc_send_request(process.stdin, request_id=1, method="initialize", params={"clientInfo": {"name": "loom", "version": "stage3"}, "capabilities": {}})
+        initialize_response, _, initialize_errors = jsonrpc_read_response(process.stdout, request_id=1)
+        if initialize_errors:
+            return None, metadata, initialize_errors
+        if isinstance(initialize_response, dict) and isinstance(initialize_response.get("error"), dict):
+            return None, metadata, [f"Codex App initialize failed: {initialize_response['error']}"]
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=2,
+            method="review/start",
+            params={
+                "threadId": thread_id,
+                "delivery": "inline",
+                "target": {"type": "commit", "sha": reviewed_head},
+            },
+        )
+        review_response, review_notifications, review_errors = jsonrpc_read_response(process.stdout, request_id=2)
+        if review_errors:
+            return None, metadata, review_errors
+        if isinstance(review_response, dict) and isinstance(review_response.get("error"), dict):
+            return None, metadata, [f"Codex App review/start failed: {review_response['error']}"]
+        result = review_response.get("result") if isinstance(review_response, dict) else None
+        if isinstance(result, dict):
+            metadata["review_thread_id"] = result.get("reviewThreadId")
+        review_text = find_exited_review_text(result) or find_exited_review_text(review_notifications)
+        if not isinstance(review_text, str) or not review_text.strip():
+            return None, metadata, ["Codex App review/start did not return exitedReviewMode.review"]
+
+        parsed_review, parsed_errors = normalize_authoritative_codex_app_review_text(review_text, relative="app-server review/start output")
+        if parsed_review is not None and not parsed_errors:
+            metadata["normalization_source"] = "review-start-json"
+            return review_text, {**metadata, "normalized": parsed_review}, []
+
+        jsonrpc_send_request(
+            process.stdin,
+            request_id=3,
+            method="turn/start",
+            params={
+                "threadId": metadata.get("review_thread_id") or thread_id,
+                "cwd": thread_cwd,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Normalize this Codex App review output into the provided JSON schema. "
+                            "Return only the structured review result.\n\n"
+                            f"{review_text}"
+                        ),
+                    }
+                ],
+                "outputSchema": load_json_file(review_engine_schema_path()),
+            },
+        )
+        turn_response, turn_notifications, turn_errors = jsonrpc_read_response(process.stdout, request_id=3)
+        if turn_errors:
+            return review_text, metadata, turn_errors
+        if isinstance(turn_response, dict) and isinstance(turn_response.get("error"), dict):
+            return review_text, metadata, [f"Codex App turn/start normalization failed: {turn_response['error']}"]
+        normalized = find_normalized_review_payload(turn_response.get("result") if isinstance(turn_response, dict) else None)
+        if normalized is None:
+            normalized = find_normalized_review_payload(turn_notifications)
+        if normalized is None:
+            return review_text, metadata, ["Codex App turn/start did not return a Loom review result"]
+        metadata["normalization_source"] = "turn-start-output-schema"
+        return review_text, {**metadata, "normalized": normalized}, []
+    finally:
+        try:
+            process.terminate()
+        except OSError:
+            pass
+
+
 def shadow_adapter_slug(adapter: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]", "-", adapter).strip("-") or "unknown-adapter"
 
@@ -7453,8 +7807,30 @@ def run_codex_app_review_authoritative_adapter(
     thread_id: str | None,
     thread_cwd: str | None,
     raw_file: str | None,
+    adapter_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reviewed_head = git_head_sha(context["target_root"]) or "unknown-head"
+    selection_metadata = review_adapter_selection_metadata(
+        adapter_selection
+        or {
+            "adapter": CODEX_APP_REVIEW_ADAPTER,
+            "selection_source": "explicit-cli",
+            "fallback_reason": None,
+            "app_server": app_server,
+            "thread_id": thread_id,
+            "thread_cwd": thread_cwd,
+            "raw_file": raw_file,
+            "binding_summary": codex_app_binding_summary(
+                context["target_root"],
+                app_server=app_server,
+                thread_id=thread_id,
+                thread_cwd=thread_cwd,
+                reviewed_head=reviewed_head,
+                raw_file=raw_file,
+            ),
+        },
+        reviewed_head=reviewed_head,
+    )
     runtime_root = review_runtime_root(context, reviewed_head)
     raw_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
@@ -7488,7 +7864,6 @@ def run_codex_app_review_authoritative_adapter(
         ("--codex-app-review-app-server", app_server),
         ("--codex-app-review-thread-id", thread_id),
         ("--codex-app-review-cwd", thread_cwd),
-        ("--codex-app-review-raw-file", raw_file),
     ):
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(label)
@@ -7518,6 +7893,8 @@ def run_codex_app_review_authoritative_adapter(
         missing_inputs.extend(source_errors)
         if source_path is not None:
             source_relative = relative_to_root(source_path, context["target_root"])
+    elif not codex_app_endpoint_is_live_capable(app_server):
+        missing_inputs.append("--codex-app-review-raw-file or live app-server endpoint")
 
     if missing_inputs:
         write_json_file(
@@ -7527,6 +7904,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "runtime_conflict",
@@ -7553,6 +7931,7 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative or thread_cwd,
@@ -7560,17 +7939,30 @@ def run_codex_app_review_authoritative_adapter(
             },
         }
 
-    try:
-        raw_text = source_path.read_text(encoding="utf-8") if source_path is not None else ""
-    except OSError as exc:
-        raw_text = ""
-        normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
-        normalized = None
+    live_metadata: dict[str, Any] = {}
+    if source_path is not None:
+        try:
+            raw_text = source_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raw_text = ""
+            normalization_errors = [f"Codex App authoritative review raw file: {exc.strerror or exc}"]
+            normalized = None
+        else:
+            normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
+                raw_text,
+                relative=source_relative or str(raw_file),
+            )
     else:
-        normalized, normalization_errors = normalize_authoritative_codex_app_review_text(
-            raw_text,
-            relative=source_relative or str(raw_file),
+        raw_text, live_metadata, normalization_errors = run_codex_app_live_review(
+            app_server=str(app_server),
+            thread_id=str(thread_id),
+            reviewed_head=reviewed_head,
+            thread_cwd=str(thread_cwd),
+            prompt_text=instructions_path.read_text(encoding="utf-8"),
         )
+        normalized = live_metadata.get("normalized") if isinstance(live_metadata.get("normalized"), dict) else None
+        if raw_text is None:
+            raw_text = ""
 
     if normalization_errors or normalized is None:
         if raw_text:
@@ -7582,6 +7974,7 @@ def run_codex_app_review_authoritative_adapter(
                 "engine": CODEX_APP_REVIEW_ENGINE,
                 "adapter": CODEX_APP_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                **selection_metadata,
                 "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "block",
                 "failure_reason": "schema_drift",
@@ -7592,6 +7985,7 @@ def run_codex_app_review_authoritative_adapter(
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         )
         return {
@@ -7609,10 +8003,12 @@ def run_codex_app_review_authoritative_adapter(
                 "evidence": evidence,
             },
             "engine_metadata": {
+                **selection_metadata,
                 "app_server": app_server,
                 "thread_id": thread_id,
                 "thread_cwd": cwd_relative,
                 "raw_source": source_relative,
+                **({"live_review": live_metadata} if live_metadata else {}),
             },
         }
 
@@ -7623,6 +8019,7 @@ def run_codex_app_review_authoritative_adapter(
         "engine": CODEX_APP_REVIEW_ENGINE,
         "adapter": CODEX_APP_REVIEW_ADAPTER,
         "profile": engine_profile,
+        **selection_metadata,
         "context_pack": relative_to_root(context_pack_path, context["target_root"]),
         "result": "pass",
         "reviewed_head": reviewed_head,
@@ -7634,6 +8031,11 @@ def run_codex_app_review_authoritative_adapter(
         "thread_id": thread_id,
         "thread_cwd": cwd_relative,
         "raw_source": source_relative,
+        "raw_result": relative_to_root(raw_path, context["target_root"]),
+        "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+        "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "review_thread_id": live_metadata.get("review_thread_id") if live_metadata else (thread_id if source_path is not None else None),
+        **({"live_review": {key: value for key, value in live_metadata.items() if key != "normalized"}} if live_metadata else {}),
         "authority_boundary": "normalized review_record_input only; raw Codex App output remains runtime evidence",
     }
     write_json_file(metadata_path, metadata)
@@ -12452,7 +12854,9 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
-        requested_engine_adapter = args.engine_adapter or DEFAULT_REVIEW_ADAPTER
+        current_head = git_head_sha(target_root) or "unknown-head"
+        adapter_selection = select_review_adapter(args, target_root, reviewed_head=current_head)
+        requested_engine_adapter = str(adapter_selection["adapter"])
         engine_profile, engine_profile_errors = resolve_review_engine_profile(
             context,
             review_kind,
@@ -12484,9 +12888,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": None,
                         "result": "not_run",
                         "failure_reason": "runtime_conflict",
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12524,9 +12929,10 @@ def handle_review(args: argparse.Namespace) -> int:
                         "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
-                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "reviewed_head": current_head,
                         "evidence": None,
                     },
+                    "engine_metadata": review_adapter_selection_metadata(adapter_selection, reviewed_head=current_head),
                     "manual_review": manual_review,
                 }
             )
@@ -12539,10 +12945,11 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
-                app_server=args.codex_app_review_app_server,
-                thread_id=args.codex_app_review_thread_id,
-                thread_cwd=args.codex_app_review_cwd,
-                raw_file=args.codex_app_review_raw_file,
+                app_server=adapter_selection.get("app_server") if isinstance(adapter_selection.get("app_server"), str) else None,
+                thread_id=adapter_selection.get("thread_id") if isinstance(adapter_selection.get("thread_id"), str) else None,
+                thread_cwd=adapter_selection.get("thread_cwd") if isinstance(adapter_selection.get("thread_cwd"), str) else None,
+                raw_file=adapter_selection.get("raw_file") if isinstance(adapter_selection.get("raw_file"), str) else None,
+                adapter_selection=adapter_selection,
             )
         else:
             engine_payload = run_default_review_engine(
@@ -12551,6 +12958,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 review_path,
                 engine_profile,
                 review_kind=review_kind,
+                adapter_selection=adapter_selection,
             )
         shadow_engine_payload = run_codex_app_review_shadow_adapter(
             context,


### PR DESCRIPTION
## Summary
- Switch `review run` default adapter selection to `loom/codex-app-review` when verified Codex App host proof is complete.
- Preserve `loom/default-codex` for CI/headless/missing or unavailable App host proof, and keep proof conflicts fail-closed.
- Record selected adapter, fallback reason, thread/target binding, reviewed head, and evidence locators in engine metadata; keep raw App output outside review/merge truth.
- Refresh skills runtime surfaces and the demo bootstrap payload.
- Bind this PR to the active Loom fact chain for `WI-750`.

## Validation
- `python3 -m py_compile tools/loom_flow.py tools/loom_check.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `python3 tools/version_surface_check.py`
- `python3 tools/loom_flow.py fact-chain --target . --item WI-750`
- `python3 tools/loom_flow.py adopt verify --target . --item WI-750`
- `python3 tools/loom_flow.py shadow-parity --target .`
- `python3 tools/loom_flow.py checkpoint merge --target . --item WI-750`
- `python3 tools/loom_check.py`
- `make check`
- `git diff --check`

## Related Work
- Loom Work Item: WI-750
- Refs #750
