### PR TITLE
docs: 记录 .loom surfaces 版本控制策略

### DIFF
--- a/.loom/bootstrap/init-result.json
+++ b/.loom/bootstrap/init-result.json
@@ -74,9 +74,9 @@
     "mode": "work-item + recovery-entry + derived status-surface",
     "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
     "entry_points": {
-      "current_item_id": "WI-751",
-      "work_item": ".loom/work-items/WI-751.md",
-      "recovery_entry": ".loom/progress/WI-751.md",
+      "current_item_id": "WI-783",
+      "work_item": ".loom/work-items/WI-783.md",
+      "recovery_entry": ".loom/progress/WI-783.md",
       "status_surface": ".loom/status/current.md"
     }
   },

--- a/.loom/progress/WI-751.md
+++ b/.loom/progress/WI-751.md
@@ -3,13 +3,13 @@
 ## Dynamic Facts
 
 - Item ID: WI-751
-- Current Checkpoint: merge checkpoint
-- Current Stop: #751 implementation, root .loom/bin carrier, generated skill/demo surfaces, installer version gate, shadow carrier refresh, loom_check, make check, and node installer release/test checks are passing locally on branch work/751-codex-review-adapter-contract-cleanup.
-- Next Step: Commit installer version gate update, refresh implementation review at latest head, push PR #771, then wait for required checks and controlled merge.
+- Current Checkpoint: merged
+- Current Stop: PR #771 merged into main at 0937e186c08f6f0722b87c5ca621ae5d4134f981 on 2026-05-17.
+- Next Step: No active execution remains for WI-751 in this workspace; parent closeout remains outside #783.
 - Blockers: None recorded.
 - Latest Validation Summary: #751 local validation passed after root carrier sync and installer gate bump: python3 tools/skills_surface.py check -> OK; python3 tools/version_surface_check.py -> OK; python3 -m py_compile tools/loom_flow.py tools/loom_check.py .loom/bin/loom_flow.py .loom/bin/loom_check.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py -> OK; python3 .loom/bin/loom_init.py verify --target . -> OK; python3 tools/loom_check.py -> OK (36 surfaces); make check -> OK; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main -> OK (0.1.108 -> 0.1.109); npm --prefix packages/loom-installer run check:release -> OK; npm --prefix packages/loom-installer test -> OK (20 tests).
-- Recovery Boundary: Branch work/751-codex-review-adapter-contract-cleanup in /Users/mc/dev/Loom-worktrees/751-codex-review-adapter-contract-cleanup; PR #771; issue #751 phase 4; parent #746 closeout after #751 merge.
-- Current Lane: #751 phase 4 / Codex review adapter contract cleanup
+- Recovery Boundary: Historical record for PR #771 / issue #751; this item is no longer an active workspace binding.
+- Current Lane: merged
 
 ## Execution Ledger
 

--- a/.loom/progress/WI-783.md
+++ b/.loom/progress/WI-783.md
@@ -1,0 +1,21 @@
+# WI-783 Progress
+
+## Dynamic Facts
+
+- Item ID: WI-783
+- Current Checkpoint: merge checkpoint
+- Current Stop: #783 implementation, docs, generated skill surface, and installer version bump are ready for PR gate consumption.
+- Next Step: Merge PR #785 after CI and Loom PR gate pass, then close issue #783.
+- Blockers: None recorded.
+- Latest Validation Summary: make skills-check -> OK; make loom-check -> OK; installer package version bumped to 0.1.110 for generated skills payload change.
+- Recovery Boundary: #783 is bounded to .loom surfaces version-control policy documentation, installed skills reference propagation, generated skills surface refresh, and required PR gate metadata.
+- Current Lane: PR #785
+
+## Execution Ledger
+
+- Ledger Binding: recovery_entry
+- Plan Locator: .loom/specs/WI-783/plan.md
+- Acceptance Locator: .loom/specs/WI-783/spec.md
+- Validation Evidence Locator: PR #785 checks and local validation summary
+- Handoff Notes Locator: not_applicable
+- Evidence Freshness: not_applicable

--- a/.loom/reviews/WI-783.json
+++ b/.loom/reviews/WI-783.json
@@ -5,7 +5,7 @@
   "kind": "general_review",
   "summary": "The implementation records a canonical .loom surfaces version-control policy, links it from adoption/install docs, mirrors it into installed skill references, refreshes generated skills, and keeps behavior enforcement deferred to the later #781/#782 checkpoints.",
   "reviewer": "codex",
-  "reviewed_head": "de1b10e57f6ad942887e4078be8a0e53d3d64e04",
+  "reviewed_head": "94dd0c72c059fa63d53c8c445f665f6bf6e4c985",
   "reviewed_validation_summary": "make skills-check -> OK; make loom-check -> OK; installer package version bumped to 0.1.110 for generated skills payload change.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-783.json
+++ b/.loom/reviews/WI-783.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-783",
+  "decision": "fallback",
+  "kind": "general_review",
+  "summary": "Formal review has not been recorded yet.",
+  "reviewer": "not yet assigned",
+  "reviewed_head": "b8b47c706e729ace24c4f77c8c67c746b89e3072",
+  "reviewed_validation_summary": "No validation recorded yet.",
+  "fallback_to": "admission",
+  "findings": [
+    {
+      "id": "scaffolded-block-1",
+      "summary": "Review artifact scaffolded but not yet concluded.",
+      "severity": "block",
+      "rebuttal": null,
+      "disposition": {
+        "status": "rejected",
+        "summary": "Scaffold placeholder must be replaced by a real formal review conclusion."
+      }
+    },
+    {
+      "id": "scaffolded-warn-1",
+      "summary": "Record a real review before asking merge checkpoint to consume it.",
+      "severity": "warn",
+      "rebuttal": null,
+      "disposition": {
+        "status": "deferred",
+        "summary": "This follow-up stays open until a real review is recorded."
+      }
+    }
+  ],
+  "blocking_issues": [
+    "Review artifact scaffolded but not yet concluded."
+  ],
+  "follow_ups": [
+    "Record a real review before asking merge checkpoint to consume it."
+  ]
+}

--- a/.loom/reviews/WI-783.spec.json
+++ b/.loom/reviews/WI-783.spec.json
@@ -2,8 +2,8 @@
   "schema_version": "loom-review/v1",
   "item_id": "WI-783",
   "decision": "allow",
-  "kind": "general_review",
-  "summary": "The implementation records a canonical .loom surfaces version-control policy, links it from adoption/install docs, mirrors it into installed skill references, refreshes generated skills, and keeps behavior enforcement deferred to the later #781/#782 checkpoints.",
+  "kind": "spec_review",
+  "summary": "The WI-783 spec is sufficient for the documentation checkpoint: it defines the policy acceptance criteria, explicitly excludes behavior enforcement, and lists the generated skills propagation and validation requirements.",
   "reviewer": "codex",
   "reviewed_head": "de1b10e57f6ad942887e4078be8a0e53d3d64e04",
   "reviewed_validation_summary": "make skills-check -> OK; make loom-check -> OK; installer package version bumped to 0.1.110 for generated skills payload change.",
@@ -13,8 +13,8 @@
   "follow_ups": [],
   "consumed_inputs": {
     "work_item": ".loom/work-items/WI-783.md",
-    "recovery_entry": ".loom/progress/WI-783.md",
-    "status_surface": ".loom/status/current.md",
-    "spec_review": ".loom/reviews/WI-783.spec.json"
+    "spec": ".loom/specs/WI-783/spec.md",
+    "plan": ".loom/specs/WI-783/plan.md",
+    "implementation_contract": ".loom/specs/WI-783/implementation-contract.md"
   }
 }

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "8e38942ca30050b0569599d724c019ea316e2d344032ff46d4517247b1793fc2"
+    ".loom/status/current.md": "cfb73ecb8eee85b5a1696c5e5a65ecdb5ce07925cc6177e101f8c3b4ae434262"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "8e38942ca30050b0569599d724c019ea316e2d344032ff46d4517247b1793fc2"
+    ".loom/status/current.md": "cfb73ecb8eee85b5a1696c5e5a65ecdb5ce07925cc6177e101f8c3b4ae434262"
   }
 }

--- a/.loom/specs/WI-783/implementation-contract.md
+++ b/.loom/specs/WI-783/implementation-contract.md
@@ -1,0 +1,19 @@
+# WI-783 Implementation Contract
+
+## Write Scope
+
+- `docs/adoption/**`
+- `src/skills/**`
+- generated `skills/**`
+- `.loom/work-items/WI-783.md`
+- `.loom/progress/WI-783.md`
+- `.loom/reviews/WI-783*.json`
+- `.loom/specs/WI-783/**`
+- `packages/loom-installer/package*.json`
+
+## Invariants
+
+- `docs/adoption/loom-surfaces-version-control.md` is the authoritative policy.
+- Installed skill references must not introduce independent rules that drift from the docs contract.
+- Generated `skills/` content must come from `python3 tools/skills_surface.py generate`.
+- Behavior enforcement remains deferred to later milestone issues.

--- a/.loom/specs/WI-783/plan.md
+++ b/.loom/specs/WI-783/plan.md
@@ -1,0 +1,8 @@
+# WI-783 Plan
+
+1. Add the canonical adoption policy document.
+2. Link the policy from zero-friction adoption, external runtime, Codex install, unified install, and adoption index docs.
+3. Add the installed-skill shared reference and include it in the runtime install layout.
+4. Regenerate the checked-in `skills/` surface from `src/skills`.
+5. Run `make skills-check` and `make loom-check`.
+6. Record review evidence and merge PR #785.

--- a/.loom/specs/WI-783/spec.md
+++ b/.loom/specs/WI-783/spec.md
@@ -1,0 +1,18 @@
+# WI-783 Spec
+
+## Goal
+
+Record a canonical `.loom` surfaces version-control policy for target repository adoption.
+
+## Acceptance Criteria
+
+- `docs/adoption/loom-surfaces-version-control.md` defines Git-visible stable carriers, runtime scratch paths, `.gitignore` discipline, verify failure guidance, and external runtime migration expectations.
+- Existing adoption and install docs link to the new policy instead of duplicating the full rule.
+- `src/skills/shared/references/adoption/loom-surfaces-version-control.md` mirrors the policy for installed skills and is included in `src/skills/install-layout.json`.
+- Generated `skills/` surfaces are refreshed from `src/skills`.
+- Validation includes `make skills-check` and `make loom-check`.
+
+## Non-goals
+
+- Do not implement bootstrap or verify behavior enforcement in this checkpoint; #781 and #782 own that work.
+- Do not change target repository business truth ownership.

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -11,13 +11,13 @@
 - Review Entry: .loom/reviews/WI-783.json
 - Validation Entry: make skills-check; make loom-check
 - Closing Condition: #783 is implemented, validated, reviewed, merged, and the policy is available to installed skills
-- Current Checkpoint: admission checkpoint
-- Current Stop: Work item scaffolded and waiting for the first execution pass.
-- Next Step: Write the first recovery update for this work item.
+- Current Checkpoint: merge checkpoint
+- Current Stop: #783 implementation, docs, generated skill surface, and installer version bump are ready for PR gate consumption.
+- Next Step: Merge PR #785 after CI and Loom PR gate pass, then close issue #783.
 - Blockers: None recorded.
-- Latest Validation Summary: No validation recorded yet.
-- Recovery Boundary: Work item scaffolded at `.loom/work-items/WI-783.md`.
-- Current Lane: not yet assigned
+- Latest Validation Summary: make skills-check -> OK; make loom-check -> OK; installer package version bumped to 0.1.110 for generated skills payload change.
+- Recovery Boundary: #783 is bounded to .loom surfaces version-control policy documentation, installed skills reference propagation, generated skills surface refresh, and required PR gate metadata.
+- Current Lane: PR #785
 
 ## Runtime Evidence
 

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -2,22 +2,22 @@
 
 ## Derived Fact Chain View
 
-- Item ID: WI-751
-- Goal: Clean up the Codex review adapter contract vocabulary and release gate for #751 phase 4.
-- Scope: Rename the exec-hosted fallback adapter contract to loom/default-codex-exec, synchronize runtime scripts, generated skill surfaces, documentation, fixtures, checkers, and prove merge-ready consumes only the authored review record.
-- Execution Path: phase/codex-review-adapter-contract-cleanup/751
+- Item ID: WI-783
+- Goal: Record the .loom surfaces version-control policy for adoption/install safety
+- Scope: Add the canonical adoption policy, link it from adoption and install docs, mirror it into the generated skills surface, and validate skills/loom checks
+- Execution Path: docs/adoption
 - Workspace Entry: .
