### PR TITLE
feat(cli): 冻结 CLI 控制面与 installed-state 合同

### DIFF
--- a/.loom/bootstrap/init-result.json
+++ b/.loom/bootstrap/init-result.json
@@ -76,9 +76,9 @@
     "mode": "work-item + recovery-entry + derived status-surface",
     "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
     "entry_points": {
-      "current_item_id": "WI-792",
-      "work_item": ".loom/work-items/WI-792.md",
-      "recovery_entry": ".loom/progress/WI-792.md",
+      "current_item_id": "WI-898",
+      "work_item": ".loom/work-items/WI-898.md",
+      "recovery_entry": ".loom/progress/WI-898.md",
       "status_surface": ".loom/status/current.md"
     }
   },

--- a/.loom/progress/WI-792.md
+++ b/.loom/progress/WI-792.md
@@ -3,13 +3,13 @@
 ## Dynamic Facts
 
 - Item ID: WI-792
-- Current Checkpoint: merge-ready checkpoint
-- Current Stop: PR #991 CI blockers were repaired locally: active carrier is WI-792, stale WI-968 carrier is terminal, installer metadata is bumped to 0.1.148, distributed skill runtime is regenerated, PR body declares Loom Work Item WI-792, and shadow carriers are refreshed.
-- Next Step: Commit and push the distributed runtime sync and refreshed review evidence, wait for PR #991 required checks, then merge before GitHub issue/Project closeout.
+- Current Checkpoint: merged
+- Current Stop: PR #991 merged into main at 65190520537e080e5791e8184560bc5d336076e3 on 2026-05-24; WI-792 is no longer the active workspace item.
+- Next Step: None for WI-792 in this workspace; #885 CLI-first phase continues through WI-898.
 - Blockers: None recorded.
-- Latest Validation Summary: Passed for PR #991 CI blocker refresh: node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main -> OK (0.1.147 -> 0.1.148); npm --prefix packages/loom-installer run check:versions -> OK; python3 tools/skills_surface.py generate refreshed distributed runtime; python3 tools/skills_surface.py check -> OK; git diff --check -> OK; python3 -m py_compile src/skills/shared/scripts/loom_flow.py skills/shared/scripts/loom_flow.py src/skills/shared/scripts/loom_check.py skills/shared/scripts/loom_check.py -> OK; root-self-governance local equivalent -> OK for WI-792; carrier refresh dry-run -> pass with no refresh_needed. Cleanup removed pycache from this run.
-- Recovery Boundary: WI-792 owns PR #991 phase closeout implementation, closeout evidence, carrier binding, stale WI-968 terminal cleanup, shadow refresh, and installer version metadata required by this branch. It does not alter retained #792 scope beyond the user-approved #872/#953 inclusion.
-- Current Lane: ci-fix/pr-gate-complete
+- Latest Validation Summary: PR #991 merged at 65190520537e080e5791e8184560bc5d336076e3; current branch starts from that merge commit. WI-792 retained evidence is terminal and must not block later PR gates.
+- Recovery Boundary: Retired historical carrier for PR #991 / issue #792 closeout; active execution is WI-898.
+- Current Lane: merged PR #991
 
 ## Execution Ledger
 

--- a/.loom/progress/WI-898.md
+++ b/.loom/progress/WI-898.md
@@ -3,13 +3,13 @@
 ## Dynamic Facts
 
 - Item ID: WI-898
-- Current Checkpoint: admission checkpoint
-- Current Stop: Work item scaffolded and waiting for the first execution pass.
-- Next Step: Write the first recovery update for this work item.
+- Current Checkpoint: merge-ready checkpoint
+- Current Stop: PR #992 has CLI-first control-plane and installed-state v2 implementation, docs, fixtures, and CI carrier baseline prepared for merge gate consumption.
+- Next Step: Consume PR #992 checks and merge after loom-pr-merge-gate, loom-check, and node installer gate pass.
 - Blockers: None recorded.
-- Latest Validation Summary: No validation recorded yet.
-- Recovery Boundary: Work item scaffolded at `.loom/work-items/WI-898.md`.
-- Current Lane: not yet assigned
+- Latest Validation Summary: Passed on branch work/886-cli-core-installed-state at 289ad5c1802e6cce1021ca93db11a78c12695587: python3 tools/loom.py version --json; python3 tools/loom.py installed-state validate --target examples/new-project --json expected fail-closed with legacy hints; make cli-contract-check; make check with loom_check OK over 40 source/distribution surfaces.
+- Recovery Boundary: WI-898 owns PR #992 for #886/#887 foundation scope only: CLI command matrix, JSON/fail-closed contract, installed-state v2 schema, installation graph, and show/validate/export fixtures. Later #888+ FR execution chains remain reserved.
+- Current Lane: cli-first/core-installed-state
 
 ## Execution Ledger
 

--- a/.loom/progress/WI-898.md
+++ b/.loom/progress/WI-898.md
@@ -1,0 +1,21 @@
+# WI-898 Progress
+
+## Dynamic Facts
+
+- Item ID: WI-898
+- Current Checkpoint: admission checkpoint
+- Current Stop: Work item scaffolded and waiting for the first execution pass.
+- Next Step: Write the first recovery update for this work item.
+- Blockers: None recorded.
+- Latest Validation Summary: No validation recorded yet.
+- Recovery Boundary: Work item scaffolded at `.loom/work-items/WI-898.md`.
+- Current Lane: not yet assigned
+
+## Execution Ledger
+
+- Ledger Binding: recovery_entry
+- Plan Locator: not_applicable
+- Acceptance Locator: not_applicable
+- Validation Evidence Locator: not_applicable
+- Handoff Notes Locator: not_applicable
+- Evidence Freshness: not_applicable

--- a/.loom/reviews/WI-898.json
+++ b/.loom/reviews/WI-898.json
@@ -1,39 +1,23 @@
 {
   "schema_version": "loom-review/v1",
   "item_id": "WI-898",
-  "decision": "fallback",
-  "kind": "general_review",
-  "summary": "Formal review has not been recorded yet.",
-  "reviewer": "not yet assigned",
-  "reviewed_head": "289ad5c1802e6cce1021ca93db11a78c12695587",
-  "reviewed_validation_summary": "No validation recorded yet.",
-  "fallback_to": "admission",
-  "findings": [
-    {
-      "id": "scaffolded-block-1",
-      "summary": "Review artifact scaffolded but not yet concluded.",
-      "severity": "block",
-      "rebuttal": null,
-      "disposition": {
-        "status": "rejected",
-        "summary": "Scaffold placeholder must be replaced by a real formal review conclusion."
-      }
-    },
-    {
-      "id": "scaffolded-warn-1",
-      "summary": "Record a real review before asking merge checkpoint to consume it.",
-      "severity": "warn",
-      "rebuttal": null,
-      "disposition": {
-        "status": "deferred",
-        "summary": "This follow-up stays open until a real review is recorded."
-      }
-    }
-  ],
-  "blocking_issues": [
-    "Review artifact scaffolded but not yet concluded."
-  ],
-  "follow_ups": [
-    "Record a real review before asking merge checkpoint to consume it."
-  ]
+  "decision": "allow",
+  "kind": "code_review",
+  "summary": "WI-898 implementation is approved for PR #992: the CLI-first entry now exposes version/help JSON, reserves the full #885 command matrix with structured fail-closed output, implements installed-state show/validate/export for loom-installed-state/v2, documents CLI/SKILLS/plugin/.loom authority boundaries, and adds contract fixtures for missing metadata, legacy hints, valid graph export, and mixed unknown version metadata.",
+  "reviewer": "codex-main-agent",
+  "reviewed_head": "325ae6b36e8afb52c6d7f3dbab545d093e05de89",
+  "reviewed_validation_summary": "Passed on branch work/886-cli-core-installed-state at 289ad5c1802e6cce1021ca93db11a78c12695587: python3 tools/loom.py version --json; python3 tools/loom.py installed-state validate --target examples/new-project --json expected fail-closed with legacy hints; make cli-contract-check; make check with loom_check OK over 40 source/distribution surfaces.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-898.md",
+    "recovery_entry": ".loom/progress/WI-898.md",
+    "status_surface": ".loom/status/current.md",
+    "spec": ".loom/specs/WI-898/spec.md",
+    "plan": ".loom/specs/WI-898/plan.md",
+    "implementation_contract": ".loom/specs/WI-898/implementation-contract.md",
+    "build_checkpoint": "pass"
+  }
 }

