### PR TITLE
feat(cli): implement control host and skills command contracts

### DIFF
--- a/.loom/bootstrap/init-result.json
+++ b/.loom/bootstrap/init-result.json
@@ -76,9 +76,9 @@
     "mode": "work-item + recovery-entry + derived status-surface",
     "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
     "entry_points": {
-      "current_item_id": "WI-906",
-      "work_item": ".loom/work-items/WI-906.md",
-      "recovery_entry": ".loom/progress/WI-906.md",
+      "current_item_id": "WI-929",
+      "work_item": ".loom/work-items/WI-929.md",
+      "recovery_entry": ".loom/progress/WI-929.md",
       "status_surface": ".loom/status/current.md"
     }
   },

--- a/.loom/progress/WI-906.md
+++ b/.loom/progress/WI-906.md
@@ -3,12 +3,12 @@
 ## Dynamic Facts
 
 - Item ID: WI-906
-- Current Checkpoint: merge-ready checkpoint
-- Current Stop: #888 detect/doctor/repair implementation, docs, fixtures, and WI carriers are ready for PR creation.
-- Next Step: Create PR, run PR gate/CI, then merge after required checks pass.
+- Current Checkpoint: merged
+- Current Stop: PR #993 merged into main as 6b6a81f2453b920f5562541c5642afa6a19c6974; #906-#909 closed.
+- Next Step: No WI-906 action in this workspace; #893/#894/#895 continue under WI-929.
 - Blockers: None recorded.
-- Latest Validation Summary: Passed on branch work/888-detect-doctor-repair: python3 -m py_compile tools/loom.py tools/check_cli_contract.py; python3 tools/check_cli_contract.py; python3 tools/loom.py detect --target . --json; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-906; python3 .loom/bin/loom_flow.py shadow-parity --target .; make check with loom_check OK over 40 source/distribution surfaces.
-- Recovery Boundary: WI-906 owns the #888 batch for #906-#909 only: detect, doctor, repair plan, repair apply fail-closed, and legacy detect fixtures. Later #893/#894/#895 installer shim, host, and skills orchestration remain reserved.
+- Latest Validation Summary: PR #993 required checks passed: loom-check, node-installer-pr-gate, loom-pr-merge-gate, py-compile, demo-bootstrap, repo-local-cli, and root-self-governance. PR #993 merged at 6b6a81f2453b920f5562541c5642afa6a19c6974; #906-#909 closed.
+- Recovery Boundary: WI-906 is terminal and no longer owns the active workspace. Later #893/#894/#895 installer shim, host, and skills orchestration continue under WI-929.
 - Current Lane: cli-first/detect-doctor-repair
 
 ## Execution Ledger

--- a/.loom/progress/WI-929.md
+++ b/.loom/progress/WI-929.md
@@ -1,0 +1,21 @@
+# WI-929 Progress
+
+## Dynamic Facts
+
+- Item ID: WI-929
+- Current Checkpoint: merge-ready checkpoint
+- Current Stop: #893/#894/#895 command implementation, docs, fixtures, and WI carriers are ready for PR creation.
+- Next Step: Create PR, run PR gate/CI, then merge after required checks pass.
+- Blockers: None recorded.
+- Latest Validation Summary: Passed on branch work/893-895-cli-orchestration: python3 -m py_compile tools/loom.py tools/check_cli_contract.py; python3 tools/check_cli_contract.py; python3 tools/loom.py host doctor --host codex --target . --json; python3 tools/loom.py skills release-check --json; python3 tools/loom.py workspace check --target . --item WI-929 --json; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-929; python3 .loom/bin/loom_flow.py shadow-parity --target .; npm test --prefix packages/loom-installer; make check with loom_check OK over 40 source/distribution surfaces.
+- Recovery Boundary: WI-929 owns the #893/#894/#895 batch for #929-#943 only. It does not implement unrelated profile finalization, bottom-layer GitHub/CI/review/worktree rewrites, repo-specific guardian replacement, or mutating host remove semantics.
+- Current Lane: cli-first/control-host-skills
+
+## Execution Ledger
+
+- Ledger Binding: recovery_entry
+- Plan Locator: .loom/specs/WI-929/plan.md
+- Acceptance Locator: .loom/specs/WI-929/spec.md
+- Validation Evidence Locator: .loom/specs/WI-929/implementation-contract.md
+- Handoff Notes Locator: not_applicable
+- Evidence Freshness: current

--- a/.loom/reviews/WI-929.json
+++ b/.loom/reviews/WI-929.json
@@ -5,7 +5,7 @@
   "kind": "code_review",
   "summary": "WI-929 implementation is approved for the #893/#894/#895 CLI-first control, host, and skills command batch based on focused local validation.",
   "reviewer": "codex-main-agent",
-  "reviewed_head": "b1b2b58f3de635340e457339566250c712cb595c",
+  "reviewed_head": "45e1f2015707faebbaabd9c1b71d715f5acbd091",
   "reviewed_validation_summary": "Passed on branch work/893-895-cli-orchestration: python3 -m py_compile tools/loom.py tools/check_cli_contract.py; python3 tools/check_cli_contract.py; python3 tools/loom.py host doctor --host codex --target . --json; python3 tools/loom.py skills release-check --json; python3 tools/loom.py workspace check --target . --item WI-929 --json; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-929; python3 .loom/bin/loom_flow.py shadow-parity --target .; npm test --prefix packages/loom-installer; make check with loom_check OK over 40 source/distribution surfaces.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-929.json
+++ b/.loom/reviews/WI-929.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-929",
+  "decision": "allow",
+  "kind": "code_review",
+  "summary": "WI-929 implementation is approved for the #893/#894/#895 CLI-first control, host, and skills command batch based on focused local validation.",
+  "reviewer": "codex-main-agent",
+  "reviewed_head": "9b1065138d8a8c1a3eb9ac5779959e7814b4021e",
+  "reviewed_validation_summary": "Passed on branch work/893-895-cli-orchestration: python3 -m py_compile tools/loom.py tools/check_cli_contract.py; python3 tools/check_cli_contract.py; python3 tools/loom.py host doctor --host codex --target . --json; python3 tools/loom.py skills release-check --json; python3 tools/loom.py workspace check --target . --item WI-929 --json; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-929; python3 .loom/bin/loom_flow.py shadow-parity --target .; npm test --prefix packages/loom-installer; make check with loom_check OK over 40 source/distribution surfaces.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-929.md",
+    "recovery_entry": ".loom/progress/WI-929.md",
+    "status_surface": ".loom/status/current.md",
+    "spec": ".loom/specs/WI-929/spec.md",
+    "plan": ".loom/specs/WI-929/plan.md",
+    "implementation_contract": ".loom/specs/WI-929/implementation-contract.md"
+  }
+}

--- a/.loom/reviews/WI-929.json
+++ b/.loom/reviews/WI-929.json
@@ -5,7 +5,7 @@
   "kind": "code_review",
   "summary": "WI-929 implementation is approved for the #893/#894/#895 CLI-first control, host, and skills command batch based on focused local validation.",
   "reviewer": "codex-main-agent",
