### PR TITLE
docs: 同步 #1013 closeout 状态载体

### DIFF
--- a/.loom/progress/WI-1013.md
+++ b/.loom/progress/WI-1013.md
@@ -4,11 +4,11 @@
 
 - Item ID: WI-1013
 - Current Checkpoint: merge checkpoint
-- Current Stop: SDD boundary docs, WI-1013 carriers, PR body `Loom Work Item: WI-1013`, origin/main sync, terminal WI-1001/WI-1005 carrier cleanup, and refreshed semantic review record are committed locally for PR #1054.
-- Next Step: Push refreshed PR #1054 head, consume host checks, merge when host checks pass, then close out #1013 and child WIs.
+- Current Stop: PR #1054 merged as `fea03a62366c057ef8671bc163262b58978402f3`; #1013, #1021, #1022, and #1023 are closed as completed.
+- Next Step: None for WI-1013. Follow-up consumers continue under #1014 delivery planning, #1015 story intake, and #1016 full/minimal spec suite.
 - Blockers: None recorded.
-- Latest Validation Summary: Passed locally after syncing origin/main: `git diff --check`; targeted ledger/landing-map ID check for `EXT-0061` / `EXT-0062` / `EXT-0063`; targeted no-copy check for `docs/spec-kit` and `.specify`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`; `python3 .loom/bin/loom_init.py fact-chain --target .`; `python3 .loom/bin/loom_flow.py carrier refresh --target . --item WI-1013 --write`.
-- Recovery Boundary: Continue only #1013 / #1021 / #1022 / #1023 boundary closeout. Do not expand into #1014, #1015, #1016, task carrier, gate-chain, or CLI implementation.
+- Latest Validation Summary: PR #1054 merged after GitHub checks passed: `py-compile`, `demo-bootstrap`, `repo-local-cli`, `root-self-governance`, `loom-check`, `loom-pr-merge-gate`, `release-judgment`, and `gate`. Local pre-merge evidence passed: `git diff --check`; targeted ledger/landing-map ID check for `EXT-0061` / `EXT-0062` / `EXT-0063`; targeted no-copy check for `docs/spec-kit` and `.specify`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`; `python3 .loom/bin/loom_init.py fact-chain --target .`; `python3 .loom/bin/loom_flow.py shadow-parity --target .`; PR #1054 head `fdd0fc772e07dbd9ba3d58e64a0bdcabc7c35170`; merge commit `fea03a62366c057ef8671bc163262b58978402f3`.
+- Recovery Boundary: #1013 / #1021 / #1022 / #1023 boundary closeout only. Do not expand into #1014, #1015, #1016, task carrier, gate-chain, or CLI implementation.
 - Current Lane: sdd-operating-layer-boundary
 
 ## Execution Ledger
@@ -16,6 +16,6 @@
 - Ledger Binding: recovery_entry
 - Plan Locator: `.loom/specs/WI-1013/plan.md`
 - Acceptance Locator: `.loom/specs/WI-1013/spec.md`
-- Validation Evidence Locator: `.loom/progress/WI-1013.md`; `.loom/reviews/WI-1013.json`; PR #1054 checks
+- Validation Evidence Locator: `.loom/progress/WI-1013.md`; `.loom/reviews/WI-1013.json`; PR #1054 checks; #1013 closeout comment https://github.com/MC-and-his-Agents/Loom/issues/1013#issuecomment-4535830551
 - Handoff Notes Locator: not_applicable
 - Evidence Freshness: current

--- a/.loom/reviews/WI-1013.json
+++ b/.loom/reviews/WI-1013.json
@@ -3,10 +3,10 @@
   "item_id": "WI-1013",
   "decision": "allow",
   "kind": "general_review",
-  "summary": "WI-1013 implementation is approved after syncing origin/main: SDD remains internalized as a Loom execution discipline, spec-kit keep/adapt/drop evidence is preserved, #1053/WI-1005 is terminal, and this PR still does not implement #1014/#1015/#1016.",
+  "summary": "WI-1013 closeout carrier sync is approved: PR #1054 is merged, #1013/#1021/#1022/#1023 are closed completed, status/progress now consume that host truth, and this PR still does not implement #1014/#1015/#1016.",
   "reviewer": "codex-main-agent",