-- Recovery Entry: .loom/progress/WI-751.md
-- Review Entry: .loom/reviews/WI-751.json
-- Validation Entry: python3 tools/version_surface_check.py && python3 -m py_compile tools/loom_flow.py tools/loom_check.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py && python3 tools/loom_check.py && make check
-- Closing Condition: #751 implementation, generated surfaces, docs, review records, PR gates, required checks, controlled merge, post-merge validation, #751 closeout, and parent #746 closeout are all complete with GitHub truth readback.
-- Current Checkpoint: merge checkpoint
-- Current Stop: #751 implementation, root .loom/bin carrier, generated skill/demo surfaces, installer version gate, shadow carrier refresh, loom_check, make check, and node installer release/test checks are passing locally on branch work/751-codex-review-adapter-contract-cleanup.
-- Next Step: Commit installer version gate update, refresh implementation review at latest head, push PR #771, then wait for required checks and controlled merge.
+- Recovery Entry: .loom/progress/WI-783.md
+- Review Entry: .loom/reviews/WI-783.json
+- Validation Entry: make skills-check; make loom-check
+- Closing Condition: #783 is implemented, validated, reviewed, merged, and the policy is available to installed skills
+- Current Checkpoint: admission checkpoint
+- Current Stop: Work item scaffolded and waiting for the first execution pass.
+- Next Step: Write the first recovery update for this work item.
 - Blockers: None recorded.
-- Latest Validation Summary: #751 local validation passed after root carrier sync and installer gate bump: python3 tools/skills_surface.py check -> OK; python3 tools/version_surface_check.py -> OK; python3 -m py_compile tools/loom_flow.py tools/loom_check.py .loom/bin/loom_flow.py .loom/bin/loom_check.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py -> OK; python3 .loom/bin/loom_init.py verify --target . -> OK; python3 tools/loom_check.py -> OK (36 surfaces); make check -> OK; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main -> OK (0.1.108 -> 0.1.109); npm --prefix packages/loom-installer run check:release -> OK; npm --prefix packages/loom-installer test -> OK (20 tests).
-- Recovery Boundary: Branch work/751-codex-review-adapter-contract-cleanup in /Users/mc/dev/Loom-worktrees/751-codex-review-adapter-contract-cleanup; PR #771; issue #751 phase 4; parent #746 closeout after #751 merge.
-- Current Lane: #751 phase 4 / Codex review adapter contract cleanup
+- Latest Validation Summary: No validation recorded yet.
+- Recovery Boundary: Work item scaffolded at `.loom/work-items/WI-783.md`.
+- Current Lane: not yet assigned
 
 ## Runtime Evidence
 
@@ -29,7 +29,7 @@
 
 ## Sources
 
-- Static Truth: .loom/work-items/WI-751.md
-- Dynamic Truth: .loom/progress/WI-751.md
+- Static Truth: .loom/work-items/WI-783.md
+- Dynamic Truth: .loom/progress/WI-783.md
 - Locator Truth: .loom/bootstrap/init-result.json
 - Fact Chain CLI: python3 .loom/bin/loom_init.py fact-chain --target .

--- a/.loom/work-items/WI-783.md
+++ b/.loom/work-items/WI-783.md
@@ -1,0 +1,31 @@
+# WI-783
+
+## Static Facts
+
+- Item ID: WI-783
+- Goal: Record the .loom surfaces version-control policy for adoption/install safety
+- Scope: Add the canonical adoption policy, link it from adoption and install docs, mirror it into the generated skills surface, and validate skills/loom checks
+- Execution Path: docs/adoption
+- Workspace Entry: .
+- Recovery Entry: .loom/progress/WI-783.md
+- Review Entry: .loom/reviews/WI-783.json
+- Validation Entry: make skills-check; make loom-check
+- Closing Condition: #783 is implemented, validated, reviewed, merged, and the policy is available to installed skills
+
+## Associated Artifacts
+
+- `.loom/work-items/WI-783.md`
+- `.loom/progress/WI-783.md`
+- `.loom/reviews/WI-783.json`
+- `.loom/status/current.md`
+- `docs/adoption/loom-surfaces-version-control.md`
+- `docs/adoption/zero-friction-adoption-contract.md`
+- `docs/adoption/external-runtime-companion-contract.md`
+- `src/skills/shared/references/adoption/loom-surfaces-version-control.md`
+- `skills/shared/references/adoption/loom-surfaces-version-control.md`
+- `.loom/specs/WI-783/spec.md`
+- `.loom/specs/WI-783/plan.md`
+- `.loom/specs/WI-783/implementation-contract.md`
+- `.loom/reviews/WI-783.spec.json`
+- `packages/loom-installer/package.json`
+- `packages/loom-installer/package-lock.json`

--- a/docs/adoption/README.md
+++ b/docs/adoption/README.md
@@ -25,6 +25,7 @@
 - GitHub profile 升级路径：[github-profile-upgrade.md](./github-profile-upgrade.md)
 - CI required checks bootstrap：[ci-required-checks-bootstrap.md](./ci-required-checks-bootstrap.md)
 - 目标仓库 release / version 合同：[target-repo-version-contract.md](./target-repo-version-contract.md)
+- `.loom` surfaces 版本控制策略：[loom-surfaces-version-control.md](./loom-surfaces-version-control.md)
 - 统一安装体验：[unified-install-experience.md](./unified-install-experience.md)
 - 宿主适配矩阵：`host-adapter-matrix.md`
 - 单 skill 安装合同：[single-skill-contract.md](./single-skill-contract.md)

--- a/docs/adoption/codex-install.md
+++ b/docs/adoption/codex-install.md
@@ -28,6 +28,8 @@ Enable Loom skills in Codex via native skill discovery. Clone the repository and
 
 Codex should start from `loom-init` after discovery reloads. The npm installer is not the Codex default path; it remains available for adapter-specific and single-skill helper flows.
 