--- a/.loom/reviews/WI-898.json
+++ b/.loom/reviews/WI-898.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-898",
+  "decision": "fallback",
+  "kind": "general_review",
+  "summary": "Formal review has not been recorded yet.",
+  "reviewer": "not yet assigned",
+  "reviewed_head": "289ad5c1802e6cce1021ca93db11a78c12695587",
+  "reviewed_validation_summary": "No validation recorded yet.",
+  "fallback_to": "admission",
+  "findings": [
+    {
+      "id": "scaffolded-block-1",
+      "summary": "Review artifact scaffolded but not yet concluded.",
+      "severity": "block",
+      "rebuttal": null,
+      "disposition": {
+        "status": "rejected",
+        "summary": "Scaffold placeholder must be replaced by a real formal review conclusion."
+      }
+    },
+    {
+      "id": "scaffolded-warn-1",
+      "summary": "Record a real review before asking merge checkpoint to consume it.",
+      "severity": "warn",
+      "rebuttal": null,
+      "disposition": {
+        "status": "deferred",
+        "summary": "This follow-up stays open until a real review is recorded."
+      }
+    }
+  ],
+  "blocking_issues": [
+    "Review artifact scaffolded but not yet concluded."
+  ],
+  "follow_ups": [
+    "Record a real review before asking merge checkpoint to consume it."
+  ]
+}

--- a/.loom/reviews/WI-898.spec.json
+++ b/.loom/reviews/WI-898.spec.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-898",
+  "decision": "allow",
+  "kind": "spec_review",
+  "summary": "WI-898 spec is approved for the #886/#887 foundation slice: it freezes observable CLI JSON behavior, command reservation/fail-closed semantics, installed-state v2 validation, installation graph export, and the non-goal boundary that #888+ execution chains remain reserved.",
+  "reviewer": "codex-main-agent",
+  "reviewed_head": "1bda370ff1736ca879284853c9cfd987d50dcd40",
+  "reviewed_validation_summary": "Spec suite reviewed against .loom/specs/WI-898/spec.md, plan.md, and implementation-contract.md; implementation evidence is make cli-contract-check and make check on PR #992 branch.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-898.md",
+    "recovery_entry": ".loom/progress/WI-898.md",
+    "status_surface": ".loom/status/current.md",
+    "spec": ".loom/specs/WI-898/spec.md",
+    "plan": ".loom/specs/WI-898/plan.md",
+    "implementation_contract": ".loom/specs/WI-898/implementation-contract.md",
+    "build_checkpoint": "pass"
+  }
+}

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "cb624cd5dfc9f784bf7e59ea7ea47b261e3f0b1e869308185e6ebc4017af67b5"
+    ".loom/status/current.md": "2bd177d3ec84ba6d77f9037977f7e55d06f8ab11051f02e4ce7753e2f5a0f1af"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "cb624cd5dfc9f784bf7e59ea7ea47b261e3f0b1e869308185e6ebc4017af67b5"
+    ".loom/status/current.md": "2bd177d3ec84ba6d77f9037977f7e55d06f8ab11051f02e4ce7753e2f5a0f1af"
   }
 }

--- a/.loom/specs/WI-898/implementation-contract.md
+++ b/.loom/specs/WI-898/implementation-contract.md
@@ -1,0 +1,33 @@
+# WI-898 Implementation Contract
+
+## Owned Files
+
+- `tools/loom.py`
+- `tools/check_cli_contract.py`
+- `Makefile`
+- `docs/methodology/harness/cli-first-control-plane.md`
+- `docs/methodology/harness/cli-command-matrix.md`
+- `docs/methodology/harness/README.md`
+- `docs/adoption/loom-installed-state-v2.md`
+- `docs/adoption/README.md`
+- `.loom/work-items/WI-898.md`
+- `.loom/progress/WI-898.md`
+- `.loom/reviews/WI-898.json`
+- `.loom/reviews/WI-898.spec.json`
+- `.loom/specs/WI-898/spec.md`
+- `.loom/specs/WI-898/plan.md`
+- `.loom/specs/WI-898/implementation-contract.md`
+
+## Non-Goals
+
+- Do not implement #888+ detect/doctor/repair.
+- Do not migrate installer internals into CLI in this Work Item.
+- Do not replace all scenario skills with CLI-backed execution.
+- Do not change GitHub, CI, review engine, or worktree host implementations.
+
+## Required Evidence
+
+- CLI JSON examples for version and installed-state fail-closed behavior.
+- Contract check coverage for positive and negative installed-state fixtures.
+- Full `make check` pass.
+- PR gate consuming `WI-898` authored review and spec review carriers.

--- a/.loom/specs/WI-898/plan.md
+++ b/.loom/specs/WI-898/plan.md
@@ -1,0 +1,23 @@
+# WI-898 Plan
+
+## Implementation Steps
+
+1. Replace the repo-local `tools/loom.py` wrapper with a CLI-first router that exposes `version`, `help`, and `installed-state show|validate|export`.
+2. Keep existing scenario/status commands as delegated compatibility routes.
+3. Register the full #885 command matrix as reserved/delegated/implemented and make reserved commands fail closed with structured JSON.
+4. Add `loom-installed-state/v2` validation for schema, layer version context, runtime state, upgrade eligibility, failed layer metadata, and installation graph ids.
+5. Add `tools/check_cli_contract.py` and wire it into `make check`.
+6. Add harness/adoption docs that freeze authority boundaries, command naming, JSON fields, fail-closed behavior, fallback semantics, installed-state schema, and graph semantics.
+
+## Validation
+
+- `python3 tools/loom.py version --json`
+- `python3 tools/loom.py installed-state validate --target examples/new-project --json`
+- `make cli-contract-check`
+- `make check`
+
+## Risk Controls
+
+- Reserved commands must block instead of pretending later FRs are complete.
+- Installed-state must not infer validity from legacy files alone.
+- Validation fixtures use temporary directories and leave no repository residue.

--- a/.loom/specs/WI-898/spec.md
+++ b/.loom/specs/WI-898/spec.md
@@ -1,0 +1,27 @@
+# WI-898 Spec
+
+## Behavior Contract
+
+WI-898 freezes the CLI-first control-plane entry for #886 and the installed-state contract entry for #887.
+
+Observable behavior:
+
+- `python3 tools/loom.py help --json` emits `loom-cli-output/v1`, includes the #885 command matrix, and classifies each command as `implemented`, `delegated`, or `reserved`.
+- `python3 tools/loom.py version --json` emits repository, skills, plugin, host adapter, runtime, and package version authority context.
+- `python3 tools/loom.py installed-state show|validate|export --target <repo> --json` consumes only `loom-installed-state/v2` metadata and fails closed when metadata is missing, unreadable, invalid, or carries unknown version authority.
+- Reserved #885 commands return structured `result=block` output instead of calling unrelated legacy wrappers.
+- Legacy surface hints may be reported for diagnostics, but they do not satisfy installed-state validation.
+
+## Boundaries
+
+- CLI owns command semantics, JSON output, fail-closed behavior, and installed-state interpretation.
+- SKILLS and plugins remain entry/discovery layers that call CLI or consume CLI JSON.
+- `.loom/` remains repo execution fact storage and must not become global distribution truth.
+- This Work Item does not implement #888+ detect/doctor/repair, install/upgrade, host, skills, scenario, workspace, PR, merge, or migration execution chains.
+
+## Acceptance
+
+- Command semantics and naming are documented under `docs/methodology/harness/`.
+- `loom-installed-state/v2` schema and graph rules are documented under `docs/adoption/`.
+- `tools/check_cli_contract.py` mechanically covers help/version JSON, missing metadata fail-closed, legacy hints, valid graph export, and mixed/unknown version metadata fail-closed.
+- `make check` passes on the PR head.

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -11,13 +11,13 @@
 - Review Entry: .loom/reviews/WI-898.json
 - Validation Entry: python3 tools/loom.py version --json; python3 tools/loom.py installed-state validate --target examples/new-project --json; make cli-contract-check; make check
 - Closing Condition: PR #992 合并后关闭 #898-#905，并让 #886/#887 能消费命令语义、JSON 输出、fail-closed、fallback、验证证据和 head_sha。
-- Current Checkpoint: admission checkpoint
-- Current Stop: Work item scaffolded and waiting for the first execution pass.
-- Next Step: Write the first recovery update for this work item.
+- Current Checkpoint: merge-ready checkpoint
+- Current Stop: PR #992 has CLI-first control-plane and installed-state v2 implementation, docs, fixtures, and CI carrier baseline prepared for merge gate consumption.
+- Next Step: Consume PR #992 checks and merge after loom-pr-merge-gate, loom-check, and node installer gate pass.
 - Blockers: None recorded.