-  "reviewed_head": "0dfd83fff0be652c0e8994f8d68438561fdbcc96",
+  "reviewed_head": "b1b2b58f3de635340e457339566250c712cb595c",
   "reviewed_validation_summary": "Passed on branch work/893-895-cli-orchestration: python3 -m py_compile tools/loom.py tools/check_cli_contract.py; python3 tools/check_cli_contract.py; python3 tools/loom.py host doctor --host codex --target . --json; python3 tools/loom.py skills release-check --json; python3 tools/loom.py workspace check --target . --item WI-929 --json; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-929; python3 .loom/bin/loom_flow.py shadow-parity --target .; npm test --prefix packages/loom-installer; make check with loom_check OK over 40 source/distribution surfaces.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-929.json
+++ b/.loom/reviews/WI-929.json
@@ -5,7 +5,7 @@
   "kind": "code_review",
   "summary": "WI-929 implementation is approved for the #893/#894/#895 CLI-first control, host, and skills command batch based on focused local validation.",
   "reviewer": "codex-main-agent",
-  "reviewed_head": "9b1065138d8a8c1a3eb9ac5779959e7814b4021e",
+  "reviewed_head": "0dfd83fff0be652c0e8994f8d68438561fdbcc96",
   "reviewed_validation_summary": "Passed on branch work/893-895-cli-orchestration: python3 -m py_compile tools/loom.py tools/check_cli_contract.py; python3 tools/check_cli_contract.py; python3 tools/loom.py host doctor --host codex --target . --json; python3 tools/loom.py skills release-check --json; python3 tools/loom.py workspace check --target . --item WI-929 --json; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-929; python3 .loom/bin/loom_flow.py shadow-parity --target .; npm test --prefix packages/loom-installer; make check with loom_check OK over 40 source/distribution surfaces.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-929.spec.json
+++ b/.loom/reviews/WI-929.spec.json
@@ -5,7 +5,7 @@
   "kind": "spec_review",
   "summary": "WI-929 spec and implementation contract are approved for the #893/#894/#895 CLI-first command batch.",
   "reviewer": "codex-main-agent",
-  "reviewed_head": "9b1065138d8a8c1a3eb9ac5779959e7814b4021e",
+  "reviewed_head": "b1b2b58f3de635340e457339566250c712cb595c",
   "reviewed_validation_summary": "Spec review consumed .loom/specs/WI-929/spec.md, plan.md, and implementation-contract.md; scope is limited to #929-#943 and excludes profile finalization or bottom-layer host rewrites.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-929.spec.json
+++ b/.loom/reviews/WI-929.spec.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-929",
+  "decision": "allow",
+  "kind": "spec_review",
+  "summary": "WI-929 spec and implementation contract are approved for the #893/#894/#895 CLI-first command batch.",
+  "reviewer": "codex-main-agent",
+  "reviewed_head": "9b1065138d8a8c1a3eb9ac5779959e7814b4021e",
+  "reviewed_validation_summary": "Spec review consumed .loom/specs/WI-929/spec.md, plan.md, and implementation-contract.md; scope is limited to #929-#943 and excludes profile finalization or bottom-layer host rewrites.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-929.md",
+    "recovery_entry": ".loom/progress/WI-929.md",
+    "status_surface": ".loom/status/current.md",
+    "spec": ".loom/specs/WI-929/spec.md",
+    "plan": ".loom/specs/WI-929/plan.md",
+    "implementation_contract": ".loom/specs/WI-929/implementation-contract.md"
+  }
+}

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "c7b5d290ea536fa599bcbeedfd35c66b1f8c5653398a9fef28f92cd27bca5ac0"
+    ".loom/status/current.md": "2ae63aa64299da84857484578b5332bd30c03f02c61688982364b2915e126c57"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "c7b5d290ea536fa599bcbeedfd35c66b1f8c5653398a9fef28f92cd27bca5ac0"
+    ".loom/status/current.md": "2ae63aa64299da84857484578b5332bd30c03f02c61688982364b2915e126c57"
   }
 }

--- a/.loom/specs/WI-929/implementation-contract.md
+++ b/.loom/specs/WI-929/implementation-contract.md
@@ -1,0 +1,32 @@
+# WI-929 Implementation Contract
+
+## Owned Files
+
+- `tools/loom.py`
+- `tools/check_cli_contract.py`
+- `docs/methodology/harness/cli-command-matrix.md`
+- `docs/methodology/harness/cli-first-control-plane.md`
+- `.loom/work-items/WI-929.md`
+- `.loom/progress/WI-929.md`
+- `.loom/progress/WI-906.md`
+- `.loom/reviews/WI-929.json`
+- `.loom/reviews/WI-929.spec.json`
+- `.loom/status/current.md`
+- `.loom/bootstrap/init-result.json`
+- `.loom/shadow/merge-ready-loom.json`
+- `.loom/shadow/closeout-loom.json`
+
+## Required Evidence
+
+- `python3 -m py_compile tools/loom.py tools/check_cli_contract.py`
+- `python3 tools/check_cli_contract.py`
+- `python3 tools/loom.py host doctor --host codex --target . --json`
+- `python3 tools/loom.py skills release-check --json`
+- `make check`
+
+## Non-Goals
+
+- No bottom-layer GitHub, CI, code review, or worktree reimplementation.
+- No profile finalization.
+- No repo-specific guardian replacement.
+- No host remove mutation without a later rollback/delete ownership contract.

--- a/.loom/specs/WI-929/plan.md
+++ b/.loom/specs/WI-929/plan.md
@@ -1,0 +1,8 @@
+# WI-929 Plan
+
+1. Move #893/#894/#895 command names from reserved to implemented in `tools/loom.py`.
+2. Add thin JSON wrappers for workspace, issue, project, PR, merge, reconcile, host, and skills domains.
+3. Delegate to existing `loom_flow.py`, `skills_surface.py`, `host_adapter_check.py`, `version_surface_check.py`, and installer shim evidence where appropriate.
+4. Extend CLI contract checks with host-control, host, and skills command fixtures.
+5. Update CLI control-plane docs and Work Item carriers.
+6. Validate with focused CLI commands and full repository checks before PR creation.

--- a/.loom/specs/WI-929/spec.md
+++ b/.loom/specs/WI-929/spec.md
@@ -1,0 +1,14 @@
+# WI-929 Spec
+
+## Objective
+
+Implement the CLI-first command layer for #893/#894/#895 so the phase can consume executable command semantics for host control, host adapters, and generated SKILLS surfaces.
+
+## Acceptance
+
+- `loom help --json` marks #929-#943 command names implemented.
+- Host-control commands emit structured JSON and delegate existing harness readers where available.
+- Host adapter commands distinguish full-repo/native discovery from adapter-managed plugin and single-skill paths.
+- Skills commands read, check, package, and fail-closed around generated `skills/` mutation.
+- Mutating host, skills, workspace, merge, and reconciliation paths require explicit apply/execute semantics or block with fallback.
+- Contract checks cover representative positive and fail-closed fixtures.

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -2,22 +2,22 @@
 
 ## Derived Fact Chain View
 