+This installs Loom's own generated skill surface. It does not define which `.loom` files an adopted target repository should commit. Target repository `.loom` carrier visibility is defined in [loom-surfaces-version-control.md](./loom-surfaces-version-control.md).
+
 ## Verify
 
 ```bash

--- a/docs/adoption/external-runtime-companion-contract.md
+++ b/docs/adoption/external-runtime-companion-contract.md
@@ -22,6 +22,7 @@ external-runtime 的目标是让成熟 adopted repo 最终可以：
 - `loom_init verify` 已经要求 `.loom/bin/*` 与 `.loom/bootstrap/manifest.json` 一致
 - manifest 中的 runtime artifact `sha256` 是当前 fail-closed trust boundary
 - strong-governance adopted repo 仍需要本地可审计 runtime provenance
+- vendored `.loom/bin/**` 在该阶段属于 [.loom surfaces 版本控制策略](./loom-surfaces-version-control.md) 中的稳定 carrier，必须 Git 可见
 
 因此，external-runtime 只是一条显式迁移路径，不是当前默认安装形态。
 
@@ -79,6 +80,8 @@ external-runtime companion 必须显式声明 runtime locator，而不是依赖�
    - `shadow-parity --blocking`，仅限显式 strong profile smoke
 4. 确认 `.loom/companion`、status、work item、review、shadow evidence 均未因 runtime locator 改变而漂移
 5. 只在以上检查通过后删除或停止提交 vendored `.loom/bin`
+
+停止提交 vendored `.loom/bin` 时，不得引入 blanket `.loom/` ignore；`.loom/companion`、`interop.json` 与其他已启用治理载体必须继续 Git 可见。
 
 ## 6. Rollback
 

--- a/docs/adoption/loom-surfaces-version-control.md
+++ b/docs/adoption/loom-surfaces-version-control.md
@@ -1,0 +1,94 @@
+# Loom Surfaces Version Control Policy
+
+本文冻结目标仓库中 `.loom` surfaces 的版本控制策略。
+
+它回答两个问题：
+
+- 哪些 `.loom` 文件是稳定治理载体，应当进入 Git
+- 哪些 `.loom` 文件是运行态 scratch，不应进入 Git
+
+本策略不改变 [repo companion](./repo-companion-contract.md)、[repo interop](./repo-interop-contract.md)、[target repo version](./target-repo-version-contract.md) 或 [external runtime](./external-runtime-companion-contract.md) 的 ownership 边界。
+
+## 1. 稳定载体必须 Git 可见
+
+以下路径一旦由当前 adoption profile 生成或启用，必须能被 `git status` 看见并可被提交：
+
+- `.loom/bootstrap/manifest.json`
+- `.loom/bootstrap/init-result.json`
+- `.loom/README.md`
+- `.loom/companion/manifest.json`
+- `.loom/companion/README.md`
+- `.loom/companion/repo-interface.json`
+- `.loom/companion/interop.json`
+- `.loom/companion/**` 下由 repo companion 合同允许的 repo-specific locator 文档
+- `.loom/bin/**`，仅限当前采用 vendored repo-local runtime 阶段
+- `.loom/work-items/**`，仅限显式启用 execution-control 或 strong-governance 后
+- `.loom/progress/**`，仅限显式启用 execution-control 或 strong-governance 后
+- `.loom/reviews/**`，仅限显式启用 execution-control、strong-governance 或 Loom-authored review carrier 后
+- `.loom/status/current.md`，仅限显式启用 Loom-owned status surface 后
+- `.loom/specs/**`，仅限显式启用 Loom-authored spec truth 后
+- `.loom/shadow/**`，仅限显式启用 shadow evidence 并由 Loom 合同要求版本化后
+
+`attach-only` profile 默认只提交 attach metadata、repo companion / interop read surfaces、repo-local verify entry 与必要 vendored runtime。它不得生成 Loom-authored work item、progress、status、review 或 spec truth，除非 adoption intent 显式升级到 execution-control。
+
+## 2. 运行态残留必须保持未版本化
+
+以下路径是运行态 scratch、缓存或本地尝试残留，不应提交：
+
+- `.loom/runtime/**`
+- `.loom/tmp/**`
+- `.loom/cache/**`
+- `.loom/attempts/**/raw-logs/**`
+- `.loom/attempts/**/scratch/**`
+- `.loom/local/**`
+- host token、local credential、machine cache 或一次性调试输出
+
+若某个 profile 需要把 attempt evidence 版本化，必须先定义稳定 evidence schema 与 locator；不能直接提交 raw logs 或 scratch 目录。
+
+## 3. `.gitignore` 纪律
+
+目标仓库不得用 blanket ignore 隐藏整个 `.loom/`。
+
+禁止：
+
+```gitignore
+.loom/
+.loom/**
+```
+
+推荐只忽略运行态目录：
+
+```gitignore
+.loom/runtime/
+.loom/tmp/
+.loom/cache/
+.loom/attempts/**/raw-logs/
+.loom/attempts/**/scratch/
+.loom/local/
+```
+
+如果目标仓库已经存在 blanket `.loom/` ignore，bootstrap 和 verify 必须 fail closed，或输出可审查的 ignore 修复方案。不要用 `git add -f .loom` 粗粒度绕过，因为这会同时掩盖稳定载体和运行态残留的边界。
+
+## 4. Verify failure guidance
+
+当 verify 发现稳定 carrier 被忽略、缺失或不可见时，输出必须包含：
+
+- 具体路径
+- 该路径属于哪个 profile 或 capability
+- 当前失败原因：`missing`、`ignored`、`untracked` 或 `unexpected runtime path`
+- 建议动作：移除 blanket ignore、改成细粒度 ignore、显式升级 adoption intent，或删除 forbidden authored carrier
+
+运行态路径如 `.loom/runtime/`、`.loom/tmp/`、`.loom/cache/` 不得被误报为必须提交。
+
+## 5. External runtime 迁移
+
+在 vendored repo-local runtime 阶段，`.loom/bin/**` 是可审计 runtime provenance，必须 Git 可见。
+
+迁移到 versioned external runtime 后，`.loom/bin/**` 可以停止提交，但必须同时满足 [external runtime companion contract](./external-runtime-companion-contract.md)：
+
+- external runtime locator 已版本化
+- fallback runtime 或 rebootstrap 路径明确
+- `.loom/companion` 与 `interop.json` 继续保持 Git 可见
+- rollback 能恢复到可信 runtime
+
+external runtime 只替换执行来源，不能替代仓内治理真相。

--- a/docs/adoption/unified-install-experience.md
+++ b/docs/adoption/unified-install-experience.md
@@ -42,6 +42,8 @@ Verify it with:
 make skills-check
 ```
 
+This install surface is distinct from target repository `.loom` governance carriers. When Loom adopts a target repository, stable `.loom` carriers must follow [loom-surfaces-version-control.md](./loom-surfaces-version-control.md); installers and adapters must not hide them with a blanket `.loom/` ignore.
+
 ## Full Repo Install
 
 Full repo install is the default user journey. It exposes the complete Loom scenario surface:

--- a/docs/adoption/zero-friction-adoption-contract.md
+++ b/docs/adoption/zero-friction-adoption-contract.md
@@ -141,6 +141,7 @@ generated `repo interop` 只能生成或更新以下内容：
 - 未生成的 companion / interop surface 被显式记录为 intentionally absent
 - repo-owned residue 保留在原 ownership
 - 没有新增平行事实链或平行状态面
+- 稳定 `.loom` carrier 遵守 [.loom surfaces 版本控制策略](./loom-surfaces-version-control.md)，不能被 blanket `.loom/` ignore 隐藏
 
 ## 7. Adopt Verify Closure
 
@@ -150,6 +151,7 @@ generated `repo interop` 只能生成或更新以下内容：
 - generated interop locators 存在，或被标记为 intentionally absent
 - companion / interop 边界未承载运行态真相、host action result 或 closeout result
 - repo-specific 判断都有 source locator、reasoning、writeback target 与 verification evidence
+- 稳定 `.loom` carrier 对 Git 可见；`.loom/runtime`、`.loom/tmp`、`.loom/cache` 等运行态残留不被误报为必须提交
 - `fact-chain` 能复读 adoption 结果
 - resume guidance 能给出后续 continuation entry 或明确说明无需恢复
 
@@ -181,5 +183,7 @@ adoption 完成后，`loom-resume` 不消费 adoption 输出作为新的事实�
   - 成熟治理重仓的 attach-only 默认路径
 - [github-profile-upgrade.md](./github-profile-upgrade.md)
   - GitHub profile 的 advisory / blocking / rollback gate rollout 合同
+- [loom-surfaces-version-control.md](./loom-surfaces-version-control.md)
+  - 冻结稳定 `.loom` carrier 与运行态 scratch 的 Git 可见性边界
 
 本合同只定义 adoption 闭环，不复制这些合同的 schema 或 gate 规则。

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/install-layout.json
+++ b/skills/install-layout.json
@@ -82,6 +82,7 @@
     "shared/references/adoption/repo-companion-contract.md",
     "shared/references/adoption/repo-interop-contract.md",
     "shared/references/adoption/target-repo-version-contract.md",
+    "shared/references/adoption/loom-surfaces-version-control.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-adopt/.loom-runtime/install-layout.json
+++ b/skills/loom-adopt/.loom-runtime/install-layout.json
@@ -82,6 +82,7 @@
     "shared/references/adoption/repo-companion-contract.md",
     "shared/references/adoption/repo-interop-contract.md",
     "shared/references/adoption/target-repo-version-contract.md",
+    "shared/references/adoption/loom-surfaces-version-control.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-adopt/.loom-runtime/loom-adopt/SKILL.md
+++ b/skills/loom-adopt/.loom-runtime/loom-adopt/SKILL.md
@@ -34,6 +34,7 @@ description: 负责把仓库接入 Loom 的初始化场景入口。Use when Code
   - [../shared/references/adoption/zero-friction-adoption-contract.md](../shared/references/adoption/zero-friction-adoption-contract.md)
   - [../shared/references/adoption/lightweight-retrofit-default.md](../shared/references/adoption/lightweight-retrofit-default.md)
   - [../shared/references/adoption/routing-and-checkpoints.md](../shared/references/adoption/routing-and-checkpoints.md)
+  - [../shared/references/adoption/loom-surfaces-version-control.md](../shared/references/adoption/loom-surfaces-version-control.md)
   - [../shared/references/harness/fact-chain-contract.md](../shared/references/harness/fact-chain-contract.md)
   - [../loom-init/references/input-signals.md](../loom-init/references/input-signals.md)
   - [../loom-init/references/output-contract.md](../loom-init/references/output-contract.md)

--- a/skills/loom-adopt/.loom-runtime/loom-init/SKILL.md
+++ b/skills/loom-adopt/.loom-runtime/loom-init/SKILL.md
@@ -82,6 +82,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - `skills/shared/references/adoption/routing-and-checkpoints.md`
   - `skills/shared/references/adoption/lightweight-retrofit-default.md`
   - `skills/shared/references/adoption/deep-existing-repo-default.md`
+  - `skills/shared/references/adoption/loom-surfaces-version-control.md`
 - `skills/shared/references/harness/recovery-model.md`
 - `skills/shared/references/harness/fact-chain-contract.md`
 - `skills/shared/references/harness/item-context-contract.md`

--- a/skills/loom-adopt/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
@@ -1,0 +1,80 @@
+# Loom Surfaces Version Control Policy
+
+Authoritative source: `docs/adoption/loom-surfaces-version-control.md`.
+
+This mirrored reference exists for executable skills that need local shared adoption context. Do not extend this mirror with independent rules; update the authoritative adoption contract instead.
+
+## Stable carriers must be Git-visible
+
+When generated or enabled by the selected adoption profile, these `.loom` paths are stable carriers and must be visible to Git:
+
+- `.loom/bootstrap/manifest.json`
+- `.loom/bootstrap/init-result.json`
+- `.loom/README.md`
+- `.loom/companion/manifest.json`
+- `.loom/companion/README.md`
+- `.loom/companion/repo-interface.json`
+- `.loom/companion/interop.json`
+- `.loom/companion/**` repo companion locators allowed by the repo companion contract
+- `.loom/bin/**` while the target repository uses vendored repo-local runtime
+- `.loom/work-items/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/progress/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/reviews/**` only after execution-control, strong-governance, or Loom-authored review carriers are explicitly enabled
+- `.loom/status/current.md` only after Loom-owned status surface is explicitly enabled
+- `.loom/specs/**` only after Loom-authored spec truth is explicitly enabled
+- `.loom/shadow/**` only when shadow evidence is enabled and the relevant Loom contract requires versioning
+
+`attach-only` defaults to attach metadata, repo companion / interop read surfaces, repo-local verify entry, and required vendored runtime. It must not generate Loom-authored work item, progress, status, review, or spec truth unless adoption intent explicitly upgrades to execution-control.
+
+## Runtime residue must stay unversioned
+
+These paths are runtime scratch, cache, or local attempt residue and should not be committed:
+
+- `.loom/runtime/**`
+- `.loom/tmp/**`
+- `.loom/cache/**`
+- `.loom/attempts/**/raw-logs/**`
+- `.loom/attempts/**/scratch/**`
+- `.loom/local/**`
+- host tokens, local credentials, machine caches, and one-off debug output
+
+If a profile needs versioned attempt evidence, it must define a stable evidence schema and locator first. Raw logs and scratch directories are not stable carriers.
+
+## `.gitignore` discipline
+
+Target repositories must not hide the whole `.loom/` tree with blanket ignores such as:
+
+```gitignore
+.loom/
+.loom/**
+```
+
+Ignore only runtime paths:
+
+```gitignore
+.loom/runtime/
+.loom/tmp/
+.loom/cache/
+.loom/attempts/**/raw-logs/
+.loom/attempts/**/scratch/
+.loom/local/
+```
+
+Bootstrap and verify must fail closed or provide a reviewable ignore repair when a target repository already has a blanket `.loom/` ignore. Do not use `git add -f .loom` as the normal answer because it hides the stable-carrier/runtime-residue boundary.
+
+## Verify failure guidance
+
+When verify finds a stable carrier that is ignored, missing, or not visible, it must report:
+
+- the concrete path
+- the profile or capability that requires the path
+- the reason: `missing`, `ignored`, `untracked`, or `unexpected runtime path`
+- the suggested action: remove blanket ignore, switch to runtime-only ignores, explicitly upgrade adoption intent, or remove a forbidden authored carrier
+
+Runtime paths such as `.loom/runtime/`, `.loom/tmp/`, and `.loom/cache/` must not be reported as required Git-visible carriers.
+
+## External runtime migration
+
+During vendored repo-local runtime, `.loom/bin/**` is auditable runtime provenance and must be Git-visible.
+
+After migration to versioned external runtime, `.loom/bin/**` may stop being committed only when the external runtime contract is satisfied: versioned locator, explicit fallback or rebootstrap path, Git-visible `.loom/companion` and `interop.json`, and rollback to a trusted runtime.

--- a/skills/loom-adopt/SKILL.md
+++ b/skills/loom-adopt/SKILL.md
@@ -34,6 +34,7 @@ description: 负责把仓库接入 Loom 的初始化场景入口。Use when Code
   - [../shared/references/adoption/zero-friction-adoption-contract.md](.loom-runtime/shared/references/adoption/zero-friction-adoption-contract.md)
   - [../shared/references/adoption/lightweight-retrofit-default.md](.loom-runtime/shared/references/adoption/lightweight-retrofit-default.md)
   - [../shared/references/adoption/routing-and-checkpoints.md](.loom-runtime/shared/references/adoption/routing-and-checkpoints.md)
+  - [../shared/references/adoption/loom-surfaces-version-control.md](.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md)
   - [../shared/references/harness/fact-chain-contract.md](.loom-runtime/shared/references/harness/fact-chain-contract.md)
   - [../loom-init/references/input-signals.md](.loom-runtime/loom-init/references/input-signals.md)
   - [../loom-init/references/output-contract.md](.loom-runtime/loom-init/references/output-contract.md)

--- a/skills/loom-build/.loom-runtime/install-layout.json
+++ b/skills/loom-build/.loom-runtime/install-layout.json
@@ -82,6 +82,7 @@
     "shared/references/adoption/repo-companion-contract.md",
     "shared/references/adoption/repo-interop-contract.md",
     "shared/references/adoption/target-repo-version-contract.md",
+    "shared/references/adoption/loom-surfaces-version-control.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-build/.loom-runtime/loom-adopt/SKILL.md
+++ b/skills/loom-build/.loom-runtime/loom-adopt/SKILL.md
@@ -34,6 +34,7 @@ description: 负责把仓库接入 Loom 的初始化场景入口。Use when Code
   - [../shared/references/adoption/zero-friction-adoption-contract.md](../shared/references/adoption/zero-friction-adoption-contract.md)
   - [../shared/references/adoption/lightweight-retrofit-default.md](../shared/references/adoption/lightweight-retrofit-default.md)
   - [../shared/references/adoption/routing-and-checkpoints.md](../shared/references/adoption/routing-and-checkpoints.md)
+  - [../shared/references/adoption/loom-surfaces-version-control.md](../shared/references/adoption/loom-surfaces-version-control.md)
   - [../shared/references/harness/fact-chain-contract.md](../shared/references/harness/fact-chain-contract.md)
   - [../loom-init/references/input-signals.md](../loom-init/references/input-signals.md)
   - [../loom-init/references/output-contract.md](../loom-init/references/output-contract.md)

--- a/skills/loom-build/.loom-runtime/loom-init/SKILL.md
+++ b/skills/loom-build/.loom-runtime/loom-init/SKILL.md
@@ -82,6 +82,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - `skills/shared/references/adoption/routing-and-checkpoints.md`
   - `skills/shared/references/adoption/lightweight-retrofit-default.md`
   - `skills/shared/references/adoption/deep-existing-repo-default.md`
+  - `skills/shared/references/adoption/loom-surfaces-version-control.md`
 - `skills/shared/references/harness/recovery-model.md`
 - `skills/shared/references/harness/fact-chain-contract.md`
 - `skills/shared/references/harness/item-context-contract.md`

--- a/skills/loom-build/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
+++ b/skills/loom-build/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
@@ -1,0 +1,80 @@
+# Loom Surfaces Version Control Policy
+
+Authoritative source: `docs/adoption/loom-surfaces-version-control.md`.
+
+This mirrored reference exists for executable skills that need local shared adoption context. Do not extend this mirror with independent rules; update the authoritative adoption contract instead.
+
+## Stable carriers must be Git-visible
+
+When generated or enabled by the selected adoption profile, these `.loom` paths are stable carriers and must be visible to Git:
+
+- `.loom/bootstrap/manifest.json`
+- `.loom/bootstrap/init-result.json`
+- `.loom/README.md`
+- `.loom/companion/manifest.json`
+- `.loom/companion/README.md`
+- `.loom/companion/repo-interface.json`
+- `.loom/companion/interop.json`
+- `.loom/companion/**` repo companion locators allowed by the repo companion contract
+- `.loom/bin/**` while the target repository uses vendored repo-local runtime
+- `.loom/work-items/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/progress/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/reviews/**` only after execution-control, strong-governance, or Loom-authored review carriers are explicitly enabled
+- `.loom/status/current.md` only after Loom-owned status surface is explicitly enabled
+- `.loom/specs/**` only after Loom-authored spec truth is explicitly enabled
+- `.loom/shadow/**` only when shadow evidence is enabled and the relevant Loom contract requires versioning
+
+`attach-only` defaults to attach metadata, repo companion / interop read surfaces, repo-local verify entry, and required vendored runtime. It must not generate Loom-authored work item, progress, status, review, or spec truth unless adoption intent explicitly upgrades to execution-control.
+
+## Runtime residue must stay unversioned
+
+These paths are runtime scratch, cache, or local attempt residue and should not be committed:
+
+- `.loom/runtime/**`
+- `.loom/tmp/**`
+- `.loom/cache/**`
+- `.loom/attempts/**/raw-logs/**`
+- `.loom/attempts/**/scratch/**`
+- `.loom/local/**`
+- host tokens, local credentials, machine caches, and one-off debug output
+
+If a profile needs versioned attempt evidence, it must define a stable evidence schema and locator first. Raw logs and scratch directories are not stable carriers.
+
+## `.gitignore` discipline
+
+Target repositories must not hide the whole `.loom/` tree with blanket ignores such as:
+
+```gitignore
+.loom/
+.loom/**
+```
+
+Ignore only runtime paths:
+
+```gitignore
+.loom/runtime/
+.loom/tmp/
+.loom/cache/
+.loom/attempts/**/raw-logs/
+.loom/attempts/**/scratch/
+.loom/local/
+```
+
+Bootstrap and verify must fail closed or provide a reviewable ignore repair when a target repository already has a blanket `.loom/` ignore. Do not use `git add -f .loom` as the normal answer because it hides the stable-carrier/runtime-residue boundary.
+
+## Verify failure guidance
+
+When verify finds a stable carrier that is ignored, missing, or not visible, it must report:
+
+- the concrete path
+- the profile or capability that requires the path
+- the reason: `missing`, `ignored`, `untracked`, or `unexpected runtime path`
+- the suggested action: remove blanket ignore, switch to runtime-only ignores, explicitly upgrade adoption intent, or remove a forbidden authored carrier
+
+Runtime paths such as `.loom/runtime/`, `.loom/tmp/`, and `.loom/cache/` must not be reported as required Git-visible carriers.
+
+## External runtime migration
+
+During vendored repo-local runtime, `.loom/bin/**` is auditable runtime provenance and must be Git-visible.
+
+After migration to versioned external runtime, `.loom/bin/**` may stop being committed only when the external runtime contract is satisfied: versioned locator, explicit fallback or rebootstrap path, Git-visible `.loom/companion` and `interop.json`, and rollback to a trusted runtime.

--- a/skills/loom-handoff/.loom-runtime/install-layout.json
+++ b/skills/loom-handoff/.loom-runtime/install-layout.json
@@ -82,6 +82,7 @@
     "shared/references/adoption/repo-companion-contract.md",
     "shared/references/adoption/repo-interop-contract.md",
     "shared/references/adoption/target-repo-version-contract.md",
+    "shared/references/adoption/loom-surfaces-version-control.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-handoff/.loom-runtime/loom-adopt/SKILL.md
+++ b/skills/loom-handoff/.loom-runtime/loom-adopt/SKILL.md
@@ -34,6 +34,7 @@ description: 负责把仓库接入 Loom 的初始化场景入口。Use when Code
   - [../shared/references/adoption/zero-friction-adoption-contract.md](../shared/references/adoption/zero-friction-adoption-contract.md)
   - [../shared/references/adoption/lightweight-retrofit-default.md](../shared/references/adoption/lightweight-retrofit-default.md)
   - [../shared/references/adoption/routing-and-checkpoints.md](../shared/references/adoption/routing-and-checkpoints.md)
+  - [../shared/references/adoption/loom-surfaces-version-control.md](../shared/references/adoption/loom-surfaces-version-control.md)
   - [../shared/references/harness/fact-chain-contract.md](../shared/references/harness/fact-chain-contract.md)
   - [../loom-init/references/input-signals.md](../loom-init/references/input-signals.md)
   - [../loom-init/references/output-contract.md](../loom-init/references/output-contract.md)

--- a/skills/loom-handoff/.loom-runtime/loom-init/SKILL.md
+++ b/skills/loom-handoff/.loom-runtime/loom-init/SKILL.md
@@ -82,6 +82,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - `skills/shared/references/adoption/routing-and-checkpoints.md`
   - `skills/shared/references/adoption/lightweight-retrofit-default.md`
   - `skills/shared/references/adoption/deep-existing-repo-default.md`
+  - `skills/shared/references/adoption/loom-surfaces-version-control.md`
 - `skills/shared/references/harness/recovery-model.md`
 - `skills/shared/references/harness/fact-chain-contract.md`
 - `skills/shared/references/harness/item-context-contract.md`

--- a/skills/loom-handoff/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
@@ -1,0 +1,80 @@
+# Loom Surfaces Version Control Policy
+
+Authoritative source: `docs/adoption/loom-surfaces-version-control.md`.
+
+This mirrored reference exists for executable skills that need local shared adoption context. Do not extend this mirror with independent rules; update the authoritative adoption contract instead.
+
+## Stable carriers must be Git-visible
+
+When generated or enabled by the selected adoption profile, these `.loom` paths are stable carriers and must be visible to Git:
+
+- `.loom/bootstrap/manifest.json`
+- `.loom/bootstrap/init-result.json`
+- `.loom/README.md`
+- `.loom/companion/manifest.json`
+- `.loom/companion/README.md`
+- `.loom/companion/repo-interface.json`
+- `.loom/companion/interop.json`
+- `.loom/companion/**` repo companion locators allowed by the repo companion contract
+- `.loom/bin/**` while the target repository uses vendored repo-local runtime
+- `.loom/work-items/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/progress/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/reviews/**` only after execution-control, strong-governance, or Loom-authored review carriers are explicitly enabled
+- `.loom/status/current.md` only after Loom-owned status surface is explicitly enabled
+- `.loom/specs/**` only after Loom-authored spec truth is explicitly enabled
+- `.loom/shadow/**` only when shadow evidence is enabled and the relevant Loom contract requires versioning
+
+`attach-only` defaults to attach metadata, repo companion / interop read surfaces, repo-local verify entry, and required vendored runtime. It must not generate Loom-authored work item, progress, status, review, or spec truth unless adoption intent explicitly upgrades to execution-control.
+
+## Runtime residue must stay unversioned
+
+These paths are runtime scratch, cache, or local attempt residue and should not be committed:
+
+- `.loom/runtime/**`
+- `.loom/tmp/**`
+- `.loom/cache/**`
+- `.loom/attempts/**/raw-logs/**`
+- `.loom/attempts/**/scratch/**`
+- `.loom/local/**`
+- host tokens, local credentials, machine caches, and one-off debug output
+
+If a profile needs versioned attempt evidence, it must define a stable evidence schema and locator first. Raw logs and scratch directories are not stable carriers.
+
+## `.gitignore` discipline
+
+Target repositories must not hide the whole `.loom/` tree with blanket ignores such as:
+
+```gitignore
+.loom/
+.loom/**
+```
+
+Ignore only runtime paths:
+
+```gitignore
+.loom/runtime/
+.loom/tmp/
+.loom/cache/
+.loom/attempts/**/raw-logs/
+.loom/attempts/**/scratch/
+.loom/local/
+```
+
+Bootstrap and verify must fail closed or provide a reviewable ignore repair when a target repository already has a blanket `.loom/` ignore. Do not use `git add -f .loom` as the normal answer because it hides the stable-carrier/runtime-residue boundary.
+
+## Verify failure guidance
+
+When verify finds a stable carrier that is ignored, missing, or not visible, it must report:
+
+- the concrete path
+- the profile or capability that requires the path
+- the reason: `missing`, `ignored`, `untracked`, or `unexpected runtime path`
+- the suggested action: remove blanket ignore, switch to runtime-only ignores, explicitly upgrade adoption intent, or remove a forbidden authored carrier
+
+Runtime paths such as `.loom/runtime/`, `.loom/tmp/`, and `.loom/cache/` must not be reported as required Git-visible carriers.
+
+## External runtime migration
+
+During vendored repo-local runtime, `.loom/bin/**` is auditable runtime provenance and must be Git-visible.
+
+After migration to versioned external runtime, `.loom/bin/**` may stop being committed only when the external runtime contract is satisfied: versioned locator, explicit fallback or rebootstrap path, Git-visible `.loom/companion` and `interop.json`, and rollback to a trusted runtime.

--- a/skills/loom-init/.loom-runtime/install-layout.json
+++ b/skills/loom-init/.loom-runtime/install-layout.json
@@ -82,6 +82,7 @@
     "shared/references/adoption/repo-companion-contract.md",
     "shared/references/adoption/repo-interop-contract.md",
     "shared/references/adoption/target-repo-version-contract.md",
+    "shared/references/adoption/loom-surfaces-version-control.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-init/.loom-runtime/loom-adopt/SKILL.md
+++ b/skills/loom-init/.loom-runtime/loom-adopt/SKILL.md
@@ -34,6 +34,7 @@ description: 负责把仓库接入 Loom 的初始化场景入口。Use when Code
   - [../shared/references/adoption/zero-friction-adoption-contract.md](../shared/references/adoption/zero-friction-adoption-contract.md)
   - [../shared/references/adoption/lightweight-retrofit-default.md](../shared/references/adoption/lightweight-retrofit-default.md)
   - [../shared/references/adoption/routing-and-checkpoints.md](../shared/references/adoption/routing-and-checkpoints.md)
+  - [../shared/references/adoption/loom-surfaces-version-control.md](../shared/references/adoption/loom-surfaces-version-control.md)
   - [../shared/references/harness/fact-chain-contract.md](../shared/references/harness/fact-chain-contract.md)
   - [../loom-init/references/input-signals.md](../loom-init/references/input-signals.md)
   - [../loom-init/references/output-contract.md](../loom-init/references/output-contract.md)

--- a/skills/loom-init/.loom-runtime/loom-init/SKILL.md
+++ b/skills/loom-init/.loom-runtime/loom-init/SKILL.md
@@ -82,6 +82,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - `skills/shared/references/adoption/routing-and-checkpoints.md`
   - `skills/shared/references/adoption/lightweight-retrofit-default.md`
   - `skills/shared/references/adoption/deep-existing-repo-default.md`
+  - `skills/shared/references/adoption/loom-surfaces-version-control.md`
 - `skills/shared/references/harness/recovery-model.md`
 - `skills/shared/references/harness/fact-chain-contract.md`
 - `skills/shared/references/harness/item-context-contract.md`

--- a/skills/loom-init/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
+++ b/skills/loom-init/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
@@ -1,0 +1,80 @@
+# Loom Surfaces Version Control Policy
+
+Authoritative source: `docs/adoption/loom-surfaces-version-control.md`.
+
+This mirrored reference exists for executable skills that need local shared adoption context. Do not extend this mirror with independent rules; update the authoritative adoption contract instead.
+
+## Stable carriers must be Git-visible
+
+When generated or enabled by the selected adoption profile, these `.loom` paths are stable carriers and must be visible to Git:
+
+- `.loom/bootstrap/manifest.json`
+- `.loom/bootstrap/init-result.json`
+- `.loom/README.md`
+- `.loom/companion/manifest.json`
+- `.loom/companion/README.md`
+- `.loom/companion/repo-interface.json`
+- `.loom/companion/interop.json`
+- `.loom/companion/**` repo companion locators allowed by the repo companion contract
+- `.loom/bin/**` while the target repository uses vendored repo-local runtime
+- `.loom/work-items/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/progress/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/reviews/**` only after execution-control, strong-governance, or Loom-authored review carriers are explicitly enabled
+- `.loom/status/current.md` only after Loom-owned status surface is explicitly enabled
+- `.loom/specs/**` only after Loom-authored spec truth is explicitly enabled
+- `.loom/shadow/**` only when shadow evidence is enabled and the relevant Loom contract requires versioning
+
+`attach-only` defaults to attach metadata, repo companion / interop read surfaces, repo-local verify entry, and required vendored runtime. It must not generate Loom-authored work item, progress, status, review, or spec truth unless adoption intent explicitly upgrades to execution-control.
+
+## Runtime residue must stay unversioned
+
+These paths are runtime scratch, cache, or local attempt residue and should not be committed:
+
+- `.loom/runtime/**`
+- `.loom/tmp/**`
+- `.loom/cache/**`
+- `.loom/attempts/**/raw-logs/**`
+- `.loom/attempts/**/scratch/**`
+- `.loom/local/**`
+- host tokens, local credentials, machine caches, and one-off debug output
+
+If a profile needs versioned attempt evidence, it must define a stable evidence schema and locator first. Raw logs and scratch directories are not stable carriers.
+
+## `.gitignore` discipline
+
+Target repositories must not hide the whole `.loom/` tree with blanket ignores such as:
+
+```gitignore
+.loom/
+.loom/**
+```
+
+Ignore only runtime paths:
+
+```gitignore
+.loom/runtime/
+.loom/tmp/
+.loom/cache/
+.loom/attempts/**/raw-logs/
+.loom/attempts/**/scratch/
+.loom/local/
+```
+
+Bootstrap and verify must fail closed or provide a reviewable ignore repair when a target repository already has a blanket `.loom/` ignore. Do not use `git add -f .loom` as the normal answer because it hides the stable-carrier/runtime-residue boundary.
+
+## Verify failure guidance
+
+When verify finds a stable carrier that is ignored, missing, or not visible, it must report:
+
+- the concrete path
+- the profile or capability that requires the path
+- the reason: `missing`, `ignored`, `untracked`, or `unexpected runtime path`
+- the suggested action: remove blanket ignore, switch to runtime-only ignores, explicitly upgrade adoption intent, or remove a forbidden authored carrier
+
+Runtime paths such as `.loom/runtime/`, `.loom/tmp/`, and `.loom/cache/` must not be reported as required Git-visible carriers.
+
+## External runtime migration
+
+During vendored repo-local runtime, `.loom/bin/**` is auditable runtime provenance and must be Git-visible.
+
+After migration to versioned external runtime, `.loom/bin/**` may stop being committed only when the external runtime contract is satisfied: versioned locator, explicit fallback or rebootstrap path, Git-visible `.loom/companion` and `interop.json`, and rollback to a trusted runtime.

--- a/skills/loom-init/SKILL.md
+++ b/skills/loom-init/SKILL.md
@@ -82,6 +82,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - `skills/shared/references/adoption/routing-and-checkpoints.md`
   - `skills/shared/references/adoption/lightweight-retrofit-default.md`
   - `skills/shared/references/adoption/deep-existing-repo-default.md`
+  - `skills/shared/references/adoption/loom-surfaces-version-control.md`
 - `skills/shared/references/harness/recovery-model.md`
 - `skills/shared/references/harness/fact-chain-contract.md`
 - `skills/shared/references/harness/item-context-contract.md`

--- a/skills/loom-merge-ready/.loom-runtime/install-layout.json
+++ b/skills/loom-merge-ready/.loom-runtime/install-layout.json
@@ -82,6 +82,7 @@
     "shared/references/adoption/repo-companion-contract.md",
     "shared/references/adoption/repo-interop-contract.md",
     "shared/references/adoption/target-repo-version-contract.md",
+    "shared/references/adoption/loom-surfaces-version-control.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-merge-ready/.loom-runtime/loom-adopt/SKILL.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-adopt/SKILL.md
@@ -34,6 +34,7 @@ description: 负责把仓库接入 Loom 的初始化场景入口。Use when Code
   - [../shared/references/adoption/zero-friction-adoption-contract.md](../shared/references/adoption/zero-friction-adoption-contract.md)
   - [../shared/references/adoption/lightweight-retrofit-default.md](../shared/references/adoption/lightweight-retrofit-default.md)
   - [../shared/references/adoption/routing-and-checkpoints.md](../shared/references/adoption/routing-and-checkpoints.md)
+  - [../shared/references/adoption/loom-surfaces-version-control.md](../shared/references/adoption/loom-surfaces-version-control.md)
   - [../shared/references/harness/fact-chain-contract.md](../shared/references/harness/fact-chain-contract.md)
   - [../loom-init/references/input-signals.md](../loom-init/references/input-signals.md)
   - [../loom-init/references/output-contract.md](../loom-init/references/output-contract.md)

--- a/skills/loom-merge-ready/.loom-runtime/loom-init/SKILL.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-init/SKILL.md
@@ -82,6 +82,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - `skills/shared/references/adoption/routing-and-checkpoints.md`
   - `skills/shared/references/adoption/lightweight-retrofit-default.md`
   - `skills/shared/references/adoption/deep-existing-repo-default.md`
+  - `skills/shared/references/adoption/loom-surfaces-version-control.md`
 - `skills/shared/references/harness/recovery-model.md`
 - `skills/shared/references/harness/fact-chain-contract.md`
 - `skills/shared/references/harness/item-context-contract.md`

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
@@ -1,0 +1,80 @@
+# Loom Surfaces Version Control Policy
+
+Authoritative source: `docs/adoption/loom-surfaces-version-control.md`.
+
+This mirrored reference exists for executable skills that need local shared adoption context. Do not extend this mirror with independent rules; update the authoritative adoption contract instead.
+
+## Stable carriers must be Git-visible
+
+When generated or enabled by the selected adoption profile, these `.loom` paths are stable carriers and must be visible to Git:
+
+- `.loom/bootstrap/manifest.json`
+- `.loom/bootstrap/init-result.json`
+- `.loom/README.md`
+- `.loom/companion/manifest.json`
+- `.loom/companion/README.md`
+- `.loom/companion/repo-interface.json`
+- `.loom/companion/interop.json`
+- `.loom/companion/**` repo companion locators allowed by the repo companion contract
+- `.loom/bin/**` while the target repository uses vendored repo-local runtime
+- `.loom/work-items/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/progress/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/reviews/**` only after execution-control, strong-governance, or Loom-authored review carriers are explicitly enabled
+- `.loom/status/current.md` only after Loom-owned status surface is explicitly enabled
+- `.loom/specs/**` only after Loom-authored spec truth is explicitly enabled
+- `.loom/shadow/**` only when shadow evidence is enabled and the relevant Loom contract requires versioning
+
+`attach-only` defaults to attach metadata, repo companion / interop read surfaces, repo-local verify entry, and required vendored runtime. It must not generate Loom-authored work item, progress, status, review, or spec truth unless adoption intent explicitly upgrades to execution-control.
+
+## Runtime residue must stay unversioned
+
+These paths are runtime scratch, cache, or local attempt residue and should not be committed:
+
+- `.loom/runtime/**`
+- `.loom/tmp/**`
+- `.loom/cache/**`
+- `.loom/attempts/**/raw-logs/**`
+- `.loom/attempts/**/scratch/**`
+- `.loom/local/**`
+- host tokens, local credentials, machine caches, and one-off debug output
+
+If a profile needs versioned attempt evidence, it must define a stable evidence schema and locator first. Raw logs and scratch directories are not stable carriers.
+
+## `.gitignore` discipline
+
+Target repositories must not hide the whole `.loom/` tree with blanket ignores such as:
+
+```gitignore
+.loom/
+.loom/**
+```
+
+Ignore only runtime paths:
+
+```gitignore
+.loom/runtime/
+.loom/tmp/
+.loom/cache/
+.loom/attempts/**/raw-logs/
+.loom/attempts/**/scratch/
+.loom/local/
+```
+
+Bootstrap and verify must fail closed or provide a reviewable ignore repair when a target repository already has a blanket `.loom/` ignore. Do not use `git add -f .loom` as the normal answer because it hides the stable-carrier/runtime-residue boundary.
+
+## Verify failure guidance
+
+When verify finds a stable carrier that is ignored, missing, or not visible, it must report:
+
+- the concrete path
+- the profile or capability that requires the path
+- the reason: `missing`, `ignored`, `untracked`, or `unexpected runtime path`
+- the suggested action: remove blanket ignore, switch to runtime-only ignores, explicitly upgrade adoption intent, or remove a forbidden authored carrier
+
+Runtime paths such as `.loom/runtime/`, `.loom/tmp/`, and `.loom/cache/` must not be reported as required Git-visible carriers.
+
+## External runtime migration
+
+During vendored repo-local runtime, `.loom/bin/**` is auditable runtime provenance and must be Git-visible.
+
+After migration to versioned external runtime, `.loom/bin/**` may stop being committed only when the external runtime contract is satisfied: versioned locator, explicit fallback or rebootstrap path, Git-visible `.loom/companion` and `interop.json`, and rollback to a trusted runtime.

--- a/skills/loom-pre-review/.loom-runtime/install-layout.json
+++ b/skills/loom-pre-review/.loom-runtime/install-layout.json
@@ -82,6 +82,7 @@
     "shared/references/adoption/repo-companion-contract.md",
     "shared/references/adoption/repo-interop-contract.md",
     "shared/references/adoption/target-repo-version-contract.md",
+    "shared/references/adoption/loom-surfaces-version-control.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-pre-review/.loom-runtime/loom-adopt/SKILL.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-adopt/SKILL.md
@@ -34,6 +34,7 @@ description: 负责把仓库接入 Loom 的初始化场景入口。Use when Code
   - [../shared/references/adoption/zero-friction-adoption-contract.md](../shared/references/adoption/zero-friction-adoption-contract.md)
   - [../shared/references/adoption/lightweight-retrofit-default.md](../shared/references/adoption/lightweight-retrofit-default.md)
   - [../shared/references/adoption/routing-and-checkpoints.md](../shared/references/adoption/routing-and-checkpoints.md)
+  - [../shared/references/adoption/loom-surfaces-version-control.md](../shared/references/adoption/loom-surfaces-version-control.md)
   - [../shared/references/harness/fact-chain-contract.md](../shared/references/harness/fact-chain-contract.md)
   - [../loom-init/references/input-signals.md](../loom-init/references/input-signals.md)
   - [../loom-init/references/output-contract.md](../loom-init/references/output-contract.md)

--- a/skills/loom-pre-review/.loom-runtime/loom-init/SKILL.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-init/SKILL.md
@@ -82,6 +82,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - `skills/shared/references/adoption/routing-and-checkpoints.md`
   - `skills/shared/references/adoption/lightweight-retrofit-default.md`
   - `skills/shared/references/adoption/deep-existing-repo-default.md`
+  - `skills/shared/references/adoption/loom-surfaces-version-control.md`
 - `skills/shared/references/harness/recovery-model.md`
 - `skills/shared/references/harness/fact-chain-contract.md`
 - `skills/shared/references/harness/item-context-contract.md`

--- a/skills/loom-pre-review/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
@@ -1,0 +1,80 @@
+# Loom Surfaces Version Control Policy
+
+Authoritative source: `docs/adoption/loom-surfaces-version-control.md`.
+
+This mirrored reference exists for executable skills that need local shared adoption context. Do not extend this mirror with independent rules; update the authoritative adoption contract instead.
+
+## Stable carriers must be Git-visible
+
+When generated or enabled by the selected adoption profile, these `.loom` paths are stable carriers and must be visible to Git:
+
+- `.loom/bootstrap/manifest.json`
+- `.loom/bootstrap/init-result.json`
+- `.loom/README.md`
+- `.loom/companion/manifest.json`
+- `.loom/companion/README.md`
+- `.loom/companion/repo-interface.json`
+- `.loom/companion/interop.json`
+- `.loom/companion/**` repo companion locators allowed by the repo companion contract
+- `.loom/bin/**` while the target repository uses vendored repo-local runtime
+- `.loom/work-items/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/progress/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/reviews/**` only after execution-control, strong-governance, or Loom-authored review carriers are explicitly enabled
+- `.loom/status/current.md` only after Loom-owned status surface is explicitly enabled
+- `.loom/specs/**` only after Loom-authored spec truth is explicitly enabled
+- `.loom/shadow/**` only when shadow evidence is enabled and the relevant Loom contract requires versioning
+
+`attach-only` defaults to attach metadata, repo companion / interop read surfaces, repo-local verify entry, and required vendored runtime. It must not generate Loom-authored work item, progress, status, review, or spec truth unless adoption intent explicitly upgrades to execution-control.
+
+## Runtime residue must stay unversioned
+
+These paths are runtime scratch, cache, or local attempt residue and should not be committed:
+
+- `.loom/runtime/**`
+- `.loom/tmp/**`
+- `.loom/cache/**`
+- `.loom/attempts/**/raw-logs/**`
+- `.loom/attempts/**/scratch/**`
+- `.loom/local/**`
+- host tokens, local credentials, machine caches, and one-off debug output
+
+If a profile needs versioned attempt evidence, it must define a stable evidence schema and locator first. Raw logs and scratch directories are not stable carriers.
+
+## `.gitignore` discipline
+
+Target repositories must not hide the whole `.loom/` tree with blanket ignores such as:
+
+```gitignore
+.loom/
+.loom/**
+```
+
+Ignore only runtime paths:
+
+```gitignore
+.loom/runtime/
+.loom/tmp/
+.loom/cache/
+.loom/attempts/**/raw-logs/
+.loom/attempts/**/scratch/
+.loom/local/
+```
+
+Bootstrap and verify must fail closed or provide a reviewable ignore repair when a target repository already has a blanket `.loom/` ignore. Do not use `git add -f .loom` as the normal answer because it hides the stable-carrier/runtime-residue boundary.
+
+## Verify failure guidance
+
+When verify finds a stable carrier that is ignored, missing, or not visible, it must report:
+
+- the concrete path
+- the profile or capability that requires the path
+- the reason: `missing`, `ignored`, `untracked`, or `unexpected runtime path`
+- the suggested action: remove blanket ignore, switch to runtime-only ignores, explicitly upgrade adoption intent, or remove a forbidden authored carrier
+
+Runtime paths such as `.loom/runtime/`, `.loom/tmp/`, and `.loom/cache/` must not be reported as required Git-visible carriers.
+
+## External runtime migration
+
+During vendored repo-local runtime, `.loom/bin/**` is auditable runtime provenance and must be Git-visible.
+
+After migration to versioned external runtime, `.loom/bin/**` may stop being committed only when the external runtime contract is satisfied: versioned locator, explicit fallback or rebootstrap path, Git-visible `.loom/companion` and `interop.json`, and rollback to a trusted runtime.

--- a/skills/loom-resume/.loom-runtime/install-layout.json
+++ b/skills/loom-resume/.loom-runtime/install-layout.json
@@ -82,6 +82,7 @@
     "shared/references/adoption/repo-companion-contract.md",
     "shared/references/adoption/repo-interop-contract.md",
     "shared/references/adoption/target-repo-version-contract.md",
+    "shared/references/adoption/loom-surfaces-version-control.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-resume/.loom-runtime/loom-adopt/SKILL.md
+++ b/skills/loom-resume/.loom-runtime/loom-adopt/SKILL.md
@@ -34,6 +34,7 @@ description: 负责把仓库接入 Loom 的初始化场景入口。Use when Code
   - [../shared/references/adoption/zero-friction-adoption-contract.md](../shared/references/adoption/zero-friction-adoption-contract.md)
   - [../shared/references/adoption/lightweight-retrofit-default.md](../shared/references/adoption/lightweight-retrofit-default.md)
   - [../shared/references/adoption/routing-and-checkpoints.md](../shared/references/adoption/routing-and-checkpoints.md)
+  - [../shared/references/adoption/loom-surfaces-version-control.md](../shared/references/adoption/loom-surfaces-version-control.md)
   - [../shared/references/harness/fact-chain-contract.md](../shared/references/harness/fact-chain-contract.md)
   - [../loom-init/references/input-signals.md](../loom-init/references/input-signals.md)
   - [../loom-init/references/output-contract.md](../loom-init/references/output-contract.md)

--- a/skills/loom-resume/.loom-runtime/loom-init/SKILL.md
+++ b/skills/loom-resume/.loom-runtime/loom-init/SKILL.md
@@ -82,6 +82,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - `skills/shared/references/adoption/routing-and-checkpoints.md`
   - `skills/shared/references/adoption/lightweight-retrofit-default.md`
   - `skills/shared/references/adoption/deep-existing-repo-default.md`
+  - `skills/shared/references/adoption/loom-surfaces-version-control.md`
 - `skills/shared/references/harness/recovery-model.md`
 - `skills/shared/references/harness/fact-chain-contract.md`
 - `skills/shared/references/harness/item-context-contract.md`

--- a/skills/loom-resume/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
@@ -1,0 +1,80 @@
+# Loom Surfaces Version Control Policy
+
+Authoritative source: `docs/adoption/loom-surfaces-version-control.md`.
+
+This mirrored reference exists for executable skills that need local shared adoption context. Do not extend this mirror with independent rules; update the authoritative adoption contract instead.
+
+## Stable carriers must be Git-visible
+
+When generated or enabled by the selected adoption profile, these `.loom` paths are stable carriers and must be visible to Git:
+
+- `.loom/bootstrap/manifest.json`
+- `.loom/bootstrap/init-result.json`
+- `.loom/README.md`
+- `.loom/companion/manifest.json`
+- `.loom/companion/README.md`
+- `.loom/companion/repo-interface.json`
+- `.loom/companion/interop.json`
+- `.loom/companion/**` repo companion locators allowed by the repo companion contract
+- `.loom/bin/**` while the target repository uses vendored repo-local runtime
+- `.loom/work-items/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/progress/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/reviews/**` only after execution-control, strong-governance, or Loom-authored review carriers are explicitly enabled
+- `.loom/status/current.md` only after Loom-owned status surface is explicitly enabled
+- `.loom/specs/**` only after Loom-authored spec truth is explicitly enabled
+- `.loom/shadow/**` only when shadow evidence is enabled and the relevant Loom contract requires versioning
+
+`attach-only` defaults to attach metadata, repo companion / interop read surfaces, repo-local verify entry, and required vendored runtime. It must not generate Loom-authored work item, progress, status, review, or spec truth unless adoption intent explicitly upgrades to execution-control.
+
+## Runtime residue must stay unversioned
+
+These paths are runtime scratch, cache, or local attempt residue and should not be committed:
+
+- `.loom/runtime/**`
+- `.loom/tmp/**`
+- `.loom/cache/**`
+- `.loom/attempts/**/raw-logs/**`
+- `.loom/attempts/**/scratch/**`
+- `.loom/local/**`
+- host tokens, local credentials, machine caches, and one-off debug output
+
+If a profile needs versioned attempt evidence, it must define a stable evidence schema and locator first. Raw logs and scratch directories are not stable carriers.
+
+## `.gitignore` discipline
+
+Target repositories must not hide the whole `.loom/` tree with blanket ignores such as:
+
+```gitignore
+.loom/
+.loom/**
+```
+
+Ignore only runtime paths:
+
+```gitignore
+.loom/runtime/
+.loom/tmp/
+.loom/cache/
+.loom/attempts/**/raw-logs/
+.loom/attempts/**/scratch/
+.loom/local/
+```
+
+Bootstrap and verify must fail closed or provide a reviewable ignore repair when a target repository already has a blanket `.loom/` ignore. Do not use `git add -f .loom` as the normal answer because it hides the stable-carrier/runtime-residue boundary.
+
+## Verify failure guidance
+
+When verify finds a stable carrier that is ignored, missing, or not visible, it must report:
+
+- the concrete path
+- the profile or capability that requires the path
+- the reason: `missing`, `ignored`, `untracked`, or `unexpected runtime path`
+- the suggested action: remove blanket ignore, switch to runtime-only ignores, explicitly upgrade adoption intent, or remove a forbidden authored carrier
+
+Runtime paths such as `.loom/runtime/`, `.loom/tmp/`, and `.loom/cache/` must not be reported as required Git-visible carriers.
+
+## External runtime migration
+
+During vendored repo-local runtime, `.loom/bin/**` is auditable runtime provenance and must be Git-visible.
+
+After migration to versioned external runtime, `.loom/bin/**` may stop being committed only when the external runtime contract is satisfied: versioned locator, explicit fallback or rebootstrap path, Git-visible `.loom/companion` and `interop.json`, and rollback to a trusted runtime.

--- a/skills/loom-retire/.loom-runtime/install-layout.json
+++ b/skills/loom-retire/.loom-runtime/install-layout.json
@@ -82,6 +82,7 @@
     "shared/references/adoption/repo-companion-contract.md",
     "shared/references/adoption/repo-interop-contract.md",
     "shared/references/adoption/target-repo-version-contract.md",
+    "shared/references/adoption/loom-surfaces-version-control.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-retire/.loom-runtime/loom-adopt/SKILL.md
+++ b/skills/loom-retire/.loom-runtime/loom-adopt/SKILL.md
@@ -34,6 +34,7 @@ description: 负责把仓库接入 Loom 的初始化场景入口。Use when Code
   - [../shared/references/adoption/zero-friction-adoption-contract.md](../shared/references/adoption/zero-friction-adoption-contract.md)
   - [../shared/references/adoption/lightweight-retrofit-default.md](../shared/references/adoption/lightweight-retrofit-default.md)
   - [../shared/references/adoption/routing-and-checkpoints.md](../shared/references/adoption/routing-and-checkpoints.md)
+  - [../shared/references/adoption/loom-surfaces-version-control.md](../shared/references/adoption/loom-surfaces-version-control.md)
   - [../shared/references/harness/fact-chain-contract.md](../shared/references/harness/fact-chain-contract.md)
   - [../loom-init/references/input-signals.md](../loom-init/references/input-signals.md)
   - [../loom-init/references/output-contract.md](../loom-init/references/output-contract.md)

--- a/skills/loom-retire/.loom-runtime/loom-init/SKILL.md
+++ b/skills/loom-retire/.loom-runtime/loom-init/SKILL.md
@@ -82,6 +82,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - `skills/shared/references/adoption/routing-and-checkpoints.md`
   - `skills/shared/references/adoption/lightweight-retrofit-default.md`
   - `skills/shared/references/adoption/deep-existing-repo-default.md`
+  - `skills/shared/references/adoption/loom-surfaces-version-control.md`
 - `skills/shared/references/harness/recovery-model.md`
 - `skills/shared/references/harness/fact-chain-contract.md`
 - `skills/shared/references/harness/item-context-contract.md`

--- a/skills/loom-retire/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
@@ -1,0 +1,80 @@
+# Loom Surfaces Version Control Policy
+
+Authoritative source: `docs/adoption/loom-surfaces-version-control.md`.
+
+This mirrored reference exists for executable skills that need local shared adoption context. Do not extend this mirror with independent rules; update the authoritative adoption contract instead.
+
+## Stable carriers must be Git-visible
+
+When generated or enabled by the selected adoption profile, these `.loom` paths are stable carriers and must be visible to Git:
+
+- `.loom/bootstrap/manifest.json`
+- `.loom/bootstrap/init-result.json`
+- `.loom/README.md`
+- `.loom/companion/manifest.json`
+- `.loom/companion/README.md`
+- `.loom/companion/repo-interface.json`
+- `.loom/companion/interop.json`
+- `.loom/companion/**` repo companion locators allowed by the repo companion contract
+- `.loom/bin/**` while the target repository uses vendored repo-local runtime
+- `.loom/work-items/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/progress/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/reviews/**` only after execution-control, strong-governance, or Loom-authored review carriers are explicitly enabled
+- `.loom/status/current.md` only after Loom-owned status surface is explicitly enabled
+- `.loom/specs/**` only after Loom-authored spec truth is explicitly enabled
+- `.loom/shadow/**` only when shadow evidence is enabled and the relevant Loom contract requires versioning
+
+`attach-only` defaults to attach metadata, repo companion / interop read surfaces, repo-local verify entry, and required vendored runtime. It must not generate Loom-authored work item, progress, status, review, or spec truth unless adoption intent explicitly upgrades to execution-control.
+
+## Runtime residue must stay unversioned
+
+These paths are runtime scratch, cache, or local attempt residue and should not be committed:
+
+- `.loom/runtime/**`
+- `.loom/tmp/**`
+- `.loom/cache/**`
+- `.loom/attempts/**/raw-logs/**`
+- `.loom/attempts/**/scratch/**`
+- `.loom/local/**`
+- host tokens, local credentials, machine caches, and one-off debug output
+
+If a profile needs versioned attempt evidence, it must define a stable evidence schema and locator first. Raw logs and scratch directories are not stable carriers.
+
+## `.gitignore` discipline
+
+Target repositories must not hide the whole `.loom/` tree with blanket ignores such as:
+
+```gitignore
+.loom/
+.loom/**
+```
+
+Ignore only runtime paths:
+
+```gitignore
+.loom/runtime/
+.loom/tmp/
+.loom/cache/
+.loom/attempts/**/raw-logs/
+.loom/attempts/**/scratch/
+.loom/local/
+```
+
+Bootstrap and verify must fail closed or provide a reviewable ignore repair when a target repository already has a blanket `.loom/` ignore. Do not use `git add -f .loom` as the normal answer because it hides the stable-carrier/runtime-residue boundary.
+
+## Verify failure guidance
+
+When verify finds a stable carrier that is ignored, missing, or not visible, it must report:
+
+- the concrete path
+- the profile or capability that requires the path
+- the reason: `missing`, `ignored`, `untracked`, or `unexpected runtime path`
+- the suggested action: remove blanket ignore, switch to runtime-only ignores, explicitly upgrade adoption intent, or remove a forbidden authored carrier
+
+Runtime paths such as `.loom/runtime/`, `.loom/tmp/`, and `.loom/cache/` must not be reported as required Git-visible carriers.
+
+## External runtime migration
+
+During vendored repo-local runtime, `.loom/bin/**` is auditable runtime provenance and must be Git-visible.
+
+After migration to versioned external runtime, `.loom/bin/**` may stop being committed only when the external runtime contract is satisfied: versioned locator, explicit fallback or rebootstrap path, Git-visible `.loom/companion` and `interop.json`, and rollback to a trusted runtime.

--- a/skills/loom-review/.loom-runtime/install-layout.json
+++ b/skills/loom-review/.loom-runtime/install-layout.json
@@ -82,6 +82,7 @@
     "shared/references/adoption/repo-companion-contract.md",
     "shared/references/adoption/repo-interop-contract.md",
     "shared/references/adoption/target-repo-version-contract.md",
+    "shared/references/adoption/loom-surfaces-version-control.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-review/.loom-runtime/loom-adopt/SKILL.md
+++ b/skills/loom-review/.loom-runtime/loom-adopt/SKILL.md
@@ -34,6 +34,7 @@ description: 负责把仓库接入 Loom 的初始化场景入口。Use when Code
   - [../shared/references/adoption/zero-friction-adoption-contract.md](../shared/references/adoption/zero-friction-adoption-contract.md)
   - [../shared/references/adoption/lightweight-retrofit-default.md](../shared/references/adoption/lightweight-retrofit-default.md)
   - [../shared/references/adoption/routing-and-checkpoints.md](../shared/references/adoption/routing-and-checkpoints.md)
+  - [../shared/references/adoption/loom-surfaces-version-control.md](../shared/references/adoption/loom-surfaces-version-control.md)
   - [../shared/references/harness/fact-chain-contract.md](../shared/references/harness/fact-chain-contract.md)
   - [../loom-init/references/input-signals.md](../loom-init/references/input-signals.md)
   - [../loom-init/references/output-contract.md](../loom-init/references/output-contract.md)

--- a/skills/loom-review/.loom-runtime/loom-init/SKILL.md
+++ b/skills/loom-review/.loom-runtime/loom-init/SKILL.md
@@ -82,6 +82,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - `skills/shared/references/adoption/routing-and-checkpoints.md`
   - `skills/shared/references/adoption/lightweight-retrofit-default.md`
   - `skills/shared/references/adoption/deep-existing-repo-default.md`
+  - `skills/shared/references/adoption/loom-surfaces-version-control.md`
 - `skills/shared/references/harness/recovery-model.md`
 - `skills/shared/references/harness/fact-chain-contract.md`
 - `skills/shared/references/harness/item-context-contract.md`

--- a/skills/loom-review/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
+++ b/skills/loom-review/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
@@ -1,0 +1,80 @@
+# Loom Surfaces Version Control Policy
+
+Authoritative source: `docs/adoption/loom-surfaces-version-control.md`.
+
+This mirrored reference exists for executable skills that need local shared adoption context. Do not extend this mirror with independent rules; update the authoritative adoption contract instead.
+
+## Stable carriers must be Git-visible
+
+When generated or enabled by the selected adoption profile, these `.loom` paths are stable carriers and must be visible to Git:
+
+- `.loom/bootstrap/manifest.json`
+- `.loom/bootstrap/init-result.json`
+- `.loom/README.md`
+- `.loom/companion/manifest.json`
+- `.loom/companion/README.md`
+- `.loom/companion/repo-interface.json`
+- `.loom/companion/interop.json`
+- `.loom/companion/**` repo companion locators allowed by the repo companion contract
+- `.loom/bin/**` while the target repository uses vendored repo-local runtime
+- `.loom/work-items/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/progress/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/reviews/**` only after execution-control, strong-governance, or Loom-authored review carriers are explicitly enabled
+- `.loom/status/current.md` only after Loom-owned status surface is explicitly enabled
+- `.loom/specs/**` only after Loom-authored spec truth is explicitly enabled
+- `.loom/shadow/**` only when shadow evidence is enabled and the relevant Loom contract requires versioning
+
+`attach-only` defaults to attach metadata, repo companion / interop read surfaces, repo-local verify entry, and required vendored runtime. It must not generate Loom-authored work item, progress, status, review, or spec truth unless adoption intent explicitly upgrades to execution-control.
+
+## Runtime residue must stay unversioned
+
+These paths are runtime scratch, cache, or local attempt residue and should not be committed:
+
+- `.loom/runtime/**`
+- `.loom/tmp/**`
+- `.loom/cache/**`
+- `.loom/attempts/**/raw-logs/**`
+- `.loom/attempts/**/scratch/**`
+- `.loom/local/**`
+- host tokens, local credentials, machine caches, and one-off debug output
+
+If a profile needs versioned attempt evidence, it must define a stable evidence schema and locator first. Raw logs and scratch directories are not stable carriers.
+
+## `.gitignore` discipline
+
+Target repositories must not hide the whole `.loom/` tree with blanket ignores such as:
+
+```gitignore
+.loom/
+.loom/**
+```
+
+Ignore only runtime paths:
+
+```gitignore
+.loom/runtime/
+.loom/tmp/
+.loom/cache/
+.loom/attempts/**/raw-logs/
+.loom/attempts/**/scratch/
+.loom/local/
+```
+
+Bootstrap and verify must fail closed or provide a reviewable ignore repair when a target repository already has a blanket `.loom/` ignore. Do not use `git add -f .loom` as the normal answer because it hides the stable-carrier/runtime-residue boundary.
+
+## Verify failure guidance
+
+When verify finds a stable carrier that is ignored, missing, or not visible, it must report:
+
+- the concrete path
+- the profile or capability that requires the path
+- the reason: `missing`, `ignored`, `untracked`, or `unexpected runtime path`
+- the suggested action: remove blanket ignore, switch to runtime-only ignores, explicitly upgrade adoption intent, or remove a forbidden authored carrier
+
+Runtime paths such as `.loom/runtime/`, `.loom/tmp/`, and `.loom/cache/` must not be reported as required Git-visible carriers.
+
+## External runtime migration
+
+During vendored repo-local runtime, `.loom/bin/**` is auditable runtime provenance and must be Git-visible.
+
+After migration to versioned external runtime, `.loom/bin/**` may stop being committed only when the external runtime contract is satisfied: versioned locator, explicit fallback or rebootstrap path, Git-visible `.loom/companion` and `interop.json`, and rollback to a trusted runtime.

--- a/skills/loom-spec-review/.loom-runtime/install-layout.json
+++ b/skills/loom-spec-review/.loom-runtime/install-layout.json
@@ -82,6 +82,7 @@
     "shared/references/adoption/repo-companion-contract.md",
     "shared/references/adoption/repo-interop-contract.md",
     "shared/references/adoption/target-repo-version-contract.md",
+    "shared/references/adoption/loom-surfaces-version-control.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-spec-review/.loom-runtime/loom-adopt/SKILL.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-adopt/SKILL.md
@@ -34,6 +34,7 @@ description: 负责把仓库接入 Loom 的初始化场景入口。Use when Code
   - [../shared/references/adoption/zero-friction-adoption-contract.md](../shared/references/adoption/zero-friction-adoption-contract.md)
   - [../shared/references/adoption/lightweight-retrofit-default.md](../shared/references/adoption/lightweight-retrofit-default.md)
   - [../shared/references/adoption/routing-and-checkpoints.md](../shared/references/adoption/routing-and-checkpoints.md)
+  - [../shared/references/adoption/loom-surfaces-version-control.md](../shared/references/adoption/loom-surfaces-version-control.md)
   - [../shared/references/harness/fact-chain-contract.md](../shared/references/harness/fact-chain-contract.md)
   - [../loom-init/references/input-signals.md](../loom-init/references/input-signals.md)
   - [../loom-init/references/output-contract.md](../loom-init/references/output-contract.md)

--- a/skills/loom-spec-review/.loom-runtime/loom-init/SKILL.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-init/SKILL.md
@@ -82,6 +82,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - `skills/shared/references/adoption/routing-and-checkpoints.md`
   - `skills/shared/references/adoption/lightweight-retrofit-default.md`
   - `skills/shared/references/adoption/deep-existing-repo-default.md`
+  - `skills/shared/references/adoption/loom-surfaces-version-control.md`
 - `skills/shared/references/harness/recovery-model.md`
 - `skills/shared/references/harness/fact-chain-contract.md`
 - `skills/shared/references/harness/item-context-contract.md`

--- a/skills/loom-spec-review/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
@@ -1,0 +1,80 @@
+# Loom Surfaces Version Control Policy
+
+Authoritative source: `docs/adoption/loom-surfaces-version-control.md`.
+
+This mirrored reference exists for executable skills that need local shared adoption context. Do not extend this mirror with independent rules; update the authoritative adoption contract instead.
+
+## Stable carriers must be Git-visible
+
+When generated or enabled by the selected adoption profile, these `.loom` paths are stable carriers and must be visible to Git:
+
+- `.loom/bootstrap/manifest.json`
+- `.loom/bootstrap/init-result.json`
+- `.loom/README.md`
+- `.loom/companion/manifest.json`
+- `.loom/companion/README.md`
+- `.loom/companion/repo-interface.json`
+- `.loom/companion/interop.json`
+- `.loom/companion/**` repo companion locators allowed by the repo companion contract
+- `.loom/bin/**` while the target repository uses vendored repo-local runtime
+- `.loom/work-items/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/progress/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/reviews/**` only after execution-control, strong-governance, or Loom-authored review carriers are explicitly enabled
+- `.loom/status/current.md` only after Loom-owned status surface is explicitly enabled
+- `.loom/specs/**` only after Loom-authored spec truth is explicitly enabled
+- `.loom/shadow/**` only when shadow evidence is enabled and the relevant Loom contract requires versioning
+
+`attach-only` defaults to attach metadata, repo companion / interop read surfaces, repo-local verify entry, and required vendored runtime. It must not generate Loom-authored work item, progress, status, review, or spec truth unless adoption intent explicitly upgrades to execution-control.
+
+## Runtime residue must stay unversioned
+
+These paths are runtime scratch, cache, or local attempt residue and should not be committed:
+
+- `.loom/runtime/**`
+- `.loom/tmp/**`
+- `.loom/cache/**`
+- `.loom/attempts/**/raw-logs/**`
+- `.loom/attempts/**/scratch/**`
+- `.loom/local/**`
+- host tokens, local credentials, machine caches, and one-off debug output
+
+If a profile needs versioned attempt evidence, it must define a stable evidence schema and locator first. Raw logs and scratch directories are not stable carriers.
+
+## `.gitignore` discipline
+
+Target repositories must not hide the whole `.loom/` tree with blanket ignores such as:
+
+```gitignore
+.loom/
+.loom/**
+```
+
+Ignore only runtime paths:
+
+```gitignore
+.loom/runtime/
+.loom/tmp/
+.loom/cache/
+.loom/attempts/**/raw-logs/
+.loom/attempts/**/scratch/
+.loom/local/
+```
+
+Bootstrap and verify must fail closed or provide a reviewable ignore repair when a target repository already has a blanket `.loom/` ignore. Do not use `git add -f .loom` as the normal answer because it hides the stable-carrier/runtime-residue boundary.
+
+## Verify failure guidance
+
+When verify finds a stable carrier that is ignored, missing, or not visible, it must report:
+
+- the concrete path
+- the profile or capability that requires the path
+- the reason: `missing`, `ignored`, `untracked`, or `unexpected runtime path`
+- the suggested action: remove blanket ignore, switch to runtime-only ignores, explicitly upgrade adoption intent, or remove a forbidden authored carrier
+
+Runtime paths such as `.loom/runtime/`, `.loom/tmp/`, and `.loom/cache/` must not be reported as required Git-visible carriers.
+
+## External runtime migration
+
+During vendored repo-local runtime, `.loom/bin/**` is auditable runtime provenance and must be Git-visible.
+
+After migration to versioned external runtime, `.loom/bin/**` may stop being committed only when the external runtime contract is satisfied: versioned locator, explicit fallback or rebootstrap path, Git-visible `.loom/companion` and `interop.json`, and rollback to a trusted runtime.

--- a/skills/loom-story/.loom-runtime/install-layout.json
+++ b/skills/loom-story/.loom-runtime/install-layout.json
@@ -82,6 +82,7 @@
     "shared/references/adoption/repo-companion-contract.md",
     "shared/references/adoption/repo-interop-contract.md",
     "shared/references/adoption/target-repo-version-contract.md",
+    "shared/references/adoption/loom-surfaces-version-control.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-story/.loom-runtime/loom-adopt/SKILL.md
+++ b/skills/loom-story/.loom-runtime/loom-adopt/SKILL.md
@@ -34,6 +34,7 @@ description: 负责把仓库接入 Loom 的初始化场景入口。Use when Code
   - [../shared/references/adoption/zero-friction-adoption-contract.md](../shared/references/adoption/zero-friction-adoption-contract.md)
   - [../shared/references/adoption/lightweight-retrofit-default.md](../shared/references/adoption/lightweight-retrofit-default.md)
   - [../shared/references/adoption/routing-and-checkpoints.md](../shared/references/adoption/routing-and-checkpoints.md)
+  - [../shared/references/adoption/loom-surfaces-version-control.md](../shared/references/adoption/loom-surfaces-version-control.md)
   - [../shared/references/harness/fact-chain-contract.md](../shared/references/harness/fact-chain-contract.md)
   - [../loom-init/references/input-signals.md](../loom-init/references/input-signals.md)
   - [../loom-init/references/output-contract.md](../loom-init/references/output-contract.md)

--- a/skills/loom-story/.loom-runtime/loom-init/SKILL.md
+++ b/skills/loom-story/.loom-runtime/loom-init/SKILL.md
@@ -82,6 +82,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - `skills/shared/references/adoption/routing-and-checkpoints.md`
   - `skills/shared/references/adoption/lightweight-retrofit-default.md`
   - `skills/shared/references/adoption/deep-existing-repo-default.md`
+  - `skills/shared/references/adoption/loom-surfaces-version-control.md`
 - `skills/shared/references/harness/recovery-model.md`
 - `skills/shared/references/harness/fact-chain-contract.md`
 - `skills/shared/references/harness/item-context-contract.md`

--- a/skills/loom-story/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
+++ b/skills/loom-story/.loom-runtime/shared/references/adoption/loom-surfaces-version-control.md
@@ -1,0 +1,80 @@
+# Loom Surfaces Version Control Policy
+
+Authoritative source: `docs/adoption/loom-surfaces-version-control.md`.
+
+This mirrored reference exists for executable skills that need local shared adoption context. Do not extend this mirror with independent rules; update the authoritative adoption contract instead.
+
+## Stable carriers must be Git-visible
+
+When generated or enabled by the selected adoption profile, these `.loom` paths are stable carriers and must be visible to Git:
+
+- `.loom/bootstrap/manifest.json`
+- `.loom/bootstrap/init-result.json`
+- `.loom/README.md`
+- `.loom/companion/manifest.json`
+- `.loom/companion/README.md`
+- `.loom/companion/repo-interface.json`
+- `.loom/companion/interop.json`
+- `.loom/companion/**` repo companion locators allowed by the repo companion contract
+- `.loom/bin/**` while the target repository uses vendored repo-local runtime
+- `.loom/work-items/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/progress/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/reviews/**` only after execution-control, strong-governance, or Loom-authored review carriers are explicitly enabled
+- `.loom/status/current.md` only after Loom-owned status surface is explicitly enabled
+- `.loom/specs/**` only after Loom-authored spec truth is explicitly enabled
+- `.loom/shadow/**` only when shadow evidence is enabled and the relevant Loom contract requires versioning
+
+`attach-only` defaults to attach metadata, repo companion / interop read surfaces, repo-local verify entry, and required vendored runtime. It must not generate Loom-authored work item, progress, status, review, or spec truth unless adoption intent explicitly upgrades to execution-control.
+
+## Runtime residue must stay unversioned
+
+These paths are runtime scratch, cache, or local attempt residue and should not be committed:
+
+- `.loom/runtime/**`
+- `.loom/tmp/**`
+- `.loom/cache/**`
+- `.loom/attempts/**/raw-logs/**`
+- `.loom/attempts/**/scratch/**`
+- `.loom/local/**`
+- host tokens, local credentials, machine caches, and one-off debug output
+
+If a profile needs versioned attempt evidence, it must define a stable evidence schema and locator first. Raw logs and scratch directories are not stable carriers.
+
+## `.gitignore` discipline
+
+Target repositories must not hide the whole `.loom/` tree with blanket ignores such as:
+
+```gitignore
+.loom/
+.loom/**
+```
+
+Ignore only runtime paths:
+
+```gitignore
+.loom/runtime/
+.loom/tmp/
+.loom/cache/
+.loom/attempts/**/raw-logs/
+.loom/attempts/**/scratch/
+.loom/local/
+```
+
+Bootstrap and verify must fail closed or provide a reviewable ignore repair when a target repository already has a blanket `.loom/` ignore. Do not use `git add -f .loom` as the normal answer because it hides the stable-carrier/runtime-residue boundary.
+
+## Verify failure guidance
+
+When verify finds a stable carrier that is ignored, missing, or not visible, it must report:
+
+- the concrete path
+- the profile or capability that requires the path
+- the reason: `missing`, `ignored`, `untracked`, or `unexpected runtime path`
+- the suggested action: remove blanket ignore, switch to runtime-only ignores, explicitly upgrade adoption intent, or remove a forbidden authored carrier
+
+Runtime paths such as `.loom/runtime/`, `.loom/tmp/`, and `.loom/cache/` must not be reported as required Git-visible carriers.
+
+## External runtime migration
+
+During vendored repo-local runtime, `.loom/bin/**` is auditable runtime provenance and must be Git-visible.
+
+After migration to versioned external runtime, `.loom/bin/**` may stop being committed only when the external runtime contract is satisfied: versioned locator, explicit fallback or rebootstrap path, Git-visible `.loom/companion` and `interop.json`, and rollback to a trusted runtime.

--- a/skills/shared/references/adoption/loom-surfaces-version-control.md
+++ b/skills/shared/references/adoption/loom-surfaces-version-control.md
@@ -1,0 +1,80 @@
+# Loom Surfaces Version Control Policy
+
+Authoritative source: `docs/adoption/loom-surfaces-version-control.md`.
+
+This mirrored reference exists for executable skills that need local shared adoption context. Do not extend this mirror with independent rules; update the authoritative adoption contract instead.
+
+## Stable carriers must be Git-visible
+
+When generated or enabled by the selected adoption profile, these `.loom` paths are stable carriers and must be visible to Git:
+
+- `.loom/bootstrap/manifest.json`
+- `.loom/bootstrap/init-result.json`
+- `.loom/README.md`
+- `.loom/companion/manifest.json`
+- `.loom/companion/README.md`
+- `.loom/companion/repo-interface.json`
+- `.loom/companion/interop.json`
+- `.loom/companion/**` repo companion locators allowed by the repo companion contract
+- `.loom/bin/**` while the target repository uses vendored repo-local runtime
+- `.loom/work-items/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/progress/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/reviews/**` only after execution-control, strong-governance, or Loom-authored review carriers are explicitly enabled
+- `.loom/status/current.md` only after Loom-owned status surface is explicitly enabled
+- `.loom/specs/**` only after Loom-authored spec truth is explicitly enabled
+- `.loom/shadow/**` only when shadow evidence is enabled and the relevant Loom contract requires versioning
+
+`attach-only` defaults to attach metadata, repo companion / interop read surfaces, repo-local verify entry, and required vendored runtime. It must not generate Loom-authored work item, progress, status, review, or spec truth unless adoption intent explicitly upgrades to execution-control.
+
+## Runtime residue must stay unversioned
+
+These paths are runtime scratch, cache, or local attempt residue and should not be committed:
+
+- `.loom/runtime/**`
+- `.loom/tmp/**`
+- `.loom/cache/**`
+- `.loom/attempts/**/raw-logs/**`
+- `.loom/attempts/**/scratch/**`
+- `.loom/local/**`
+- host tokens, local credentials, machine caches, and one-off debug output
+
+If a profile needs versioned attempt evidence, it must define a stable evidence schema and locator first. Raw logs and scratch directories are not stable carriers.
+
+## `.gitignore` discipline
+
+Target repositories must not hide the whole `.loom/` tree with blanket ignores such as:
+
+```gitignore
+.loom/
+.loom/**
+```
+
+Ignore only runtime paths:
+
+```gitignore
+.loom/runtime/
+.loom/tmp/
+.loom/cache/
+.loom/attempts/**/raw-logs/
+.loom/attempts/**/scratch/
+.loom/local/
+```
+
+Bootstrap and verify must fail closed or provide a reviewable ignore repair when a target repository already has a blanket `.loom/` ignore. Do not use `git add -f .loom` as the normal answer because it hides the stable-carrier/runtime-residue boundary.
+
+## Verify failure guidance
+
+When verify finds a stable carrier that is ignored, missing, or not visible, it must report:
+
+- the concrete path
+- the profile or capability that requires the path
+- the reason: `missing`, `ignored`, `untracked`, or `unexpected runtime path`
+- the suggested action: remove blanket ignore, switch to runtime-only ignores, explicitly upgrade adoption intent, or remove a forbidden authored carrier
+
+Runtime paths such as `.loom/runtime/`, `.loom/tmp/`, and `.loom/cache/` must not be reported as required Git-visible carriers.
+
+## External runtime migration
+
+During vendored repo-local runtime, `.loom/bin/**` is auditable runtime provenance and must be Git-visible.
+
+After migration to versioned external runtime, `.loom/bin/**` may stop being committed only when the external runtime contract is satisfied: versioned locator, explicit fallback or rebootstrap path, Git-visible `.loom/companion` and `interop.json`, and rollback to a trusted runtime.

--- a/src/skills/install-layout.json
+++ b/src/skills/install-layout.json
@@ -82,6 +82,7 @@
     "shared/references/adoption/repo-companion-contract.md",
     "shared/references/adoption/repo-interop-contract.md",
     "shared/references/adoption/target-repo-version-contract.md",
+    "shared/references/adoption/loom-surfaces-version-control.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/src/skills/loom-adopt/SKILL.md
+++ b/src/skills/loom-adopt/SKILL.md
@@ -34,6 +34,7 @@ description: 负责把仓库接入 Loom 的初始化场景入口。Use when Code
   - [../shared/references/adoption/zero-friction-adoption-contract.md](../shared/references/adoption/zero-friction-adoption-contract.md)
   - [../shared/references/adoption/lightweight-retrofit-default.md](../shared/references/adoption/lightweight-retrofit-default.md)
   - [../shared/references/adoption/routing-and-checkpoints.md](../shared/references/adoption/routing-and-checkpoints.md)
+  - [../shared/references/adoption/loom-surfaces-version-control.md](../shared/references/adoption/loom-surfaces-version-control.md)
   - [../shared/references/harness/fact-chain-contract.md](../shared/references/harness/fact-chain-contract.md)
   - [../loom-init/references/input-signals.md](../loom-init/references/input-signals.md)
   - [../loom-init/references/output-contract.md](../loom-init/references/output-contract.md)

--- a/src/skills/loom-init/SKILL.md
+++ b/src/skills/loom-init/SKILL.md
@@ -82,6 +82,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - `skills/shared/references/adoption/routing-and-checkpoints.md`
   - `skills/shared/references/adoption/lightweight-retrofit-default.md`
   - `skills/shared/references/adoption/deep-existing-repo-default.md`
+  - `skills/shared/references/adoption/loom-surfaces-version-control.md`
 - `skills/shared/references/harness/recovery-model.md`
 - `skills/shared/references/harness/fact-chain-contract.md`
 - `skills/shared/references/harness/item-context-contract.md`

--- a/src/skills/shared/references/adoption/loom-surfaces-version-control.md
+++ b/src/skills/shared/references/adoption/loom-surfaces-version-control.md
@@ -1,0 +1,80 @@
+# Loom Surfaces Version Control Policy
+
+Authoritative source: `docs/adoption/loom-surfaces-version-control.md`.
+
+This mirrored reference exists for executable skills that need local shared adoption context. Do not extend this mirror with independent rules; update the authoritative adoption contract instead.
+
+## Stable carriers must be Git-visible
+
+When generated or enabled by the selected adoption profile, these `.loom` paths are stable carriers and must be visible to Git:
+
+- `.loom/bootstrap/manifest.json`
+- `.loom/bootstrap/init-result.json`
+- `.loom/README.md`
+- `.loom/companion/manifest.json`
+- `.loom/companion/README.md`
+- `.loom/companion/repo-interface.json`
+- `.loom/companion/interop.json`
+- `.loom/companion/**` repo companion locators allowed by the repo companion contract
+- `.loom/bin/**` while the target repository uses vendored repo-local runtime
+- `.loom/work-items/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/progress/**` only after execution-control or strong-governance is explicitly enabled
+- `.loom/reviews/**` only after execution-control, strong-governance, or Loom-authored review carriers are explicitly enabled
+- `.loom/status/current.md` only after Loom-owned status surface is explicitly enabled
+- `.loom/specs/**` only after Loom-authored spec truth is explicitly enabled
+- `.loom/shadow/**` only when shadow evidence is enabled and the relevant Loom contract requires versioning
+
+`attach-only` defaults to attach metadata, repo companion / interop read surfaces, repo-local verify entry, and required vendored runtime. It must not generate Loom-authored work item, progress, status, review, or spec truth unless adoption intent explicitly upgrades to execution-control.
+
+## Runtime residue must stay unversioned
+
+These paths are runtime scratch, cache, or local attempt residue and should not be committed:
+
+- `.loom/runtime/**`
+- `.loom/tmp/**`
+- `.loom/cache/**`
+- `.loom/attempts/**/raw-logs/**`
+- `.loom/attempts/**/scratch/**`
+- `.loom/local/**`
+- host tokens, local credentials, machine caches, and one-off debug output
+
+If a profile needs versioned attempt evidence, it must define a stable evidence schema and locator first. Raw logs and scratch directories are not stable carriers.
+
+## `.gitignore` discipline
+
+Target repositories must not hide the whole `.loom/` tree with blanket ignores such as:
+
+```gitignore
+.loom/
+.loom/**
+```
+
+Ignore only runtime paths:
+
+```gitignore
+.loom/runtime/
+.loom/tmp/
+.loom/cache/
+.loom/attempts/**/raw-logs/
+.loom/attempts/**/scratch/
+.loom/local/
+```
+
+Bootstrap and verify must fail closed or provide a reviewable ignore repair when a target repository already has a blanket `.loom/` ignore. Do not use `git add -f .loom` as the normal answer because it hides the stable-carrier/runtime-residue boundary.
+
+## Verify failure guidance
+
+When verify finds a stable carrier that is ignored, missing, or not visible, it must report:
+
+- the concrete path
+- the profile or capability that requires the path
+- the reason: `missing`, `ignored`, `untracked`, or `unexpected runtime path`
+- the suggested action: remove blanket ignore, switch to runtime-only ignores, explicitly upgrade adoption intent, or remove a forbidden authored carrier
+
+Runtime paths such as `.loom/runtime/`, `.loom/tmp/`, and `.loom/cache/` must not be reported as required Git-visible carriers.
+
+## External runtime migration
+
+During vendored repo-local runtime, `.loom/bin/**` is auditable runtime provenance and must be Git-visible.
+
+After migration to versioned external runtime, `.loom/bin/**` may stop being committed only when the external runtime contract is satisfied: versioned locator, explicit fallback or rebootstrap path, Git-visible `.loom/companion` and `interop.json`, and rollback to a trusted runtime.


### PR DESCRIPTION
## Summary
- Closes #783.
- Loom Work Item: WI-783
- Adds a canonical adoption contract for target-repo .loom version-control policy.
- Links the policy from zero-friction adoption, external runtime, Codex install, unified install, and adoption index docs.
- Adds the policy to src/skills shared references and regenerates the checked-in skills surface.
- Bumps the installer package version for the generated skills payload change.

## Validation
- make skills-check
- node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main
- make loom-check
- python3 tools/loom_flow.py state-check --target . --item WI-783
- python3 tools/loom_flow.py checkpoint merge --target . --item WI-783
- python3 tools/loom_flow.py shadow-parity --target .
- python3 tools/loom_flow.py adopt verify --target . --item WI-783

## Checkpoint #783
Completed: documented stable Git-visible .loom carriers, runtime scratch paths, blanket .loom ignore guidance, verify failure guidance, external runtime migration expectations, installed skill reference propagation, and PR gate metadata.
Remaining risk: behavior enforcement is intentionally left to #781/#782, which are later checkpoints in this milestone.