-  "reviewed_head": "7ed9ce57a350283021d66ec0bbebad664c72839e",
-  "reviewed_validation_summary": "Passed locally after syncing origin/main: `git diff --check`; targeted ledger/landing-map ID check for `EXT-0061` / `EXT-0062` / `EXT-0063`; targeted no-copy check for `docs/spec-kit` and `.specify`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`; `python3 .loom/bin/loom_init.py fact-chain --target .`; `python3 .loom/bin/loom_flow.py carrier refresh --target . --item WI-1013 --write`.",
+  "reviewed_head": "28e36ffc8b4eca35cb99ca4e9800bdff94623394",
+  "reviewed_validation_summary": "PR #1054 merged after GitHub checks passed: `py-compile`, `demo-bootstrap`, `repo-local-cli`, `root-self-governance`, `loom-check`, `loom-pr-merge-gate`, `release-judgment`, and `gate`. Local pre-merge evidence passed: `git diff --check`; targeted ledger/landing-map ID check for `EXT-0061` / `EXT-0062` / `EXT-0063`; targeted no-copy check for `docs/spec-kit` and `.specify`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`; `python3 .loom/bin/loom_init.py fact-chain --target .`; `python3 .loom/bin/loom_flow.py shadow-parity --target .`; PR #1054 head `fdd0fc772e07dbd9ba3d58e64a0bdcabc7c35170`; merge commit `fea03a62366c057ef8671bc163262b58978402f3`.",
   "fallback_to": null,
   "findings": [
     {

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "374810c9c7fd915ffd99fad15464052a4fb403694d816c949b4cb3838d6f5950"
+    ".loom/status/current.md": "5704bc38863aa56346a1100a95c9955f2cf18e2e83d2c6595f6f3830fac8f7a7"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "374810c9c7fd915ffd99fad15464052a4fb403694d816c949b4cb3838d6f5950"
+    ".loom/status/current.md": "5704bc38863aa56346a1100a95c9955f2cf18e2e83d2c6595f6f3830fac8f7a7"
   }
 }

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -12,11 +12,11 @@
 - Validation Entry: git diff --check; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 tools/loom.py verify --target . --json; python3 tools/loom.py doctor --target . --json
 - Closing Condition: #1021, #1022, and #1023 are covered by PR #1054; #1013 documents SDD as a Loom execution discipline, records keep/adapt/drop spec-kit evidence, and leaves #1014/#1015/#1016 able to consume the boundary without re-litigating scope.
 - Current Checkpoint: merge checkpoint
-- Current Stop: SDD boundary docs, WI-1013 carriers, PR body `Loom Work Item: WI-1013`, origin/main sync, terminal WI-1001/WI-1005 carrier cleanup, and refreshed semantic review record are committed locally for PR #1054.
-- Next Step: Push refreshed PR #1054 head, consume host checks, merge when host checks pass, then close out #1013 and child WIs.
+- Current Stop: PR #1054 merged as `fea03a62366c057ef8671bc163262b58978402f3`; #1013, #1021, #1022, and #1023 are closed as completed.
+- Next Step: None for WI-1013. Follow-up consumers continue under #1014 delivery planning, #1015 story intake, and #1016 full/minimal spec suite.
 - Blockers: None recorded.
-- Latest Validation Summary: Passed locally after syncing origin/main: `git diff --check`; targeted ledger/landing-map ID check for `EXT-0061` / `EXT-0062` / `EXT-0063`; targeted no-copy check for `docs/spec-kit` and `.specify`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`; `python3 .loom/bin/loom_init.py fact-chain --target .`; `python3 .loom/bin/loom_flow.py carrier refresh --target . --item WI-1013 --write`.
-- Recovery Boundary: Continue only #1013 / #1021 / #1022 / #1023 boundary closeout. Do not expand into #1014, #1015, #1016, task carrier, gate-chain, or CLI implementation.
+- Latest Validation Summary: PR #1054 merged after GitHub checks passed: `py-compile`, `demo-bootstrap`, `repo-local-cli`, `root-self-governance`, `loom-check`, `loom-pr-merge-gate`, `release-judgment`, and `gate`. Local pre-merge evidence passed: `git diff --check`; targeted ledger/landing-map ID check for `EXT-0061` / `EXT-0062` / `EXT-0063`; targeted no-copy check for `docs/spec-kit` and `.specify`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`; `python3 .loom/bin/loom_init.py fact-chain --target .`; `python3 .loom/bin/loom_flow.py shadow-parity --target .`; PR #1054 head `fdd0fc772e07dbd9ba3d58e64a0bdcabc7c35170`; merge commit `fea03a62366c057ef8671bc163262b58978402f3`.
+- Recovery Boundary: #1013 / #1021 / #1022 / #1023 boundary closeout only. Do not expand into #1014, #1015, #1016, task carrier, gate-chain, or CLI implementation.
 - Current Lane: sdd-operating-layer-boundary
 
 ## Runtime Evidence


### PR DESCRIPTION
Loom Work Item: WI-1013

## Summary

同步 #1013 在 PR #1054 合并后的 repo-local closeout 状态载体，避免 `.loom/progress/WI-1013.md` 和 `.loom/status/current.md` 继续显示“等待推送/合并”。

## Validation

- `git diff --check`
- `PYTHONDONTWRITEBYTECODE=1 python3 .loom/bin/loom_init.py fact-chain --target .`
- `PYTHONDONTWRITEBYTECODE=1 python3 .loom/bin/loom_flow.py shadow-parity --target .`
- `PYTHONDONTWRITEBYTECODE=1 python3 .loom/bin/loom_flow.py checkpoint merge --target . --item WI-1013`
- `python3 tools/loom_check.py --profile source --source-surface contract-only .`

## Risks And Follow-ups

- 不实现 #1014、#1015、#1016。
- 不修改 task carrier、gate-chain 或 CLI 语义。
- 保持 `Current Checkpoint: merge checkpoint`，避免把 terminal closeout 语义混入本 PR。

## Related Work

- PR #1054 已完成 #1013 / #1021 / #1022 / #1023。
- #1014、#1015、#1016 已写入来自 #1013 的消费边界 comment。

Closes no issue; #1013 已由 PR #1054 关闭为 completed，本 PR 只修正本地状态载体与 closeout evidence。