-- Latest Validation Summary: No validation recorded yet.
-- Recovery Boundary: Work item scaffolded at `.loom/work-items/WI-898.md`.
-- Current Lane: not yet assigned
+- Latest Validation Summary: Passed on branch work/886-cli-core-installed-state at 289ad5c1802e6cce1021ca93db11a78c12695587: python3 tools/loom.py version --json; python3 tools/loom.py installed-state validate --target examples/new-project --json expected fail-closed with legacy hints; make cli-contract-check; make check with loom_check OK over 40 source/distribution surfaces.
+- Recovery Boundary: WI-898 owns PR #992 for #886/#887 foundation scope only: CLI command matrix, JSON/fail-closed contract, installed-state v2 schema, installation graph, and show/validate/export fixtures. Later #888+ FR execution chains remain reserved.
+- Current Lane: cli-first/core-installed-state
 
 ## Runtime Evidence
 

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -2,22 +2,22 @@
 
 ## Derived Fact Chain View
 
-- Item ID: WI-792
-- Goal: Close GitHub issue #792 phase by completing retained GitHub issue / Project / PR host control plane gaps and producing #812 closeout basis.
-- Scope: Issue #792 retained closeout implementation: github-intake issue, native dependency host mirror consumption, #953/#872 source check profile work, #812 closeout evidence, PR/main/issue/Project reconciliation basis.
-- Execution Path: github-host-control-plane/phase-closeout
+- Item ID: WI-898
+- Goal: 冻结 CLI-first 控制面、命令矩阵和 installed-state v2 合同
+- Scope: 覆盖 #886/#887 的 #898-#905：CLI/SKILLS/plugin/.loom 边界、命令矩阵、JSON 输出、fail-closed/fallback、installed-state schema、installation graph、show/validate/export 和 fixtures；不实现后续 #888+ 执行链。
+- Execution Path: cli-first/core-installed-state
 - Workspace Entry: .
-- Recovery Entry: .loom/progress/WI-792.md
-- Review Entry: .loom/reviews/WI-792.json
-- Validation Entry: python3 tools/loom_check.py --profile source .; python3 tools/loom_flow.py pr-gate check --target . --pr 991
-- Closing Condition: PR #991 merged to main; retained #792 child issues and rollups closed or explicitly deferred; #812/#792 closeout evidence and host state reconciled.
-- Current Checkpoint: merge-ready checkpoint
-- Current Stop: PR #991 CI blockers were repaired locally: active carrier is WI-792, stale WI-968 carrier is terminal, installer metadata is bumped to 0.1.148, distributed skill runtime is regenerated, PR body declares Loom Work Item WI-792, and shadow carriers are refreshed.
-- Next Step: Commit and push the distributed runtime sync and refreshed review evidence, wait for PR #991 required checks, then merge before GitHub issue/Project closeout.
+- Recovery Entry: .loom/progress/WI-898.md
+- Review Entry: .loom/reviews/WI-898.json
+- Validation Entry: python3 tools/loom.py version --json; python3 tools/loom.py installed-state validate --target examples/new-project --json; make cli-contract-check; make check
+- Closing Condition: PR #992 合并后关闭 #898-#905，并让 #886/#887 能消费命令语义、JSON 输出、fail-closed、fallback、验证证据和 head_sha。
+- Current Checkpoint: admission checkpoint
+- Current Stop: Work item scaffolded and waiting for the first execution pass.
+- Next Step: Write the first recovery update for this work item.
 - Blockers: None recorded.
-- Latest Validation Summary: Passed for PR #991 CI blocker refresh: node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main -> OK (0.1.147 -> 0.1.148); npm --prefix packages/loom-installer run check:versions -> OK; python3 tools/skills_surface.py generate refreshed distributed runtime; python3 tools/skills_surface.py check -> OK; git diff --check -> OK; python3 -m py_compile src/skills/shared/scripts/loom_flow.py skills/shared/scripts/loom_flow.py src/skills/shared/scripts/loom_check.py skills/shared/scripts/loom_check.py -> OK; root-self-governance local equivalent -> OK for WI-792; carrier refresh dry-run -> pass with no refresh_needed. Cleanup removed pycache from this run.
-- Recovery Boundary: WI-792 owns PR #991 phase closeout implementation, closeout evidence, carrier binding, stale WI-968 terminal cleanup, shadow refresh, and installer version metadata required by this branch. It does not alter retained #792 scope beyond the user-approved #872/#953 inclusion.
-- Current Lane: ci-fix/pr-gate-complete
+- Latest Validation Summary: No validation recorded yet.
+- Recovery Boundary: Work item scaffolded at `.loom/work-items/WI-898.md`.
+- Current Lane: not yet assigned
 
 ## Runtime Evidence
 
@@ -29,7 +29,7 @@
 
 ## Sources
 
-- Static Truth: .loom/work-items/WI-792.md
-- Dynamic Truth: .loom/progress/WI-792.md
+- Static Truth: .loom/work-items/WI-898.md
+- Dynamic Truth: .loom/progress/WI-898.md
 - Locator Truth: .loom/bootstrap/init-result.json
 - Fact Chain CLI: python3 .loom/bin/loom_init.py fact-chain --target .

--- a/.loom/work-items/WI-898.md
+++ b/.loom/work-items/WI-898.md
@@ -1,0 +1,28 @@
+# WI-898
+
+## Static Facts
+
+- Item ID: WI-898
+- Goal: 冻结 CLI-first 控制面、命令矩阵和 installed-state v2 合同
+- Scope: 覆盖 #886/#887 的 #898-#905：CLI/SKILLS/plugin/.loom 边界、命令矩阵、JSON 输出、fail-closed/fallback、installed-state schema、installation graph、show/validate/export 和 fixtures；不实现后续 #888+ 执行链。
+- Execution Path: cli-first/core-installed-state
+- Workspace Entry: .
+- Recovery Entry: .loom/progress/WI-898.md
+- Review Entry: .loom/reviews/WI-898.json
+- Validation Entry: python3 tools/loom.py version --json; python3 tools/loom.py installed-state validate --target examples/new-project --json; make cli-contract-check; make check
+- Closing Condition: PR #992 合并后关闭 #898-#905，并让 #886/#887 能消费命令语义、JSON 输出、fail-closed、fallback、验证证据和 head_sha。
+
+## Associated Artifacts
+
+- `.loom/work-items/WI-898.md`
+- `.loom/progress/WI-898.md`
+- `.loom/reviews/WI-898.json`
+- `.loom/status/current.md`
+- `docs/methodology/harness/cli-first-control-plane.md`
+- `docs/methodology/harness/cli-command-matrix.md`
+- `docs/adoption/loom-installed-state-v2.md`
+- `tools/loom.py`
+- `tools/check_cli_contract.py`
+- `.loom/specs/WI-898/spec.md`
+- `.loom/specs/WI-898/plan.md`
+- `.loom/specs/WI-898/implementation-contract.md`

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: loom-check check py-compile skills-check host-adapter-check version-surface-check loom-check-runtime-regression loom-demo-new-project loom-demo-new-project-check loom-demo-new-project-sync loom-self-plugin-check
+.PHONY: loom-check check py-compile skills-check host-adapter-check version-surface-check cli-contract-check loom-check-runtime-regression loom-demo-new-project loom-demo-new-project-check loom-demo-new-project-sync loom-self-plugin-check
 
 loom-check: loom-self-plugin-check loom-demo-new-project-check loom-check-runtime-regression
 	python3 tools/loom_check.py
 
 py-compile:
-	python3 tools/py_compile_clean.py tools/loom_init.py tools/loom_flow.py tools/loom_check.py tools/loom_status.py tools/py_compile_clean.py tools/check_demo_bootstrap_fixture.py tools/check_loom_check_runtime_regressions.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py skills/loom-init/scripts/*.py skills/loom-adopt/scripts/*.py skills/loom-resume/scripts/*.py skills/loom-pre-review/scripts/*.py skills/loom-review/scripts/*.py skills/loom-spec-review/scripts/*.py skills/loom-handoff/scripts/*.py skills/loom-retire/scripts/*.py skills/loom-merge-ready/scripts/*.py skills/loom-build/scripts/*.py skills/loom-story/scripts/*.py
+	python3 tools/py_compile_clean.py tools/loom.py tools/loom_init.py tools/loom_flow.py tools/loom_check.py tools/loom_status.py tools/py_compile_clean.py tools/check_cli_contract.py tools/check_demo_bootstrap_fixture.py tools/check_loom_check_runtime_regressions.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py skills/loom-init/scripts/*.py skills/loom-adopt/scripts/*.py skills/loom-resume/scripts/*.py skills/loom-pre-review/scripts/*.py skills/loom-review/scripts/*.py skills/loom-spec-review/scripts/*.py skills/loom-handoff/scripts/*.py skills/loom-retire/scripts/*.py skills/loom-merge-ready/scripts/*.py skills/loom-build/scripts/*.py skills/loom-story/scripts/*.py
 
 skills-check:
 	python3 tools/skills_surface.py check
@@ -15,10 +15,13 @@ host-adapter-check:
 version-surface-check:
 	python3 tools/version_surface_check.py
 
+cli-contract-check:
+	python3 tools/check_cli_contract.py
+
 loom-check-runtime-regression:
 	python3 tools/check_loom_check_runtime_regressions.py
 
-check: py-compile skills-check host-adapter-check version-surface-check loom-check
+check: py-compile skills-check host-adapter-check version-surface-check cli-contract-check loom-check
 
 loom-demo-new-project:
 	python3 tools/check_demo_bootstrap_fixture.py

--- a/docs/adoption/README.md
+++ b/docs/adoption/README.md
@@ -31,6 +31,7 @@
 - 宿主适配矩阵：`host-adapter-matrix.md`
 - 单 skill 安装合同：[single-skill-contract.md](./single-skill-contract.md)
 - 已安装 Loom status 与升级演练：[installed-loom-status.md](./installed-loom-status.md)
+- CLI-first installed-state 合同：[loom-installed-state-v2.md](./loom-installed-state-v2.md)
 - 版本权威图：[version-authority-map.md](./version-authority-map.md)
 
 边界约束：

--- a/docs/adoption/loom-installed-state-v2.md
+++ b/docs/adoption/loom-installed-state-v2.md
@@ -1,0 +1,83 @@
+# loom-installed-state/v2
+
+`loom-installed-state/v2` describes which Loom layers a target repository consumes. It is installation metadata, not backlog truth and not governance truth.
+
+The canonical target path is:
+
+```text
+.loom/installed-state.json
+```
+
+The CLI also reads `.loom/installed-state.v2.json` and `.loom/installed-state/installed-state.json` as compatibility paths.
+
+## Required Shape
+
+```json
+{
+  "schema_version": "loom-installed-state/v2",
+  "installation_id": "repo-specific-stable-id",
+  "target": "/absolute/or/repo-relative/target",
+  "upgrade_eligibility": "current",
+  "layers": [
+    {
+      "id": "runtime",
+      "layer_type": "full-repo-runtime",
+      "installed_path": ".loom/bin",
+      "version_context": {
+        "repo_version": "v0.12.0",
+        "runtime_core_version": "1.0.0"
+      },
+      "runtime_state": "ready",
+      "upgrade_eligibility": "current",
+      "provides": ["loom runtime wrappers"],
+      "consumes": []
+    }
+  ],
+  "installation_graph": {
+    "layers": ["runtime"],
+    "edges": []
+  }
+}
+```
+
+## Layers
+
+Each layer must include:
+
+- `id`
+- `layer_type`
+- `installed_path`
+- `version_context`
+- `runtime_state`: `ready`, `blocked`, or `unknown`
+- `upgrade_eligibility`: `current`, `upgrade-available`, `drift`, `incompatible`, or `unknown`
+
+`version_context` must be non-empty and must not contain missing or `unknown` values. If Loom cannot identify a layer's version authority, the layer is not safe to upgrade.
+
+Non-ready layers must include:
+
+- `failed_layer`
+- `fail_closed_reason`
+
+## Installation Graph
+
+`installation_graph.layers` lists layer ids. `installation_graph.edges` records dependency direction, typically:
+
+```json
+{"from": "skills", "to": "runtime", "relationship": "consumes"}
+```
+
+The graph exists so `loom upgrade-plan`, `loom repair plan`, host adapters, skills sync, and installer shims can reason about layer ordering without reading unrelated governance files.
+
+## CLI Semantics
+
+```bash
+python3 tools/loom.py installed-state show --target <repo> --json
+python3 tools/loom.py installed-state validate --target <repo> --json
+python3 tools/loom.py installed-state export --target <repo> --json
+```
+
+All three commands fail closed when metadata is missing, unreadable, or invalid. Missing metadata may include `legacy_surface_hints` such as `.loom/bin`, `.agents/skills`, `skills/registry.json`, plugin manifests, or old installer status files. Those hints are diagnostic input for `loom detect`, `loom doctor`, and `loom repair plan`; they are not treated as valid installed-state by themselves.
+
+## Work Item Consumption
+
+This contract is the stable output of #902 and #903. `installed-state show|validate|export` implements the first CLI consumer for #904, with fixture coverage for missing metadata, legacy surfaces, valid graph export, and mixed/unknown version metadata for #905.

--- a/docs/methodology/harness/README.md
+++ b/docs/methodology/harness/README.md
@@ -9,6 +9,10 @@
 
 - [work-item-contract.md](./work-item-contract.md)
   - 定义唯一默认执行入口与 enforcement 合同
+- [cli-first-control-plane.md](./cli-first-control-plane.md)
+  - 定义 `loom` CLI、SKILLS、plugins、installer shim 与 `.loom/` 的职责边界和 fail-closed 规则
+- [cli-command-matrix.md](./cli-command-matrix.md)
+  - 冻结 CLI-first phase 的命令命名、状态分类与机器可读矩阵入口
 - [fact-chain-contract.md](./fact-chain-contract.md)
   - 定义静态真相、动态真相、host/control-plane mirror、retained result 与派生读面的读取优先级和 provenance 纪律
 - [execution-context.md](./execution-context.md)

--- a/docs/methodology/harness/cli-command-matrix.md
+++ b/docs/methodology/harness/cli-command-matrix.md
@@ -1,0 +1,90 @@
+# Loom CLI Command Matrix
+
+The `loom` CLI is the primary control plane for the CLI-first operating layer. The current matrix is exposed mechanically through:
+
+```bash
+python3 tools/loom.py help --json
+```
+
+The JSON output is the canonical machine-readable matrix for tests and downstream consumers. This document freezes the naming rules and command families for human review.
+
+## Naming Rules
+
+- Commands are verb-first where the domain is implicit: `loom detect`, `loom doctor`, `loom verify`.
+- Domain commands use `<domain> <verb>`: `loom installed-state validate`, `loom host doctor`, `loom skills release-check`.
+- Gate and checkpoint commands use the stable gate name as the subcommand: `loom gate merge`, `loom checkpoint admission`.
+- Host-control commands keep the host object name: `loom issue inspect`, `loom pr gate`, `loom workspace check`.
+- Scenario commands keep the skill-facing scenario names: `loom spec-review`, `loom merge-ready`, `loom handoff`.
+
+## Core And Installation
+
+| Command | Status | Contract |
+| --- | --- | --- |
+| `loom version` | implemented | Emits repository, skills, plugin, host-adapter, runtime, and package version context. |
+| `loom help` | implemented | Emits the full command matrix and fail-closed rules. |
+| `loom installed-state show` | implemented | Reads `loom-installed-state/v2` from the target repo. |
+| `loom installed-state validate` | implemented | Validates schema, layers, graph, and version metadata. |
+| `loom installed-state export` | implemented | Emits valid installed-state plus installation graph. |
+
+## Reserved Phase Commands
+
+These names are frozen for #885. Until their Work Items implement them, invoking them returns `result=block`.
+
+```text
+loom detect
+loom doctor
+loom repair plan|apply
+loom install
+loom upgrade-plan
+loom upgrade
+loom rollback
+loom verify
+loom profile status|upgrade-plan|upgrade
+loom story
+loom spec
+loom plan
+loom build
+loom pre-review
+loom closeout
+loom handoff
+loom retire
+loom checkpoint admission|build|merge
+loom gate pre-review|spec-review|review|pr|merge|closeout
+loom workspace create|locate|check|retire
+loom issue inspect|bind|reconcile
+loom project status|reconcile
+loom pr inspect|metadata-preflight|gate
+loom merge check|run
+loom reconcile
+loom host list|doctor|install|verify|upgrade|remove
+loom skills list|generate|sync|check|doctor|package|release-check
+```
+
+## Delegated Compatibility Commands
+
+These commands currently route to existing wrappers and remain compatibility paths while the CLI-first execution layer is filled in:
+
+```text
+loom init
+loom adopt
+loom route
+loom status
+loom fact-chain
+loom resume
+loom spec-review
+loom review
+loom merge-ready
+loom check
+```
+
+Delegated commands are allowed only when the wrapper is the existing authoritative implementation for that workflow. Missing wrappers fail closed.
+
+## Verification
+
+The command matrix is checked by:
+
+```bash
+python3 tools/check_cli_contract.py
+```
+
+This covers #899 and #901 by asserting that required names appear in `loom help --json`, version output is structured, and installed-state positive and negative fixtures behave consistently.

--- a/docs/methodology/harness/cli-first-control-plane.md
+++ b/docs/methodology/harness/cli-first-control-plane.md
@@ -1,0 +1,60 @@
+# CLI-First Control Plane
+
+Loom's CLI owns executable operating semantics. Skills, plugins, installer shims, and repo-local carriers may expose entry points, but they do not own the truth of command behavior.
+
+## Authority Split
+
+| Surface | Responsibility | Must not own |
+| --- | --- | --- |
+| `loom` CLI | Command semantics, JSON output, fail-closed behavior, install-state interpretation, and execution orchestration. | Business backlog truth or host-owned GitHub state. |
+| `SKILLS` | Agent-facing scenario entry and host discovery text. They call CLI commands or consume CLI JSON. | Core algorithms, upgrade truth, or hidden state transitions. |
+| Plugins / host adapters | Native host discovery, tool mapping, bootstrap wiring, and adapter version metadata. | Installation graph truth or governance truth. |
+| `.loom/` | Repo execution facts: companion contracts, work items, review evidence, status, checkpoints, and installed-state metadata when adopted. | Global Loom distribution truth or external backlog truth. |
+| `loom-installer` | Legacy compatibility shim and adapter-managed install path. | Primary command semantics after CLI-first adoption. |
+
+## Command Contract
+
+Every top-level `loom` command is one of:
+
+- `implemented`: executable in the current CLI.
+- `delegated`: compatibility route to an existing repo-local wrapper.
+- `reserved`: frozen in the command matrix but intentionally fail-closed until its Work Item implements it.
+
+Reserved commands must return structured JSON with:
+
+- `schema_version: loom-cli-output/v1`
+- `result: block`
+- `failed_layer`
+- `fail_closed_reason`
+- `fallback_to`
+
+They must not silently call an unrelated legacy wrapper. This keeps future command names stable without pretending that later phase work is complete.
+
+## JSON Output
+
+Machine-readable CLI commands use `loom-cli-output/v1` unless a narrower command contract states otherwise. The minimum fields are:
+
+- `schema_version`
+- `command`
+- `result`: `pass` or `block`
+- `generated_at`
+- `summary`
+
+Blocking outputs add `failed_layer`, `fail_closed_reason`, and `fallback_to`. Commands that inspect target repository state also include `target`.
+
+## Fail-Closed Rules
+
+The CLI must fail closed when:
+
+- the command is unknown;
+- a reserved command is invoked before implementation;
+- a delegated wrapper is missing;
+- target installed-state metadata is missing, unreadable, or not `loom-installed-state/v2`;
+- installed layers have missing, unknown, or inconsistent version metadata;
+- a non-ready layer omits `failed_layer` or `fail_closed_reason`.
+
+Fallbacks must name executable next checks, not prose-only advice.
+
+## Work Item Consumption
+
+This contract is the stable output of #898 and #900. Later Work Items may move reserved commands to `implemented`, but they must preserve the command name, JSON result shape, and fail-closed behavior unless the parent FR records an explicit contract change.

--- a/tools/check_cli_contract.py
+++ b/tools/check_cli_contract.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Contract checks for the CLI-first Loom surface."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LOOM = REPO_ROOT / "tools" / "loom.py"
+
+REQUIRED_COMMANDS = {
+    "version",
+    "help",
+    "installed-state show",
+    "installed-state validate",
+    "installed-state export",
+    "detect",
+    "doctor",
+    "repair plan",
+    "repair apply",
+    "install",
+    "upgrade-plan",
+    "upgrade",
+    "rollback",
+    "verify",
+    "host list",
+    "skills release-check",
+}
+
+
+def run_json(args: list[str], *, expect: int | None = None) -> tuple[int, dict[str, Any]]:
+    completed = subprocess.run(
+        [sys.executable, str(LOOM), *args],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if expect is not None and completed.returncode != expect:
+        raise AssertionError(f"{args} returned {completed.returncode}, expected {expect}\n{completed.stderr}\n{completed.stdout}")
+    raw = completed.stdout or completed.stderr
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(f"{args} did not emit JSON: {exc}\n{raw}") from exc
+    return completed.returncode, payload
+
+
+def write_state(target: Path, payload: dict[str, Any]) -> None:
+    state_dir = target / ".loom"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "installed-state.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def valid_state(target: Path) -> dict[str, Any]:
+    return {
+        "schema_version": "loom-installed-state/v2",
+        "installation_id": "fixture-valid",
+        "target": str(target),
+        "upgrade_eligibility": "current",
+        "layers": [
+            {
+                "id": "runtime",
+                "layer_type": "full-repo-runtime",
+                "installed_path": ".loom/bin",
+                "version_context": {
+                    "repo_version": "v0.12.0",
+                    "runtime_core_version": "1.0.0",
+                },
+                "runtime_state": "ready",
+                "upgrade_eligibility": "current",
+                "provides": ["loom runtime wrappers"],
+                "consumes": [],
+            },
+            {
+                "id": "skills",
+                "layer_type": "generated-skills",
+                "installed_path": "skills",
+                "version_context": {
+                    "skills_registry_version": "1.7.0",
+                    "skill_package_version": "1.0.0",
+                },
+                "runtime_state": "ready",
+                "upgrade_eligibility": "current",
+                "provides": ["scenario skills"],
+                "consumes": ["runtime"],
+            },
+        ],
+        "installation_graph": {
+            "layers": ["runtime", "skills"],
+            "edges": [{"from": "skills", "to": "runtime", "relationship": "consumes"}],
+        },
+    }
+
+
+def main() -> int:
+    _, help_payload = run_json(["help", "--json"], expect=0)
+    commands = {entry["command"] for entry in help_payload["commands"]}
+    missing = sorted(REQUIRED_COMMANDS - commands)
+    if missing:
+        raise AssertionError(f"help matrix missing commands: {missing}")
+
+    _, version_payload = run_json(["version", "--json"], expect=0)
+    if version_payload["result"] != "pass" or not version_payload["versions"]["repo_version"]:
+        raise AssertionError("version output did not include repo version context")
+
+    with tempfile.TemporaryDirectory(prefix="loom-cli-contract-") as raw_tmp:
+        tmp = Path(raw_tmp)
+        missing_target = tmp / "missing"
+        missing_target.mkdir()
+        status, missing_payload = run_json(["installed-state", "validate", "--target", str(missing_target), "--json"])
+        if status == 0 or missing_payload["result"] != "block" or missing_payload["runtime_state"] != "blocked":
+            raise AssertionError("missing installed-state did not fail closed")
+
+        legacy_target = tmp / "legacy"
+        (legacy_target / ".loom" / "bin").mkdir(parents=True)
+        status, legacy_payload = run_json(["installed-state", "show", "--target", str(legacy_target), "--json"])
+        if status == 0 or not legacy_payload["legacy_surface_hints"]:
+            raise AssertionError("legacy surface hints were not reported")
+
+        valid_target = tmp / "valid"
+        valid_target.mkdir()
+        write_state(valid_target, valid_state(valid_target))
+        run_json(["installed-state", "validate", "--target", str(valid_target), "--json"], expect=0)
+        _, exported = run_json(["installed-state", "export", "--target", str(valid_target), "--json"], expect=0)
+        if exported["installation_graph"]["layers"] != ["runtime", "skills"]:
+            raise AssertionError("installed-state export did not include graph")
+
+        mixed_target = tmp / "mixed"
+        mixed_target.mkdir()
+        bad_state = valid_state(mixed_target)
+        bad_state["layers"][1]["version_context"]["skill_package_version"] = "unknown"
+        write_state(mixed_target, bad_state)
+        status, mixed_payload = run_json(["installed-state", "validate", "--target", str(mixed_target), "--json"])
+        if status == 0 or mixed_payload["result"] != "block":
+            raise AssertionError("mixed/unknown version metadata did not fail closed")
+
+    print("cli contract checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/loom.py
+++ b/tools/loom.py
@@ -1,17 +1,140 @@
 #!/usr/bin/env python3
-"""Repo-local aggregate CLI for Loom wrapper tools."""
+"""CLI-first Loom control-plane entry.
+
+The command surface is intentionally broader than the implementation surface.
+Commands that are not implemented in this phase fail closed with a structured
+JSON block instead of silently falling back to legacy wrappers.
+"""
 
 from __future__ import annotations
 
+import argparse
+import json
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TOOLS_ROOT = REPO_ROOT / "tools"
+VERSION_FILE = REPO_ROOT / "VERSION"
+SKILLS_ROOT = REPO_ROOT / "skills"
+PLUGIN_MANIFEST = REPO_ROOT / "plugins" / "loom" / ".codex-plugin" / "plugin.json"
+
+OUTPUT_SCHEMA = "loom-cli-output/v1"
+INSTALLED_STATE_SCHEMA = "loom-installed-state/v2"
+
+
+COMMANDS: list[dict[str, Any]] = [
+    {
+        "command": "version",
+        "domain": "core",
+        "status": "implemented",
+        "json": True,
+        "summary": "Show Loom CLI and distribution version context.",
+    },
+    {
+        "command": "help",
+        "domain": "core",
+        "status": "implemented",
+        "json": True,
+        "summary": "Show the frozen CLI command matrix.",
+    },
+    {
+        "command": "installed-state show",
+        "domain": "installation",
+        "status": "implemented",
+        "json": True,
+        "summary": "Read the target repository loom-installed-state/v2 object.",
+    },
+    {
+        "command": "installed-state validate",
+        "domain": "installation",
+        "status": "implemented",
+        "json": True,
+        "summary": "Validate installed-state schema, layers, graph, and fail-closed metadata.",
+    },
+    {
+        "command": "installed-state export",
+        "domain": "installation",
+        "status": "implemented",
+        "json": True,
+        "summary": "Export installed-state plus its installation graph for upgrade consumers.",
+    },
+    {"command": "detect", "domain": "diagnostics", "status": "reserved", "json": True},
+    {"command": "doctor", "domain": "diagnostics", "status": "reserved", "json": True},
+    {"command": "repair plan", "domain": "repair", "status": "reserved", "json": True},
+    {"command": "repair apply", "domain": "repair", "status": "reserved", "json": True},
+    {"command": "install", "domain": "delivery", "status": "reserved", "json": True},
+    {"command": "upgrade-plan", "domain": "delivery", "status": "reserved", "json": True},
+    {"command": "upgrade", "domain": "delivery", "status": "reserved", "json": True},
+    {"command": "rollback", "domain": "delivery", "status": "reserved", "json": True},
+    {"command": "verify", "domain": "delivery", "status": "reserved", "json": True},
+    {"command": "init", "domain": "scenario", "status": "delegated", "json": "mixed"},
+    {"command": "adopt", "domain": "scenario", "status": "delegated", "json": "mixed"},
+    {"command": "route", "domain": "scenario", "status": "delegated", "json": True},
+    {"command": "status", "domain": "harness", "status": "delegated", "json": True},
+    {"command": "fact-chain", "domain": "harness", "status": "delegated", "json": True},
+    {"command": "profile status", "domain": "profile", "status": "reserved", "json": True},
+    {"command": "profile upgrade-plan", "domain": "profile", "status": "reserved", "json": True},
+    {"command": "profile upgrade", "domain": "profile", "status": "reserved", "json": True},
+    {"command": "story", "domain": "scenario", "status": "reserved", "json": True},
+    {"command": "spec", "domain": "scenario", "status": "reserved", "json": True},
+    {"command": "plan", "domain": "scenario", "status": "reserved", "json": True},
+    {"command": "build", "domain": "scenario", "status": "reserved", "json": True},
+    {"command": "pre-review", "domain": "scenario", "status": "reserved", "json": True},
+    {"command": "spec-review", "domain": "scenario", "status": "delegated", "json": True},
+    {"command": "review", "domain": "scenario", "status": "delegated", "json": True},
+    {"command": "merge-ready", "domain": "scenario", "status": "delegated", "json": True},
+    {"command": "closeout", "domain": "scenario", "status": "reserved", "json": True},
+    {"command": "resume", "domain": "scenario", "status": "delegated", "json": True},
+    {"command": "handoff", "domain": "scenario", "status": "reserved", "json": True},
+    {"command": "retire", "domain": "scenario", "status": "reserved", "json": True},
+    {"command": "checkpoint admission", "domain": "gate", "status": "reserved", "json": True},
+    {"command": "checkpoint build", "domain": "gate", "status": "reserved", "json": True},
+    {"command": "checkpoint merge", "domain": "gate", "status": "reserved", "json": True},
+    {"command": "gate pre-review", "domain": "gate", "status": "reserved", "json": True},
+    {"command": "gate spec-review", "domain": "gate", "status": "reserved", "json": True},
+    {"command": "gate review", "domain": "gate", "status": "reserved", "json": True},
+    {"command": "gate pr", "domain": "gate", "status": "reserved", "json": True},
+    {"command": "gate merge", "domain": "gate", "status": "reserved", "json": True},
+    {"command": "gate closeout", "domain": "gate", "status": "reserved", "json": True},
+    {"command": "workspace create", "domain": "host-control", "status": "reserved", "json": True},
+    {"command": "workspace locate", "domain": "host-control", "status": "reserved", "json": True},
+    {"command": "workspace check", "domain": "host-control", "status": "reserved", "json": True},
+    {"command": "workspace retire", "domain": "host-control", "status": "reserved", "json": True},
+    {"command": "issue inspect", "domain": "host-control", "status": "reserved", "json": True},
+    {"command": "issue bind", "domain": "host-control", "status": "reserved", "json": True},
+    {"command": "issue reconcile", "domain": "host-control", "status": "reserved", "json": True},
+    {"command": "project status", "domain": "host-control", "status": "reserved", "json": True},
+    {"command": "project reconcile", "domain": "host-control", "status": "reserved", "json": True},
+    {"command": "pr inspect", "domain": "host-control", "status": "reserved", "json": True},
+    {"command": "pr metadata-preflight", "domain": "host-control", "status": "reserved", "json": True},
+    {"command": "pr gate", "domain": "host-control", "status": "reserved", "json": True},
+    {"command": "merge check", "domain": "delivery", "status": "reserved", "json": True},
+    {"command": "merge run", "domain": "delivery", "status": "reserved", "json": True},
+    {"command": "reconcile", "domain": "host-control", "status": "reserved", "json": True},
+    {"command": "host list", "domain": "host", "status": "reserved", "json": True},
+    {"command": "host doctor", "domain": "host", "status": "reserved", "json": True},
+    {"command": "host install", "domain": "host", "status": "reserved", "json": True},
+    {"command": "host verify", "domain": "host", "status": "reserved", "json": True},
+    {"command": "host upgrade", "domain": "host", "status": "reserved", "json": True},
+    {"command": "host remove", "domain": "host", "status": "reserved", "json": True},
+    {"command": "skills list", "domain": "skills", "status": "reserved", "json": True},
+    {"command": "skills generate", "domain": "skills", "status": "reserved", "json": True},
+    {"command": "skills sync", "domain": "skills", "status": "reserved", "json": True},
+    {"command": "skills check", "domain": "skills", "status": "reserved", "json": True},
+    {"command": "skills doctor", "domain": "skills", "status": "reserved", "json": True},
+    {"command": "skills package", "domain": "skills", "status": "reserved", "json": True},
+    {"command": "skills release-check", "domain": "skills", "status": "reserved", "json": True},
+]
+
+COMMAND_INDEX = {entry["command"]: entry for entry in COMMANDS}
 
 COMMAND_ROUTES: dict[str, tuple[str, tuple[str, ...]]] = {
     "init": ("loom_init.py", ()),
+    "adopt": ("loom_flow.py", ("adopt",)),
     "route": ("loom_init.py", ("route",)),
     "flow": ("loom_flow.py", ()),
     "resume": ("loom_flow.py", ("flow", "resume")),
@@ -20,47 +143,355 @@ COMMAND_ROUTES: dict[str, tuple[str, tuple[str, ...]]] = {
     "review": ("loom_flow.py", ("review",)),
     "check": ("loom_check.py", ()),
     "status": ("loom_status.py", ()),
+    "fact-chain": ("loom_init.py", ("fact-chain",)),
 }
+
+STATE_FILENAMES = (
+    ".loom/installed-state.json",
+    ".loom/installed-state.v2.json",
+    ".loom/installed-state/installed-state.json",
+)
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def read_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def read_optional_json(path: Path) -> Any | None:
+    if not path.exists():
+        return None
+    return read_json(path)
+
+
+def repo_version() -> str:
+    if not VERSION_FILE.exists():
+        return "unknown"
+    return VERSION_FILE.read_text(encoding="utf-8").strip()
+
+
+def version_context() -> dict[str, Any]:
+    registry = read_optional_json(SKILLS_ROOT / "registry.json") or {}
+    plugin = read_optional_json(PLUGIN_MANIFEST) or {}
+    package = read_optional_json(SKILLS_ROOT / "loom-init" / "loom-package.json") or {}
+    return {
+        "repo_version": repo_version(),
+        "skills_registry_version": registry.get("registry_version", "unknown"),
+        "plugin_surface_version": plugin.get("x-loom", {}).get("plugin_surface_version", plugin.get("version", "unknown")),
+        "host_adapter_version": plugin.get("x-loom", {}).get("host_adapter_version", "unknown"),
+        "runtime_core_version": package.get("runtime_core_version", "unknown"),
+        "skill_package_version": package.get("skill_package_version", "unknown"),
+        "version_authority": "docs/adoption/version-authority-map.md",
+    }
+
+
+def emit(payload: dict[str, Any], *, stream=sys.stdout) -> int:
+    stream.write(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+    return 0 if payload.get("result") == "pass" else 1
+
+
+def output(command: str, result: str, **fields: Any) -> dict[str, Any]:
+    return {
+        "schema_version": OUTPUT_SCHEMA,
+        "command": command,
+        "result": result,
+        "generated_at": now_iso(),
+        **fields,
+    }
+
+
+def command_matrix() -> list[dict[str, Any]]:
+    return [
+        {
+            "command": entry["command"],
+            "domain": entry["domain"],
+            "status": entry["status"],
+            "json": entry.get("json", True),
+            "summary": entry.get("summary", ""),
+        }
+        for entry in COMMANDS
+    ]
 
 
 def print_usage(stream) -> None:
     stream.write(
         "usage: loom <command> [args ...]\n\n"
-        "Repo-local aggregate entry for existing Loom wrapper tools.\n\n"
-        "commands:\n"
-        "  init    pass through to tools/loom_init.py\n"
-        "  route   shortcut for tools/loom_init.py route\n"
-        "  flow    pass through to tools/loom_flow.py\n"
-        "  resume  shortcut for tools/loom_flow.py flow resume\n"
-        "  merge-ready  shortcut for tools/loom_flow.py flow merge-ready\n"
-        "  spec-review  shortcut for tools/loom_flow.py flow spec-review\n"
-        "  review  shortcut for tools/loom_flow.py review\n"
-        "  check   pass through to tools/loom_check.py\n\n"
-        "  status  pass through to tools/loom_status.py\n\n"
-        "examples:\n"
-        "  python3 tools/loom.py init bootstrap --target examples/new-project --write\n"
-        "  python3 tools/loom.py route --target examples/new-project --task \"请接手当前事项并恢复上下文后继续推进\"\n"
-        "  python3 tools/loom.py resume --target examples/new-project --item INIT-0001\n"
-        "  python3 tools/loom.py flow review --target examples/new-project --item INIT-0001\n"
-        "  python3 tools/loom.py merge-ready --target examples/new-project --item INIT-0001\n"
-        "  python3 tools/loom.py spec-review --target examples/new-project --item INIT-0001\n"
-        "  python3 tools/loom.py review read --target examples/new-project --item INIT-0001\n"
-        "  python3 tools/loom.py status --target examples/new-project --item INIT-0001\n"
-        "  python3 tools/loom.py check\n"
+        "CLI-first Loom control-plane entry.\n\n"
+        "core commands:\n"
+        "  version [--json]\n"
+        "  help [--json]\n"
+        "  installed-state show|validate|export --target <repo> [--json]\n\n"
+        "delegated compatibility commands:\n"
+        "  init, adopt, route, status, fact-chain, resume, spec-review, review, merge-ready, check\n\n"
+        "Use `loom help --json` for the full frozen command matrix, including reserved commands.\n"
     )
+
+
+def handle_version(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="loom version")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    payload = output(
+        "version",
+        "pass",
+        summary="Loom CLI version context resolved.",
+        versions=version_context(),
+        command_contract="docs/methodology/harness/cli-command-matrix.md",
+    )
+    if args.json:
+        return emit(payload)
+    versions = payload["versions"]
+    print(f"loom repo {versions['repo_version']}")
+    print(f"skills registry {versions['skills_registry_version']}")
+    print(f"plugin surface {versions['plugin_surface_version']}")
+    return 0
+
+
+def handle_help(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="loom help")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    payload = output(
+        "help",
+        "pass",
+        summary="Frozen CLI command matrix.",
+        command_count=len(COMMANDS),
+        commands=command_matrix(),
+        fail_closed_on=[
+            "unknown command",
+            "reserved command invoked before implementation",
+            "delegated wrapper missing",
+            "installed-state metadata missing or invalid",
+        ],
+        fallback_to=[
+            "loom help --json",
+            "loom installed-state validate --target <repo> --json",
+            "legacy delegated wrapper only when command status is delegated",
+        ],
+    )
+    if args.json:
+        return emit(payload)
+    print_usage(sys.stdout)
+    print("\ncommands:")
+    for entry in COMMANDS:
+        print(f"  {entry['command']:<32} {entry['status']:<11} {entry['domain']}")
+    return 0
+
+
+def resolve_target(raw_target: str) -> Path:
+    return Path(raw_target).expanduser().resolve()
+
+
+def installed_state_path(target: Path) -> Path | None:
+    for filename in STATE_FILENAMES:
+        path = target / filename
+        if path.exists():
+            return path
+    return None
+
+
+def legacy_surface_hints(target: Path) -> list[dict[str, str]]:
+    candidates = [
+        (".loom/bin", "repo-local-runtime-bin"),
+        (".loom/companion/manifest.json", "repo-companion"),
+        (".agents/skills", "repo-local-skills"),
+        ("skills/registry.json", "full-repo-skills"),
+        ("plugins/loom/.codex-plugin/plugin.json", "codex-plugin"),
+        ("plugins/loom/.loom-install-status.json", "legacy-installed-surface-status"),
+        ("packages/loom-installer/package.json", "legacy-installer-package"),
+    ]
+    hints = []
+    for relative, kind in candidates:
+        if (target / relative).exists():
+            hints.append({"kind": kind, "path": relative})
+    return hints
+
+
+def block_installed_state(command: str, target: Path, reason: str, *, hints: list[dict[str, str]] | None = None) -> dict[str, Any]:
+    return output(
+        command,
+        "block",
+        summary="Installed-state cannot be trusted.",
+        target=str(target),
+        runtime_state="blocked",
+        upgrade_eligibility="incompatible",
+        failed_layer="installed-state",
+        fail_closed_reason=reason,
+        legacy_surface_hints=hints or legacy_surface_hints(target),
+        fallback_to=["loom detect", "loom doctor", "loom repair plan"],
+    )
+
+
+def validate_installed_state(state: Any) -> list[dict[str, str]]:
+    errors: list[dict[str, str]] = []
+    if not isinstance(state, dict):
+        return [{"path": "$", "reason": "installed-state must be a JSON object"}]
+    if state.get("schema_version") != INSTALLED_STATE_SCHEMA:
+        errors.append({"path": "schema_version", "reason": f"expected {INSTALLED_STATE_SCHEMA}"})
+    for key in ("installation_id", "target", "layers", "installation_graph"):
+        if key not in state:
+            errors.append({"path": key, "reason": "required field is missing"})
+    layers = state.get("layers")
+    if not isinstance(layers, list) or not layers:
+        errors.append({"path": "layers", "reason": "must be a non-empty array"})
+        return errors
+    layer_ids: set[str] = set()
+    for index, layer in enumerate(layers):
+        path = f"layers[{index}]"
+        if not isinstance(layer, dict):
+            errors.append({"path": path, "reason": "layer must be an object"})
+            continue
+        for key in ("id", "layer_type", "installed_path", "version_context", "runtime_state", "upgrade_eligibility"):
+            if key not in layer:
+                errors.append({"path": f"{path}.{key}", "reason": "required field is missing"})
+        layer_id = layer.get("id")
+        if isinstance(layer_id, str) and layer_id:
+            if layer_id in layer_ids:
+                errors.append({"path": f"{path}.id", "reason": "duplicate layer id"})
+            layer_ids.add(layer_id)
+        if layer.get("runtime_state") not in {"ready", "blocked", "unknown"}:
+            errors.append({"path": f"{path}.runtime_state", "reason": "must be ready, blocked, or unknown"})
+        if layer.get("upgrade_eligibility") not in {"current", "upgrade-available", "drift", "incompatible", "unknown"}:
+            errors.append({"path": f"{path}.upgrade_eligibility", "reason": "unsupported upgrade eligibility"})
+        version = layer.get("version_context")
+        if not isinstance(version, dict) or not version:
+            errors.append({"path": f"{path}.version_context", "reason": "must be a non-empty object"})
+        elif any(value in (None, "", "unknown") for value in version.values()):
+            errors.append({"path": f"{path}.version_context", "reason": "version metadata must not be missing or unknown"})
+        if layer.get("runtime_state") != "ready":
+            if not layer.get("fail_closed_reason") or not layer.get("failed_layer"):
+                errors.append({"path": path, "reason": "non-ready layers must include failed_layer and fail_closed_reason"})
+    graph = state.get("installation_graph")
+    if isinstance(graph, dict):
+        graph_layers = graph.get("layers")
+        if isinstance(graph_layers, list):
+            missing = sorted(set(graph_layers) - layer_ids)
+            if missing:
+                errors.append({"path": "installation_graph.layers", "reason": f"unknown layer ids: {', '.join(missing)}"})
+    else:
+        errors.append({"path": "installation_graph", "reason": "must be an object"})
+    return errors
+
+
+def load_installed_state(target: Path) -> tuple[Path | None, Any | None, dict[str, Any] | None]:
+    path = installed_state_path(target)
+    if path is None:
+        return None, None, block_installed_state(
+            "installed-state",
+            target,
+            f"missing {INSTALLED_STATE_SCHEMA} metadata at one of: {', '.join(STATE_FILENAMES)}",
+        )
+    try:
+        return path, read_json(path), None
+    except (OSError, json.JSONDecodeError) as exc:
+        return path, None, block_installed_state("installed-state", target, f"installed-state is unreadable: {exc}")
+
+
+def handle_installed_state(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="loom installed-state")
+    parser.add_argument("action", choices=("show", "validate", "export"))
+    parser.add_argument("--target", default=".")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    target = resolve_target(args.target)
+    command = f"installed-state {args.action}"
+    path, state, error = load_installed_state(target)
+    if error:
+        error["command"] = command
+        return emit(error)
+
+    errors = validate_installed_state(state)
+    if errors:
+        return emit(
+            output(
+                command,
+                "block",
+                summary="Installed-state failed validation.",
+                target=str(target),
+                installed_state_path=str(path),
+                runtime_state="blocked",
+                upgrade_eligibility="incompatible",
+                failed_layer="installed-state",
+                fail_closed_reason="installed-state schema or version metadata is invalid",
+                errors=errors,
+                fallback_to=["loom repair plan", "loom installed-state export --target <repo> --json"],
+            )
+        )
+
+    payload = output(
+        command,
+        "pass",
+        summary="Installed-state is valid.",
+        target=str(target),
+        installed_state_path=str(path),
+        runtime_state="ready",
+        upgrade_eligibility=state.get("upgrade_eligibility", "current"),
+        installed_state=state,
+    )
+    if args.action == "export":
+        payload["installation_graph"] = state.get("installation_graph")
+        payload["export_contract"] = "docs/adoption/loom-installed-state-v2.md"
+    if args.action == "validate":
+        payload.pop("installed_state")
+        payload["validated_schema"] = INSTALLED_STATE_SCHEMA
+
+    if args.json or True:
+        return emit(payload)
+    return 0
 
 
 def dispatch(command: str, forwarded_args: list[str]) -> int:
     tool_name, prefix = COMMAND_ROUTES[command]
     tool_path = TOOLS_ROOT / tool_name
     if not tool_path.exists():
-        print(f"loom: missing delegated tool: {tool_path}", file=sys.stderr)
-        return 2
-    completed = subprocess.run(
-        [sys.executable, str(tool_path), *prefix, *forwarded_args],
-        check=False,
-    )
+        return emit(
+            output(
+                command,
+                "block",
+                summary="Delegated compatibility wrapper is missing.",
+                failed_layer="delegated-wrapper",
+                fail_closed_reason=f"missing delegated tool: {tool_path}",
+                fallback_to=["loom help --json"],
+            ),
+            stream=sys.stderr,
+        )
+    completed = subprocess.run([sys.executable, str(tool_path), *prefix, *forwarded_args], check=False)
     return completed.returncode
+
+
+def reserved_command(command: str, argv: list[str]) -> int:
+    entry = COMMAND_INDEX[command]
+    wants_json = "--json" in argv or True
+    payload = output(
+        command,
+        "block",
+        summary="Command is reserved by the CLI-first contract but not implemented in this Work Item.",
+        command_status=entry["status"],
+        domain=entry["domain"],
+        failed_layer="cli-command-implementation",
+        fail_closed_reason="reserved command has no executable implementation yet",
+        fallback_to=["loom help --json"],
+    )
+    if wants_json:
+        return emit(payload)
+    print(f"loom: {command} is reserved but not implemented", file=sys.stderr)
+    return 2
+
+
+def resolve_command(argv: list[str]) -> tuple[str, list[str]] | None:
+    if not argv:
+        return None
+    for length in (3, 2, 1):
+        if len(argv) < length:
+            continue
+        candidate = " ".join(argv[:length])
+        if candidate in COMMAND_INDEX or candidate in COMMAND_ROUTES or candidate in {"flow", "check"}:
+            return candidate, argv[length:]
+    return argv[0], argv[1:]
 
 
 def main(argv: list[str]) -> int:
@@ -68,17 +499,35 @@ def main(argv: list[str]) -> int:
         print_usage(sys.stderr)
         return 2
 
-    command = argv[1]
-    if command in {"-h", "--help", "help"}:
-        print_usage(sys.stdout)
-        return 0
-
-    if command not in COMMAND_ROUTES:
-        print(f"loom: unknown command `{command}`", file=sys.stderr)
+    resolved = resolve_command(argv[1:])
+    if resolved is None:
         print_usage(sys.stderr)
         return 2
+    command, forwarded = resolved
 
-    return dispatch(command, argv[2:])
+    if command in {"-h", "--help", "help"}:
+        return handle_help(forwarded)
+    if command == "version":
+        return handle_version(forwarded)
+    if command == "installed-state":
+        return handle_installed_state(forwarded)
+    if command.startswith("installed-state "):
+        return handle_installed_state(command.split()[1:] + forwarded)
+    if command in COMMAND_ROUTES:
+        return dispatch(command, forwarded)
+    if command in COMMAND_INDEX:
+        return reserved_command(command, forwarded)
+
+    payload = output(
+        command,
+        "block",
+        summary="Unknown Loom command.",
+        failed_layer="cli-command-router",
+        fail_closed_reason=f"unknown command: {command}",
+        fallback_to=["loom help --json"],
+    )
+    emit(payload, stream=sys.stderr)
+    return 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Freeze the CLI-first control-plane boundary, command matrix, JSON result contract, and fail-closed behavior for #886.
- Add `loom version`, `loom help --json`, and `loom installed-state show|validate|export` for #887.
- Add installed-state v2 docs plus mechanical CLI contract checks for missing metadata, legacy hints, valid graph export, and mixed/unknown version fail-closed cases.

## Scope
- Loom Work Item: WI-898
- Parent FRs: Refs #886, Refs #887
- Work Items: Closes #898, Closes #899, Closes #900, Closes #901, Closes #902, Closes #903, Closes #904, Closes #905
- Phase: Refs #885

## Execution Site
- workspace_entry: `/Users/mc/dev/Loom-work-886`
- branch: `work/886-cli-core-installed-state`
- head_sha: `2d37c11e5b4497d5df30b947b93778447a792824`

## Verification
- `python3 tools/loom.py version --json`
- `python3 tools/loom.py installed-state validate --target examples/new-project --json` (expected fail-closed with legacy hints)
- `python3 .loom/bin/loom_flow.py shadow-parity --target .` (pass after shadow evidence refresh)
- `python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-898` (pass after shadow evidence refresh)
- `make cli-contract-check`
- `make check`

## Notes
Reserved #885 phase commands now appear in the command matrix and fail closed with structured JSON until their own Work Items implement them. This PR does not claim later FR execution chains are implemented.