-- Item ID: WI-906
-- Goal: 实现 `loom detect --target`，并推进 #888 detect/doctor/repair 批次到可验证状态
-- Scope: 覆盖 #888 的 #906-#909：installed surface detection、doctor JSON、non-mutating repair plan、repair apply fail-closed、WebEnvoy/Syvert/HotCP legacy detect synthetic fixtures；不实现 installer shim、host/skills 编排或 mutating repair apply。
-- Execution Path: cli-first/detect-doctor-repair
+- Item ID: WI-929
+- Goal: 实现 #893/#894/#895 的 CLI-first 控制面、host adapter 编排和 SKILLS surface 命令合同。
+- Scope: 覆盖 #929-#943：workspace、issue、project、PR、merge、reconcile、host list/doctor/install/verify/upgrade/remove、skills list/generate/sync/check/doctor/package/release-check；冻结 JSON 输出、fail-closed、fallback 与验证证据。
+- Execution Path: cli-first/control-host-skills
 - Workspace Entry: .
-- Recovery Entry: .loom/progress/WI-906.md
-- Review Entry: .loom/reviews/WI-906.json
-- Validation Entry: python3 -m py_compile tools/loom.py tools/check_cli_contract.py; python3 tools/check_cli_contract.py; make check
-- Closing Condition: PR 合并后关闭 #906-#909，并让 #888 能消费命令语义、JSON 输出、fail-closed、fallback、验证证据和 head_sha。
+- Recovery Entry: .loom/progress/WI-929.md
+- Review Entry: .loom/reviews/WI-929.json
+- Validation Entry: python3 -m py_compile tools/loom.py tools/check_cli_contract.py; python3 tools/check_cli_contract.py; python3 tools/loom.py host doctor --host codex --target . --json; python3 tools/loom.py skills release-check --json; make check
+- Closing Condition: PR 合并后关闭 #929-#943，并让 #893/#894/#895 消费命令语义、JSON 输出、fail-closed、fallback、验证证据和 head_sha。
 - Current Checkpoint: merge-ready checkpoint
-- Current Stop: #888 detect/doctor/repair implementation, docs, fixtures, and WI carriers are ready for PR creation.
+- Current Stop: #893/#894/#895 command implementation, docs, fixtures, and WI carriers are ready for PR creation.
 - Next Step: Create PR, run PR gate/CI, then merge after required checks pass.
 - Blockers: None recorded.
-- Latest Validation Summary: Passed on branch work/888-detect-doctor-repair: python3 -m py_compile tools/loom.py tools/check_cli_contract.py; python3 tools/check_cli_contract.py; python3 tools/loom.py detect --target . --json; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-906; python3 .loom/bin/loom_flow.py shadow-parity --target .; make check with loom_check OK over 40 source/distribution surfaces.
-- Recovery Boundary: WI-906 owns the #888 batch for #906-#909 only: detect, doctor, repair plan, repair apply fail-closed, and legacy detect fixtures. Later #893/#894/#895 installer shim, host, and skills orchestration remain reserved.
-- Current Lane: cli-first/detect-doctor-repair
+- Latest Validation Summary: Passed on branch work/893-895-cli-orchestration: python3 -m py_compile tools/loom.py tools/check_cli_contract.py; python3 tools/check_cli_contract.py; python3 tools/loom.py host doctor --host codex --target . --json; python3 tools/loom.py skills release-check --json; python3 tools/loom.py workspace check --target . --item WI-929 --json; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-929; python3 .loom/bin/loom_flow.py shadow-parity --target .; npm test --prefix packages/loom-installer; make check with loom_check OK over 40 source/distribution surfaces.
+- Recovery Boundary: WI-929 owns the #893/#894/#895 batch for #929-#943 only. It does not implement unrelated profile finalization, bottom-layer GitHub/CI/review/worktree rewrites, repo-specific guardian replacement, or mutating host remove semantics.
+- Current Lane: cli-first/control-host-skills
 
 ## Runtime Evidence
 
@@ -29,7 +29,7 @@
 
 ## Sources
 
-- Static Truth: .loom/work-items/WI-906.md
-- Dynamic Truth: .loom/progress/WI-906.md
+- Static Truth: .loom/work-items/WI-929.md
+- Dynamic Truth: .loom/progress/WI-929.md
 - Locator Truth: .loom/bootstrap/init-result.json
 - Fact Chain CLI: python3 .loom/bin/loom_init.py fact-chain --target .

--- a/.loom/work-items/WI-929.md
+++ b/.loom/work-items/WI-929.md
@@ -1,0 +1,32 @@
+# WI-929
+
+## Static Facts
+
+- Item ID: WI-929
+- Goal: 实现 #893/#894/#895 的 CLI-first 控制面、host adapter 编排和 SKILLS surface 命令合同。
+- Scope: 覆盖 #929-#943：workspace、issue、project、PR、merge、reconcile、host list/doctor/install/verify/upgrade/remove、skills list/generate/sync/check/doctor/package/release-check；冻结 JSON 输出、fail-closed、fallback 与验证证据。
+- Execution Path: cli-first/control-host-skills
+- Workspace Entry: .
+- Recovery Entry: .loom/progress/WI-929.md
+- Review Entry: .loom/reviews/WI-929.json
+- Validation Entry: python3 -m py_compile tools/loom.py tools/check_cli_contract.py; python3 tools/check_cli_contract.py; python3 tools/loom.py host doctor --host codex --target . --json; python3 tools/loom.py skills release-check --json; make check
+- Closing Condition: PR 合并后关闭 #929-#943，并让 #893/#894/#895 消费命令语义、JSON 输出、fail-closed、fallback、验证证据和 head_sha。
+
+## Associated Artifacts
+
+- `.loom/work-items/WI-929.md`
+- `.loom/progress/WI-929.md`
+- `.loom/progress/WI-906.md`
+- `.loom/reviews/WI-929.json`
+- `.loom/reviews/WI-929.spec.json`
+- `.loom/status/current.md`
+- `.loom/bootstrap/init-result.json`
+- `.loom/shadow/merge-ready-loom.json`
+- `.loom/shadow/closeout-loom.json`
+- `tools/loom.py`
+- `tools/check_cli_contract.py`
+- `docs/methodology/harness/cli-first-control-plane.md`
+- `docs/methodology/harness/cli-command-matrix.md`
+- `.loom/specs/WI-929/spec.md`
+- `.loom/specs/WI-929/plan.md`
+- `.loom/specs/WI-929/implementation-contract.md`

--- a/docs/methodology/harness/cli-command-matrix.md
+++ b/docs/methodology/harness/cli-command-matrix.md
@@ -30,6 +30,37 @@ The JSON output is the canonical machine-readable matrix for tests and downstrea
 | `loom repair plan` | implemented | Emits a non-mutating repair plan for missing, invalid, or legacy installed surfaces. |
 | `loom repair apply` | implemented | Fails closed until write ownership and rollback semantics are approved by a later Work Item. |
 
+## Implemented Phase Commands
+
+#893 implements the host-control command family:
+
+```text
+loom workspace create|locate|check|retire
+loom issue inspect|bind|reconcile
+loom project status|reconcile
+loom pr inspect|metadata-preflight|gate
+loom merge check|run
+loom reconcile
+```
+
+These commands use JSON wrappers over existing harness control-plane readers. GitHub and git remain the host-owned truth sources; Loom only freezes the command names, output shape, fail-closed reasons, and fallback names.
+
+#894 implements the host adapter command family:
+
+```text
+loom host list|doctor|install|verify|upgrade|remove
+```
+
+`host list` and `host doctor` are read-only. Adapter-managed mutations fail closed unless explicit `--apply` is present. Full-repo/native discovery remains operator-owned and is not mutated by the CLI.
+
+#895 implements the generated SKILLS command family:
+
+```text
+loom skills list|generate|sync|check|doctor|package|release-check
+```
+
+`skills generate` and `skills sync` require `--apply`; check, doctor, package, and release-check are read-only.
+
 ## Reserved Phase Commands
 
 These names are frozen for #885. Until their Work Items implement them, invoking them returns `result=block`.
@@ -51,14 +82,6 @@ loom handoff
 loom retire
 loom checkpoint admission|build|merge
 loom gate pre-review|spec-review|review|pr|merge|closeout
-loom workspace create|locate|check|retire
-loom issue inspect|bind|reconcile
-loom project status|reconcile
-loom pr inspect|metadata-preflight|gate
-loom merge check|run
-loom reconcile
-loom host list|doctor|install|verify|upgrade|remove
-loom skills list|generate|sync|check|doctor|package|release-check
 ```
 
 ## Delegated Compatibility Commands
@@ -98,3 +121,12 @@ For #906-#909 it also checks:
 - valid installed-state makes `doctor` pass and `repair plan` no-op;
 - invalid graph edge endpoints fail closed;
 - `repair apply` remains a structured blocking command until mutation semantics are approved.
+
+For #929-#943 it also checks:
+
+- host-control, host, and skills command names are implemented in `loom help --json`;
+- `loom host list` emits `loom-host-orchestration/v1`;
+- `loom host install` fails closed without `--apply`;
+- `loom skills list` emits the generated registry and root entry;
+- `loom skills generate` fails closed without `--apply`;
+- `loom skills package` emits package metadata for generated skills.

--- a/docs/methodology/harness/cli-first-control-plane.md
+++ b/docs/methodology/harness/cli-first-control-plane.md
@@ -78,3 +78,37 @@ Detected surfaces are evidence, not authority by themselves. Legacy `.loom/bin`,
 `loom doctor --target <repo> --json` consumes detection plus installed-state validation. It passes only when versioned installed-state is valid and no blocking legacy surface remains.
 
 `loom repair plan --target <repo> --json` emits ordered non-mutating actions. `loom repair apply --target <repo> --json` currently fails closed and returns the plan because mutation ownership, rollback, and host adapter writes belong to later Work Items.
+
+## Host Control Commands
+
+`loom workspace`, `loom issue`, `loom project`, `loom pr`, `loom merge`, and `loom reconcile` implement the #893 control-plane command names.
+
+These commands are thin CLI-first entries over host-owned truth. They read GitHub, git worktree, PR gate, controlled merge, and reconciliation evidence through existing Loom harness commands instead of creating another state source.
+
+Stable schemas:
+
+- `loom-workspace-control/v1` for workspace lifecycle wrappers.
+- `loom-host-object-control/v1` for issue, project, PR, merge, and reconciliation wrappers.
+- Existing delegated schemas such as `loom-pr-merge-gate/v1`, `loom-controlled-merge/v1`, and `loom-reconciliation-audit/v1` remain authoritative when the wrapper delegates to `loom_flow.py`.
+
+Fail-closed conditions include missing issue or PR identifiers, unreadable GitHub state, fact-chain mismatch, dirty or ambiguous workspace state, stale PR head, missing Work Item binding, incomplete required checks, and mergeability drift.
+
+Mutating actions require an explicit execution flag on the underlying command. `loom merge run` maps to controlled merge and requires `--apply` before `--execute` is passed to the host merge command. Reconciliation defaults to audit/dry-run semantics.
+
+## Host Adapter Commands
+
+`loom host list`, `loom host doctor`, `loom host install`, `loom host verify`, `loom host upgrade`, and `loom host remove` implement the #894 host orchestration surface with `loom-host-orchestration/v1`.
+
+The CLI separates:
+
+- Codex full-repo/native skills discovery as the default path.
+- Adapter-managed plugin and single-skill installation through `loom-installer`.
+- Contract-only hosts such as OpenCode, Gemini, and Cursor until adapter CLIs are available.
+
+`host list` and `host doctor` are read-only. `host install` and `host upgrade` fail closed unless `--apply` is present and the built installer shim is available. `host remove` remains non-mutating in this phase and reports the missing rollback/delete ownership contract.
+
+## Skills Commands
+
+`loom skills list`, `loom skills generate`, `loom skills sync`, `loom skills check`, `loom skills doctor`, `loom skills package`, and `loom skills release-check` implement the #895 generated SKILLS surface with `loom-skills-surface/v1`.
+
+`skills list` and `skills package` read checked-in generated package metadata. `skills check`, `skills doctor`, and `skills release-check` delegate to the existing surface, host adapter, and version checks. `skills generate` and `skills sync` mutate `skills/`, so they fail closed unless `--apply` is supplied.

--- a/tools/check_cli_contract.py
+++ b/tools/check_cli_contract.py
@@ -29,6 +29,32 @@ REQUIRED_COMMANDS = {
     "rollback",
     "verify",
     "host list",
+    "host doctor",
+    "host install",
+    "host verify",
+    "host upgrade",
+    "host remove",
+    "workspace create",
+    "workspace locate",
+    "workspace check",
+    "workspace retire",
+    "issue inspect",
+    "issue bind",
+    "issue reconcile",
+    "project status",
+    "project reconcile",
+    "pr inspect",
+    "pr metadata-preflight",
+    "pr gate",
+    "merge check",
+    "merge run",
+    "reconcile",
+    "skills list",
+    "skills generate",
+    "skills sync",
+    "skills check",
+    "skills doctor",
+    "skills package",
     "skills release-check",
 }
 
@@ -109,6 +135,21 @@ def main() -> int:
     for command in ("detect", "doctor", "repair plan", "repair apply"):
         if matrix[command]["status"] != "implemented":
             raise AssertionError(f"{command} must be implemented for #888")
+    for command in (
+        "workspace locate",
+        "issue inspect",
+        "project status",
+        "pr gate",
+        "merge check",
+        "reconcile",
+        "host list",
+        "host doctor",
+        "skills list",
+        "skills check",
+        "skills release-check",
+    ):
+        if matrix[command]["status"] != "implemented":
+            raise AssertionError(f"{command} must be implemented for #893/#894/#895")
 
     _, version_payload = run_json(["version", "--json"], expect=0)
     if version_payload["result"] != "pass" or not version_payload["versions"]["repo_version"]:
@@ -163,6 +204,24 @@ def main() -> int:
         _, exported = run_json(["installed-state", "export", "--target", str(valid_target), "--json"], expect=0)
         if exported["installation_graph"]["layers"] != ["runtime", "skills"]:
             raise AssertionError("installed-state export did not include graph")
+        _, hosts = run_json(["host", "list", "--target", str(valid_target), "--json"], expect=0)
+        if hosts["schema"] != "loom-host-orchestration/v1" or not any(host["id"] == "codex" for host in hosts["hosts"]):
+            raise AssertionError("host list did not emit supported host adapter inventory")
+        _, host_doctor = run_json(["host", "doctor", "--host", "codex", "--target", str(valid_target), "--json"], expect=0)
+        if host_doctor["host"] != "codex" or host_doctor["mode"] != "plugin":
+            raise AssertionError("host doctor did not freeze host/mode output")
+        status, host_install = run_json(["host", "install", "--host", "codex", "--target", str(valid_target), "--json"])
+        if status == 0 or host_install["result"] != "block" or host_install["failed_layer"] != "host-install":
+            raise AssertionError("host install did not fail closed without --apply")
+        _, skills_list = run_json(["skills", "list", "--json"], expect=0)
+        if skills_list["schema"] != "loom-skills-surface/v1" or skills_list["root_entry"] != "loom-init":
+            raise AssertionError("skills list did not expose generated skills registry")
+        status, skills_generate = run_json(["skills", "generate", "--json"])
+        if status == 0 or skills_generate["failed_layer"] != "skills-surface":
+            raise AssertionError("skills generate did not fail closed without --apply")
+        _, skills_package = run_json(["skills", "package", "--json"], expect=0)
+        if not skills_package["packages"]:
+            raise AssertionError("skills package did not emit package metadata")
 
         mixed_target = tmp / "mixed"
         mixed_target.mkdir()

--- a/tools/loom.py
+++ b/tools/loom.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -27,6 +28,10 @@ INSTALLED_STATE_SCHEMA = "loom-installed-state/v2"
 DETECT_SCHEMA = "loom-installed-surface-detect/v1"
 DOCTOR_SCHEMA = "loom-installed-surface-doctor/v1"
 REPAIR_PLAN_SCHEMA = "loom-installed-surface-repair-plan/v1"
+WORKSPACE_SCHEMA = "loom-workspace-control/v1"
+HOST_OBJECT_SCHEMA = "loom-host-object-control/v1"
+HOST_SCHEMA = "loom-host-orchestration/v1"
+SKILLS_SCHEMA = "loom-skills-surface/v1"
 
 
 COMMANDS: list[dict[str, Any]] = [
@@ -127,34 +132,34 @@ COMMANDS: list[dict[str, Any]] = [
     {"command": "gate pr", "domain": "gate", "status": "reserved", "json": True},
     {"command": "gate merge", "domain": "gate", "status": "reserved", "json": True},
     {"command": "gate closeout", "domain": "gate", "status": "reserved", "json": True},
-    {"command": "workspace create", "domain": "host-control", "status": "reserved", "json": True},
-    {"command": "workspace locate", "domain": "host-control", "status": "reserved", "json": True},
-    {"command": "workspace check", "domain": "host-control", "status": "reserved", "json": True},
-    {"command": "workspace retire", "domain": "host-control", "status": "reserved", "json": True},
-    {"command": "issue inspect", "domain": "host-control", "status": "reserved", "json": True},
-    {"command": "issue bind", "domain": "host-control", "status": "reserved", "json": True},
-    {"command": "issue reconcile", "domain": "host-control", "status": "reserved", "json": True},
-    {"command": "project status", "domain": "host-control", "status": "reserved", "json": True},
-    {"command": "project reconcile", "domain": "host-control", "status": "reserved", "json": True},
-    {"command": "pr inspect", "domain": "host-control", "status": "reserved", "json": True},
-    {"command": "pr metadata-preflight", "domain": "host-control", "status": "reserved", "json": True},
-    {"command": "pr gate", "domain": "host-control", "status": "reserved", "json": True},
-    {"command": "merge check", "domain": "delivery", "status": "reserved", "json": True},
-    {"command": "merge run", "domain": "delivery", "status": "reserved", "json": True},
-    {"command": "reconcile", "domain": "host-control", "status": "reserved", "json": True},
-    {"command": "host list", "domain": "host", "status": "reserved", "json": True},
-    {"command": "host doctor", "domain": "host", "status": "reserved", "json": True},
-    {"command": "host install", "domain": "host", "status": "reserved", "json": True},
-    {"command": "host verify", "domain": "host", "status": "reserved", "json": True},
-    {"command": "host upgrade", "domain": "host", "status": "reserved", "json": True},
-    {"command": "host remove", "domain": "host", "status": "reserved", "json": True},
-    {"command": "skills list", "domain": "skills", "status": "reserved", "json": True},
-    {"command": "skills generate", "domain": "skills", "status": "reserved", "json": True},
-    {"command": "skills sync", "domain": "skills", "status": "reserved", "json": True},
-    {"command": "skills check", "domain": "skills", "status": "reserved", "json": True},
-    {"command": "skills doctor", "domain": "skills", "status": "reserved", "json": True},
-    {"command": "skills package", "domain": "skills", "status": "reserved", "json": True},
-    {"command": "skills release-check", "domain": "skills", "status": "reserved", "json": True},
+    {"command": "workspace create", "domain": "host-control", "status": "implemented", "json": True},
+    {"command": "workspace locate", "domain": "host-control", "status": "implemented", "json": True},
+    {"command": "workspace check", "domain": "host-control", "status": "implemented", "json": True},
+    {"command": "workspace retire", "domain": "host-control", "status": "implemented", "json": True},
+    {"command": "issue inspect", "domain": "host-control", "status": "implemented", "json": True},
+    {"command": "issue bind", "domain": "host-control", "status": "implemented", "json": True},
+    {"command": "issue reconcile", "domain": "host-control", "status": "implemented", "json": True},
+    {"command": "project status", "domain": "host-control", "status": "implemented", "json": True},
+    {"command": "project reconcile", "domain": "host-control", "status": "implemented", "json": True},
+    {"command": "pr inspect", "domain": "host-control", "status": "implemented", "json": True},
+    {"command": "pr metadata-preflight", "domain": "host-control", "status": "implemented", "json": True},
+    {"command": "pr gate", "domain": "host-control", "status": "implemented", "json": True},
+    {"command": "merge check", "domain": "delivery", "status": "implemented", "json": True},
+    {"command": "merge run", "domain": "delivery", "status": "implemented", "json": True},
+    {"command": "reconcile", "domain": "host-control", "status": "implemented", "json": True},
+    {"command": "host list", "domain": "host", "status": "implemented", "json": True},
+    {"command": "host doctor", "domain": "host", "status": "implemented", "json": True},
+    {"command": "host install", "domain": "host", "status": "implemented", "json": True},
+    {"command": "host verify", "domain": "host", "status": "implemented", "json": True},
+    {"command": "host upgrade", "domain": "host", "status": "implemented", "json": True},
+    {"command": "host remove", "domain": "host", "status": "implemented", "json": True},
+    {"command": "skills list", "domain": "skills", "status": "implemented", "json": True},
+    {"command": "skills generate", "domain": "skills", "status": "implemented", "json": True},
+    {"command": "skills sync", "domain": "skills", "status": "implemented", "json": True},
+    {"command": "skills check", "domain": "skills", "status": "implemented", "json": True},
+    {"command": "skills doctor", "domain": "skills", "status": "implemented", "json": True},
+    {"command": "skills package", "domain": "skills", "status": "implemented", "json": True},
+    {"command": "skills release-check", "domain": "skills", "status": "implemented", "json": True},
 ]
 
 COMMAND_INDEX = {entry["command"]: entry for entry in COMMANDS}
@@ -229,6 +234,53 @@ def output(command: str, result: str, **fields: Any) -> dict[str, Any]:
         "generated_at": now_iso(),
         **fields,
     }
+
+
+def run_capture(args: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=cwd, check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def parse_json_or_block(command: str, completed: subprocess.CompletedProcess[str], *, failed_layer: str, fallback_to: list[str]) -> dict[str, Any]:
+    raw = completed.stdout or completed.stderr
+    if raw:
+        try:
+            payload = json.loads(raw)
+            if payload.get("command") and payload.get("command") != command:
+                payload["wrapped_command"] = payload.get("command")
+            payload["command"] = command
+            return payload
+        except json.JSONDecodeError:
+            pass
+    if completed.returncode != 0:
+        return output(
+            command,
+            "block",
+            summary="Delegated command failed.",
+            failed_layer=failed_layer,
+            fail_closed_reason=raw.strip() if raw else f"{completed.args} failed",
+            fallback_to=fallback_to,
+        )
+    return output(
+        command,
+        "block",
+        summary="Delegated command did not emit JSON.",
+        failed_layer=failed_layer,
+        fail_closed_reason="invalid JSON from delegated command",
+        fallback_to=fallback_to,
+    )
+
+
+def flow_payload(command: str, flow_args: list[str], *, fallback_to: list[str]) -> dict[str, Any]:
+    completed = run_capture([sys.executable, str(TOOLS_ROOT / "loom_flow.py"), *flow_args])
+    return parse_json_or_block(command, completed, failed_layer="loom-flow", fallback_to=fallback_to)
+
+
+def emit_flow(command: str, flow_args: list[str], *, fallback_to: list[str]) -> int:
+    payload = flow_payload(command, flow_args, fallback_to=fallback_to)
+    if payload.get("command") and payload.get("command") != command:
+        payload["wrapped_command"] = payload.get("command")
+    payload["command"] = command
+    return emit(payload)
 
 
 def command_matrix() -> list[dict[str, Any]]:
@@ -835,6 +887,245 @@ def handle_installed_state(argv: list[str]) -> int:
     return 0
 
 
+def workspace_payload(action: str, args: argparse.Namespace) -> dict[str, Any]:
+    command = f"workspace {action}"
+    target = resolve_target(args.target)
+    item_args = ["--item", args.item] if getattr(args, "item", None) else []
+    if action in {"locate", "create", "retire"}:
+        operation = "retire" if action == "retire" else action
+        payload = flow_payload(command, ["workspace", operation, "--target", str(target), *item_args], fallback_to=["admission", "loom workspace check --target <repo> --json"])
+        if payload.get("command") and payload.get("command") != command:
+            payload["wrapped_command"] = payload.get("command")
+        payload["command"] = command
+        return payload
+    if action == "check":
+        payload = flow_payload(command, ["purity-check", "--target", str(target), *item_args], fallback_to=["admission", "loom workspace locate --target <repo> --json"])
+        if payload.get("command") and payload.get("command") != command:
+            payload["wrapped_command"] = payload.get("command")
+        payload["command"] = command
+        return payload
+    return output(command, "block", schema=WORKSPACE_SCHEMA, summary="Unsupported workspace action.", failed_layer="cli-router", fail_closed_reason=action, fallback_to=["loom help --json"])
+
+
+def handle_workspace(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="loom workspace")
+    parser.add_argument("action", choices=("create", "locate", "check", "retire"))
+    parser.add_argument("--target", default=".")
+    parser.add_argument("--path")
+    parser.add_argument("--branch")
+    parser.add_argument("--item")
+    parser.add_argument("--start-point", default="origin/main")
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    return emit(workspace_payload(args.action, args))
+
+
+def handle_issue(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="loom issue")
+    parser.add_argument("action", choices=("inspect", "bind", "reconcile"))
+    parser.add_argument("issue", nargs="?")
+    parser.add_argument("--work-item")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    command = f"issue {args.action}"
+    if args.action == "inspect":
+        if not args.issue:
+            return emit(output(command, "block", schema=HOST_OBJECT_SCHEMA, summary="Issue inspect requires an issue number.", failed_layer="issue-input", fail_closed_reason="missing issue number", fallback_to=["loom help --json"]))
+        return emit_flow(command, ["github-intake", "issue", "--target", ".", "--issue", args.issue], fallback_to=["github-intake", "manual-reconciliation"])
+    if args.action == "bind":
+        if not args.issue or not args.work_item:
+            return emit(output(command, "block", schema=HOST_OBJECT_SCHEMA, summary="Issue bind requires issue and --work-item.", failed_layer="issue-binding", fail_closed_reason="missing issue or work item", fallback_to=["loom issue inspect <issue> --json"]))
+        return emit_flow(command, ["host-binding", "inspect", "--target", ".", "--issue", args.issue], fallback_to=["loom issue inspect <issue> --json", "manual-reconciliation"])
+    flow_args = ["reconciliation", "audit", "--target", "."]
+    if args.issue:
+        flow_args.extend(["--issue", args.issue])
+    return emit_flow(command, flow_args, fallback_to=["manual-reconciliation"])
+
+
+def handle_project(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="loom project")
+    parser.add_argument("action", choices=("status", "reconcile"))
+    parser.add_argument("--issue")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    command = f"project {args.action}"
+    if args.issue:
+        flow_args = ["github-intake", "issue", "--target", ".", "--issue", args.issue]
+        return emit_flow(command, flow_args, fallback_to=["loom issue inspect <issue> --json", "manual-reconciliation"])
+    return emit(output(command, "block", schema=HOST_OBJECT_SCHEMA, summary="Project status requires --issue for this CLI contract.", failed_layer="project-input", fail_closed_reason="missing --issue", fallback_to=["loom issue inspect <issue> --json"]))
+
+
+def handle_pr(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="loom pr")
+    parser.add_argument("action", choices=("inspect", "metadata-preflight", "gate"))
+    parser.add_argument("pr", nargs="?")
+    parser.add_argument("--head-sha")
+    parser.add_argument("--work-item")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    command = f"pr {args.action}"
+    if not args.pr:
+        return emit(output(command, "block", schema=HOST_OBJECT_SCHEMA, summary="PR command requires a PR number.", failed_layer="pr-input", fail_closed_reason="missing PR number", fallback_to=["loom help --json"]))
+    if args.action == "inspect":
+        flow_args = ["host-binding", "inspect", "--target", ".", "--pr", args.pr]
+        if args.head_sha:
+            flow_args.extend(["--head-sha", args.head_sha])
+        return emit_flow(command, flow_args, fallback_to=["loom pr gate <pr> --json", "manual-reconciliation"])
+    if args.action == "metadata-preflight":
+        flow_args = ["pr-metadata", "preflight", "--target", ".", "--surface", "merge_ready", "--pr", args.pr]
+        if args.head_sha:
+            flow_args.extend(["--head-sha", args.head_sha])
+        return emit_flow(command, flow_args, fallback_to=["update PR body", "loom pr inspect <pr> --json"])
+    flow_args = ["pr-gate", "check", "--target", ".", "--pr", args.pr]
+    if args.head_sha:
+        flow_args.extend(["--head-sha", args.head_sha])
+    if args.work_item:
+        flow_args.extend(["--item", args.work_item])
+    return emit_flow(command, flow_args, fallback_to=["loom pr inspect <pr> --json", "manual-reconciliation"])
+
+
+def handle_merge(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="loom merge")
+    parser.add_argument("action", choices=("check", "run"))
+    parser.add_argument("pr")
+    parser.add_argument("--head-sha")
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    command = f"merge {args.action}"
+    flow_args = ["controlled-merge", "merge" if args.action == "run" else "check", "--target", ".", "--pr", args.pr, "--merge-method", "merge", "--delete-branch"]
+    if args.head_sha:
+        flow_args.extend(["--head-sha", args.head_sha])
+    if args.action == "run" and args.apply:
+        flow_args.append("--execute")
+    return emit_flow(command, flow_args, fallback_to=["loom pr gate <pr> --json", "loom merge check <pr> --json"])
+
+
+def handle_reconcile(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="loom reconcile")
+    parser.add_argument("--issue")
+    parser.add_argument("--pr")
+    parser.add_argument("--work-item")
+    parser.add_argument("--head-sha")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    flow_args = ["reconciliation", "audit", "--target", "."]
+    if args.issue:
+        flow_args.extend(["--issue", args.issue])
+    if args.pr:
+        flow_args.extend(["--pr", args.pr])
+    return emit_flow("reconcile", flow_args, fallback_to=["manual-reconciliation"])
+
+
+def supported_hosts(target: Path) -> list[dict[str, Any]]:
+    home = Path.home()
+    codex_home = Path(os.environ.get("CODEX_HOME", home / ".codex"))
+    claude_home = Path(os.environ.get("CLAUDE_CONFIG_DIR", home / ".claude"))
+    hosts = [
+        {
+            "id": "codex",
+            "support_status": "primary",
+            "detected": codex_home.exists(),
+            "default_mode": "full-repo",
+            "native_skill_path": str(home / ".agents" / "skills"),
+            "plugin_path": str(target / "plugins" / "loom"),
+        },
+        {
+            "id": "claude",
+            "support_status": "adapter",
+            "detected": claude_home.exists(),
+            "default_mode": "plugin",
+            "native_skill_path": str(claude_home / "skills"),
+            "plugin_path": str(target / ".claude" / "marketplaces" / "loom-local" / "plugins" / "loom"),
+        },
+        {"id": "opencode", "support_status": "adapter-contract", "detected": False, "default_mode": "full-repo"},
+        {"id": "gemini", "support_status": "adapter-contract", "detected": False, "default_mode": "full-repo"},
+        {"id": "cursor", "support_status": "adapter-contract", "detected": False, "default_mode": "full-repo"},
+    ]
+    return hosts
+
+
+def handle_host(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="loom host")
+    parser.add_argument("action", choices=("list", "doctor", "install", "verify", "upgrade", "remove"))
+    parser.add_argument("--host", default="auto", choices=("auto", "codex", "claude", "opencode", "gemini", "cursor"))
+    parser.add_argument("--mode", default="plugin", choices=("full-repo", "plugin", "skill"))
+    parser.add_argument("--skill-id")
+    parser.add_argument("--target", default=".")
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    command = f"host {args.action}"
+    target = resolve_target(args.target)
+    hosts = supported_hosts(target)
+    selected = [host for host in hosts if args.host == "auto" or host["id"] == args.host]
+    if args.action == "list":
+        return emit(output(command, "pass", schema=HOST_SCHEMA, summary="Supported host adapters listed.", target=str(target), hosts=hosts, fallback_to=None))
+    detected = [host for host in selected if host.get("detected")]
+    if args.host == "auto" and len(detected) != 1:
+        return emit(output(command, "block", schema=HOST_SCHEMA, summary="Host auto-detection is ambiguous or unavailable.", target=str(target), hosts=hosts, failed_layer="host-detection", fail_closed_reason="pass --host explicitly when zero or multiple supported hosts are detected", fallback_to=["loom host list --json", "loom host doctor --host <host> --json"]))
+    host = detected[0]["id"] if args.host == "auto" else args.host
+    if args.action == "doctor":
+        warnings = []
+        if host == "codex" and args.mode == "plugin":
+            warnings.append("Codex default remains full-repo/native skills discovery; plugin mode is adapter-managed.")
+        return emit(output(command, "pass", schema=HOST_SCHEMA, summary="Host adapter contract is readable.", target=str(target), host=host, mode=args.mode, hosts=hosts, warnings=warnings, verification=["docs/adoption/host-adapter-matrix.md", "tools/host_adapter_check.py"], fallback_to=None))
+    if args.mode == "full-repo" and args.action in {"install", "upgrade", "remove"}:
+        return emit(output(command, "block", schema=HOST_SCHEMA, summary="Full-repo host lifecycle remains operator-owned.", target=str(target), host=host, mode=args.mode, mutates=args.action != "verify", failed_layer="host-lifecycle", fail_closed_reason="CLI does not mutate full-repo clone/discovery state", fallback_to=["docs/adoption/host-adapter-matrix.md", "loom host verify --host <host> --mode plugin --json"]))
+    if args.action in {"install", "upgrade", "remove"} and not args.apply:
+        return emit(output(command, "block", schema=HOST_SCHEMA, summary=f"Host {args.action} is mutating and requires --apply.", target=str(target), host=host, mode=args.mode, mutates=True, failed_layer=f"host-{args.action}", fail_closed_reason="explicit --apply is required before adapter-managed host mutation", fallback_to=["loom host verify --host <host> --json", "loom host doctor --host <host> --json"]))
+    installer_command = {"install": "add", "upgrade": "add", "verify": "verify-upgrade", "remove": "verify-upgrade"}.get(args.action, "verify-upgrade")
+    if args.action == "remove":
+        return emit(output(command, "block", schema=HOST_SCHEMA, summary="Host remove only reports verified installed surfaces in this phase.", target=str(target), host=host, mode=args.mode, mutates=False, failed_layer="host-remove", fail_closed_reason="removal requires later rollback/delete ownership contract", fallback_to=["loom host verify --host <host> --json"]))
+    subject = ["plugin"] if args.mode == "plugin" else ["skill", args.skill_id or ""]
+    if args.mode == "skill" and not args.skill_id:
+        return emit(output(command, "block", schema=HOST_SCHEMA, summary="Skill mode requires --skill-id.", failed_layer="host-input", fail_closed_reason="missing --skill-id", fallback_to=["loom skills list --json"]))
+    installer_cli = REPO_ROOT / "packages/loom-installer/dist/src/cli.js"
+    if not installer_cli.exists():
+        return emit(output(command, "block", schema=HOST_SCHEMA, summary="Installer shim is not built.", target=str(target), host=host, mode=args.mode, failed_layer="loom-installer", fail_closed_reason=f"missing built installer CLI: {installer_cli}", fallback_to=["npm test --prefix packages/loom-installer", "npm run build --prefix packages/loom-installer"]))
+    completed = run_capture(["node", str(installer_cli), installer_command, *subject, "--host", host, "--target", str(target), "--json", *(["--force"] if args.force or args.action == "upgrade" else [])])
+    delegated = parse_json_or_block(command, completed, failed_layer="loom-installer", fallback_to=["npm test --prefix packages/loom-installer", "loom host doctor --json"])
+    result = "pass" if completed.returncode == 0 else "block"
+    return emit(output(command, result, schema=HOST_SCHEMA, summary="Host command delegated to installer shim.", target=str(target), host=host, mode=args.mode, delegated_result=delegated, failed_layer=None if result == "pass" else "loom-installer", fail_closed_reason=None if result == "pass" else delegated.get("fail_closed_reason", "installer shim failed"), fallback_to=None if result == "pass" else ["loom host doctor --json"]))
+
+
+def handle_skills(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="loom skills")
+    parser.add_argument("action", choices=("list", "generate", "sync", "check", "doctor", "package", "release-check"))
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    command = f"skills {args.action}"
+    registry = read_optional_json(SKILLS_ROOT / "registry.json") or {}
+    entries = registry.get("entries") if isinstance(registry, dict) else []
+    if args.action == "list":
+        return emit(output(command, "pass", schema=SKILLS_SCHEMA, summary="Generated skills registry listed.", registry_version=registry.get("registry_version"), root_entry=registry.get("root_entry"), skills=entries, fallback_to=None))
+    if args.action in {"generate", "sync"} and not args.apply:
+        return emit(output(command, "block", schema=SKILLS_SCHEMA, summary=f"`loom {command}` mutates the generated skills surface and requires --apply.", mutates=True, failed_layer="skills-surface", fail_closed_reason="explicit --apply is required before rewriting skills/", fallback_to=["loom skills check --json"]))
+    if args.action in {"generate", "sync"}:
+        completed = run_capture([sys.executable, str(TOOLS_ROOT / "skills_surface.py"), "generate"])
+        result = "pass" if completed.returncode == 0 else "block"
+        return emit(output(command, result, schema=SKILLS_SCHEMA, summary="Generated skills surface refreshed." if result == "pass" else "Skills generation failed.", mutates=True, stdout=completed.stdout.strip(), failed_layer=None if result == "pass" else "skills-surface", fail_closed_reason=None if result == "pass" else completed.stderr.strip(), fallback_to=None if result == "pass" else ["python3 tools/skills_surface.py check"]))
+    if args.action in {"check", "doctor", "release-check"}:
+        checks = [[sys.executable, str(TOOLS_ROOT / "skills_surface.py"), "check"]]
+        if args.action == "release-check":
+            checks.extend([[sys.executable, str(TOOLS_ROOT / "host_adapter_check.py")], [sys.executable, str(TOOLS_ROOT / "version_surface_check.py")]])
+        results = []
+        for check in checks:
+            completed = run_capture(check)
+            results.append({"command": " ".join(check), "returncode": completed.returncode, "stdout": completed.stdout.strip(), "stderr": completed.stderr.strip()})
+        failures = [item for item in results if item["returncode"] != 0]
+        result = "pass" if not failures else "block"
+        return emit(output(command, result, schema=SKILLS_SCHEMA, summary="Skills surface checks passed." if result == "pass" else "Skills surface checks failed.", registry_version=registry.get("registry_version"), root_entry=registry.get("root_entry"), checks=results, failed_layer=None if result == "pass" else "skills-surface", fail_closed_reason=None if result == "pass" else "one or more skills checks failed", fallback_to=None if result == "pass" else ["loom skills generate --apply --json"]))
+    package_records = []
+    for entry in entries or []:
+        package_path = SKILLS_ROOT / entry["id"] / "loom-package.json"
+        package_records.append(read_optional_json(package_path) or {"package_id": entry["id"], "missing": str(package_path)})
+    return emit(output(command, "pass", schema=SKILLS_SCHEMA, summary="Skill package metadata collected without packing artifacts.", mutates=False, registry_version=registry.get("registry_version"), packages=package_records, fallback_to=["npm run check:release --prefix packages/loom-installer"]))
+
+
 def dispatch(command: str, forwarded_args: list[str]) -> int:
     tool_name, prefix = COMMAND_ROUTES[command]
     tool_path = TOOLS_ROOT / tool_name
@@ -911,6 +1202,29 @@ def main(argv: list[str]) -> int:
     if command == "repair" or command.startswith("repair "):
         repair_args = command.split()[1:] + forwarded if command.startswith("repair ") else forwarded
         return handle_repair(repair_args)
+    if command == "workspace" or command.startswith("workspace "):
+        workspace_args = command.split()[1:] + forwarded if command.startswith("workspace ") else forwarded
+        return handle_workspace(workspace_args)
+    if command == "issue" or command.startswith("issue "):
+        issue_args = command.split()[1:] + forwarded if command.startswith("issue ") else forwarded
+        return handle_issue(issue_args)
+    if command == "project" or command.startswith("project "):
+        project_args = command.split()[1:] + forwarded if command.startswith("project ") else forwarded
+        return handle_project(project_args)
+    if command == "pr" or command.startswith("pr "):
+        pr_args = command.split()[1:] + forwarded if command.startswith("pr ") else forwarded
+        return handle_pr(pr_args)
+    if command == "merge" or command.startswith("merge "):
+        merge_args = command.split()[1:] + forwarded if command.startswith("merge ") else forwarded
+        return handle_merge(merge_args)
+    if command == "reconcile":
+        return handle_reconcile(forwarded)
+    if command == "host" or command.startswith("host "):
+        host_args = command.split()[1:] + forwarded if command.startswith("host ") else forwarded
+        return handle_host(host_args)
+    if command == "skills" or command.startswith("skills "):
+        skills_args = command.split()[1:] + forwarded if command.startswith("skills ") else forwarded
+        return handle_skills(skills_args)
     if command in COMMAND_ROUTES:
         return dispatch(command, forwarded)
     if command in COMMAND_INDEX:


### PR DESCRIPTION
## Summary

- Implements the CLI-first command surface for #893/#894/#895: workspace, issue, project, PR, merge, reconcile, host, and skills domains.
- Keeps host-control commands as thin JSON wrappers over existing Loom harness readers instead of creating a second GitHub truth source.
- Freezes host and skills fail-closed behavior: adapter mutations require explicit `--apply`; skills generate/sync require `--apply`; host remove remains non-mutating until rollback/delete ownership is approved.
- Adds WI-929 carriers and marks WI-906 terminal after PR #993 merge.

## Loom Work Item

Loom Work Item: WI-929

WI-929

## Scope

Refs #885
Refs #893
Refs #894
Refs #895
Closes #929
Closes #930
Closes #931
Closes #932
Closes #933
Closes #934
Closes #935
Closes #936
Closes #937
Closes #938
Closes #939
Closes #940
Closes #941
Closes #942
Closes #943

## Validation

- `python3 -m py_compile tools/loom.py tools/check_cli_contract.py`
- `python3 tools/check_cli_contract.py`
- `python3 tools/loom.py host doctor --host codex --target . --json`
- `python3 tools/loom.py skills release-check --json`
- `python3 tools/loom.py workspace check --target . --item WI-929 --json`
- `python3 .loom/bin/loom_init.py fact-chain --target .`
- `python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-929`
- `python3 .loom/bin/loom_flow.py shadow-parity --target .`
- `npm test --prefix packages/loom-installer`
- `make check`
