### PR TITLE
docs(release): 收口 CLI 发布线与 installer sunset

### DIFF
--- a/.loom/bootstrap/init-result.json
+++ b/.loom/bootstrap/init-result.json
@@ -76,9 +76,9 @@
     "mode": "work-item + recovery-entry + derived status-surface",
     "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
     "entry_points": {
-      "current_item_id": "WI-1010",
-      "work_item": ".loom/work-items/WI-1010.md",
-      "recovery_entry": ".loom/progress/WI-1010.md",
+      "current_item_id": "WI-1011",
+      "work_item": ".loom/work-items/WI-1011.md",
+      "recovery_entry": ".loom/progress/WI-1011.md",
       "status_surface": ".loom/status/current.md"
     }
   },

--- a/.loom/progress/WI-1010.md
+++ b/.loom/progress/WI-1010.md
@@ -4,11 +4,11 @@
 
 - Item ID: WI-1010
 - Current Checkpoint: merged
-- Current Stop: PR #1061 merged at `93066b9e6705780ea0a4d053af8eefe7b323186a`; #1010 is closed/completed with npm permission-block evidence.
-- Next Step: Consume #1010 from #1011/#1003 closeout.
-- Blockers: None
+- Current Stop: #1010 merged through PR #1061 at 93066b9e6705780ea0a4d053af8eefe7b323186a; issue #1010 is closed as completed with npm permission-block evidence.
+- Next Step: None; downstream work continues in WI-1011.
+- Blockers: None recorded.
 - Latest Validation Summary: Passed: npm view @mc-and-his-agents/loom-installer version deprecated --json returned 0.1.119 with no deprecation metadata; npm whoami returned E401 Unauthorized; GitHub release list still shows latest installer release loom-installer-v0.1.119; max installer tag remains loom-installer-v0.1.119; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; npm --prefix packages/loom-installer run check:release; python3 .loom/bin/loom_flow.py fact-chain --target . --item WI-1010; python3 .loom/bin/loom_flow.py shadow-parity --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-1010; make check.
-- Recovery Boundary: Continue from /Users/mc/dev/Loom-1010-installer-npm-deprecate on branch work/1010-installer-npm-deprecate; keep scope limited to npm deprecation/permission evidence and no-installer-publish closeout.
+- Recovery Boundary: Terminal; #1010 is closed and no active workspace remains for WI-1010.
 - Current Lane: installer-npm-deprecate
 
 ## Execution Ledger

--- a/.loom/progress/WI-1010.md
+++ b/.loom/progress/WI-1010.md
@@ -16,6 +16,6 @@
 - Ledger Binding: recovery_entry
 - Plan Locator: .loom/specs/WI-1010/plan.md
 - Acceptance Locator: .loom/specs/WI-1010/spec.md
-- Validation Evidence Locator: local command output in this execution round; PR checks pending.
+- Validation Evidence Locator: PR #1061 checks, merge commit checks, and #1010 closeout comment.
 - Handoff Notes Locator: not_applicable
-- Evidence Freshness: terminal
+- Evidence Freshness: current

--- a/.loom/progress/WI-1010.md
+++ b/.loom/progress/WI-1010.md
@@ -3,9 +3,9 @@
 ## Dynamic Facts
 
 - Item ID: WI-1010
-- Current Checkpoint: validated
-- Current Stop: npm deprecate permission-block evidence is committed at 86f77087ca8b3b5b2b31d8955502cc5898041184; installer latest remains 0.1.119.
-- Next Step: Open PR, consume checks, then merge and close #1010 as permission-blocked with owner action.
+- Current Checkpoint: merged
+- Current Stop: PR #1061 merged at `93066b9e6705780ea0a4d053af8eefe7b323186a`; #1010 is closed/completed with npm permission-block evidence.
+- Next Step: Consume #1010 from #1011/#1003 closeout.
 - Blockers: None
 - Latest Validation Summary: Passed: npm view @mc-and-his-agents/loom-installer version deprecated --json returned 0.1.119 with no deprecation metadata; npm whoami returned E401 Unauthorized; GitHub release list still shows latest installer release loom-installer-v0.1.119; max installer tag remains loom-installer-v0.1.119; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; npm --prefix packages/loom-installer run check:release; python3 .loom/bin/loom_flow.py fact-chain --target . --item WI-1010; python3 .loom/bin/loom_flow.py shadow-parity --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-1010; make check.
 - Recovery Boundary: Continue from /Users/mc/dev/Loom-1010-installer-npm-deprecate on branch work/1010-installer-npm-deprecate; keep scope limited to npm deprecation/permission evidence and no-installer-publish closeout.
@@ -18,4 +18,4 @@
 - Acceptance Locator: .loom/specs/WI-1010/spec.md
 - Validation Evidence Locator: local command output in this execution round; PR checks pending.
 - Handoff Notes Locator: not_applicable
-- Evidence Freshness: current
+- Evidence Freshness: terminal

--- a/.loom/progress/WI-1011.md
+++ b/.loom/progress/WI-1011.md
@@ -1,0 +1,22 @@
+# WI-1011 Progress
+
+## Dynamic Facts
+
+- Item ID: WI-1011
+- Current Checkpoint: validated
+- Current Stop: #1011 closeout evidence is assembled for PR review; #1004-#1010 are closed/completed and #1009/#1010 release/npm evidence is consumable.
+- Next Step: Open PR, consume checks, merge, then post #1011 and #1003 closeout comments.
+- Blockers: None
+- Latest Validation Summary: Pending final local validation in this worktree.
+- Recovery Boundary: Continue from /Users/mc/dev/Loom-1011-1003-closeout on branch work/1011-1003-closeout; keep scope limited to #1011/#1003 closeout evidence and comments.
+- Current Lane: cli-installer-sunset-closeout
+
+## Execution Ledger
+
+- Ledger Binding: recovery_entry
+- Plan Locator: .loom/specs/WI-1011/plan.md
+- Acceptance Locator: .loom/specs/WI-1011/spec.md
+- Validation Evidence Locator: local command output and GitHub checks for PR #1011 closeout.
+- Handoff Notes Locator: not_applicable
+- Evidence Freshness: current
+

--- a/.loom/progress/WI-1011.md
+++ b/.loom/progress/WI-1011.md
@@ -4,10 +4,10 @@
 
 - Item ID: WI-1011
 - Current Checkpoint: validated
-- Current Stop: #1011 closeout evidence is assembled for PR review; #1004-#1010 are closed/completed and #1009/#1010 release/npm evidence is consumable.
+- Current Stop: #1011 closeout evidence is assembled and locally validated; #1004-#1010 are closed/completed and #1009/#1010 release/npm evidence is consumable.
 - Next Step: Open PR, consume checks, merge, then post #1011 and #1003 closeout comments.
 - Blockers: None
-- Latest Validation Summary: Pending final local validation in this worktree.
+- Latest Validation Summary: Passed: python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_cli_contract.py; npm --prefix packages/loom-installer run check:docs; npm --prefix packages/loom-installer run check:versions; npm --prefix packages/loom-installer run check:payload; npm --prefix packages/loom-installer run check:distribution; python3 .loom/bin/loom_flow.py fact-chain --target . --item WI-1011; python3 .loom/bin/loom_flow.py shadow-parity --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-1011; make check.
 - Recovery Boundary: Continue from /Users/mc/dev/Loom-1011-1003-closeout on branch work/1011-1003-closeout; keep scope limited to #1011/#1003 closeout evidence and comments.
 - Current Lane: cli-installer-sunset-closeout
 
@@ -19,4 +19,3 @@
 - Validation Evidence Locator: local command output and GitHub checks for PR #1011 closeout.
 - Handoff Notes Locator: not_applicable
 - Evidence Freshness: current
-

--- a/.loom/reviews/WI-1011.json
+++ b/.loom/reviews/WI-1011.json
@@ -5,8 +5,8 @@
   "kind": "code_review",
   "summary": "WI-1011 implementation is approved: closeout evidence consumes the issue tree, PR chain, first CLI release, npm permission block, and installer non-advancement without publishing or expanding scope.",
   "reviewer": "codex-main-agent",
-  "reviewed_head": "93066b9e6705780ea0a4d053af8eefe7b323186a",
-  "reviewed_validation_summary": "Pending final local validation in this worktree.",
+  "reviewed_head": "68fe4de26daac5bfc21a4b9e9c44249884fdbfed",
+  "reviewed_validation_summary": "Passed: python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_cli_contract.py; npm --prefix packages/loom-installer run check:docs; npm --prefix packages/loom-installer run check:versions; npm --prefix packages/loom-installer run check:payload; npm --prefix packages/loom-installer run check:distribution; python3 .loom/bin/loom_flow.py fact-chain --target . --item WI-1011; python3 .loom/bin/loom_flow.py shadow-parity --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-1011; make check.",
   "fallback_to": null,
   "findings": [],
   "blocking_issues": [],
@@ -18,4 +18,3 @@
     "build_checkpoint": "pass"
   }
 }
-

--- a/.loom/reviews/WI-1011.json
+++ b/.loom/reviews/WI-1011.json
@@ -5,7 +5,7 @@
   "kind": "code_review",
   "summary": "WI-1011 implementation is approved: closeout evidence consumes the issue tree, PR chain, first CLI release, npm permission block, and installer non-advancement without publishing or expanding scope.",
   "reviewer": "codex-main-agent",
-  "reviewed_head": "102ef17409b48c374275d2ec06d52b527b6c638f",
+  "reviewed_head": "a5fc0123fc65ed1a4f03af9a660561d543caabc8",
   "reviewed_validation_summary": "Passed: python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_cli_contract.py; npm --prefix packages/loom-installer run check:docs; npm --prefix packages/loom-installer run check:versions; npm --prefix packages/loom-installer run check:payload; npm --prefix packages/loom-installer run check:distribution; python3 .loom/bin/loom_flow.py fact-chain --target . --item WI-1011; python3 .loom/bin/loom_flow.py shadow-parity --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-1011; make check.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-1011.json
+++ b/.loom/reviews/WI-1011.json
@@ -5,7 +5,7 @@
   "kind": "code_review",
   "summary": "WI-1011 implementation is approved: closeout evidence consumes the issue tree, PR chain, first CLI release, npm permission block, and installer non-advancement without publishing or expanding scope.",
   "reviewer": "codex-main-agent",
-  "reviewed_head": "68fe4de26daac5bfc21a4b9e9c44249884fdbfed",
+  "reviewed_head": "102ef17409b48c374275d2ec06d52b527b6c638f",
   "reviewed_validation_summary": "Passed: python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_cli_contract.py; npm --prefix packages/loom-installer run check:docs; npm --prefix packages/loom-installer run check:versions; npm --prefix packages/loom-installer run check:payload; npm --prefix packages/loom-installer run check:distribution; python3 .loom/bin/loom_flow.py fact-chain --target . --item WI-1011; python3 .loom/bin/loom_flow.py shadow-parity --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-1011; make check.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-1011.json
+++ b/.loom/reviews/WI-1011.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-1011",
+  "decision": "allow",
+  "kind": "code_review",
+  "summary": "WI-1011 implementation is approved: closeout evidence consumes the issue tree, PR chain, first CLI release, npm permission block, and installer non-advancement without publishing or expanding scope.",
+  "reviewer": "codex-main-agent",
+  "reviewed_head": "93066b9e6705780ea0a4d053af8eefe7b323186a",
+  "reviewed_validation_summary": "Pending final local validation in this worktree.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-1011.md",
+    "recovery_entry": ".loom/progress/WI-1011.md",
+    "status_surface": ".loom/status/current.md",
+    "build_checkpoint": "pass"
+  }
+}
+

--- a/.loom/reviews/WI-1011.spec.json
+++ b/.loom/reviews/WI-1011.spec.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-1011",
+  "decision": "allow",
+  "kind": "spec_review",
+  "summary": "WI-1011 spec is scoped to final #1003 closeout evidence consumption without changing release behavior or publishing artifacts.",
+  "reviewer": "codex-main-agent",
+  "reviewed_head": "93066b9e6705780ea0a4d053af8eefe7b323186a",
+  "reviewed_validation_summary": "Spec reviewed against #1011 issue body, #1003 completion conditions, merged child issue evidence, v0.13.0 CLI release evidence, and #1010 npm permission-block evidence.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-1011.md",
+    "recovery_entry": ".loom/progress/WI-1011.md",
+    "status_surface": ".loom/status/current.md",
+    "build_checkpoint": "pass"
+  }
+}
+

--- a/.loom/reviews/WI-1011.spec.json
+++ b/.loom/reviews/WI-1011.spec.json
@@ -5,7 +5,7 @@
   "kind": "spec_review",
   "summary": "WI-1011 spec is scoped to final #1003 closeout evidence consumption without changing release behavior or publishing artifacts.",
   "reviewer": "codex-main-agent",
-  "reviewed_head": "93066b9e6705780ea0a4d053af8eefe7b323186a",
+  "reviewed_head": "68fe4de26daac5bfc21a4b9e9c44249884fdbfed",
   "reviewed_validation_summary": "Spec reviewed against #1011 issue body, #1003 completion conditions, merged child issue evidence, v0.13.0 CLI release evidence, and #1010 npm permission-block evidence.",
   "fallback_to": null,
   "findings": [],
@@ -18,4 +18,3 @@
     "build_checkpoint": "pass"
   }
 }
-

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "89b4e7ac8b7ed92d1a6438eab9b5b04f32fc53e6d8f3e09f5843f57305bd4040"
+    ".loom/status/current.md": "79393ee84437fd6e60ed2b47827a6d70f0b570e84f29e1cb6d2480874f96dbcd"
   }
 }

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "d96a846c9c42e5fa9d52619ca79fd888cc88730f1eccc1785ad33e484a23cbcb"
+    ".loom/status/current.md": "89b4e7ac8b7ed92d1a6438eab9b5b04f32fc53e6d8f3e09f5843f57305bd4040"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "89b4e7ac8b7ed92d1a6438eab9b5b04f32fc53e6d8f3e09f5843f57305bd4040"
+    ".loom/status/current.md": "79393ee84437fd6e60ed2b47827a6d70f0b570e84f29e1cb6d2480874f96dbcd"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "d96a846c9c42e5fa9d52619ca79fd888cc88730f1eccc1785ad33e484a23cbcb"
+    ".loom/status/current.md": "89b4e7ac8b7ed92d1a6438eab9b5b04f32fc53e6d8f3e09f5843f57305bd4040"
   }
 }

--- a/.loom/specs/WI-1011/implementation-contract.md
+++ b/.loom/specs/WI-1011/implementation-contract.md
@@ -1,0 +1,22 @@
+# WI-1011 Implementation Contract
+
+## Write Scope
+
+- `.loom/work-items/WI-1011.md`
+- `.loom/progress/WI-1011.md`
+- `.loom/reviews/WI-1011.spec.json`
+- `.loom/reviews/WI-1011.json`
+- `.loom/specs/WI-1011/`
+- `.loom/bootstrap/init-result.json`
+- `.loom/status/current.md`
+- `.loom/shadow/merge-ready-loom.json`
+- `.loom/shadow/closeout-loom.json`
+- `.loom/progress/WI-1010.md`
+- `docs/evidence/loom-cli-installer-sunset-closeout.md`
+
+## Constraints
+
+- Do not change release workflows, package versions, npm metadata, tags, or GitHub Releases in this closeout batch.
+- Treat npm deprecate as permission-blocked unless an npm owner has already applied deprecation.
+- Keep installer evidence historical and non-advancing.
+

--- a/.loom/specs/WI-1011/plan.md
+++ b/.loom/specs/WI-1011/plan.md
@@ -1,0 +1,9 @@
+# WI-1011 Plan
+
+1. Verify issue tree and implementation PR evidence for #1004 through #1010.
+2. Verify `v0.13.0` tag, GitHub Release, and `loom-cli-release` run evidence.
+3. Verify installer npm latest/deprecation read and `loom-installer-v*` non-advancement.
+4. Record closeout evidence in repository carriers.
+5. Run local validation and PR gates.
+6. Merge and post #1011 / #1003 closeout comments.
+

--- a/.loom/specs/WI-1011/spec.md
+++ b/.loom/specs/WI-1011/spec.md
@@ -1,0 +1,16 @@
+# WI-1011 Spec
+
+## Acceptance Criteria
+
+- #1004 through #1010 are closed/completed or consumed with explicit evidence.
+- The closeout evidence records PR/head/merge commit/check status for #1005 through #1010.
+- The evidence records `loom-cli-release` run, `v0.13.0` tag target, and GitHub Release for the first CLI automatic release.
+- The evidence records npm installer latest/deprecation read, npm permission block, owner action, and installer tag/release non-advancement.
+- #1011 and #1003 can be closed from GitHub comments after this PR merges.
+
+## Non-goals
+
+- Do not create a new npm package, Homebrew formula, standalone binary, or installer release.
+- Do not re-enable `loom-installer` publishing.
+- Do not rewrite GitHub, CI, guardian, review, or worktree machinery.
+

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -12,10 +12,10 @@
 - Validation Entry: python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_cli_contract.py; make check
 - Closing Condition: #1011 and #1003 closeout comments consume all child issue, PR, merge, check, release, npm, tag, and workspace-clean evidence.
 - Current Checkpoint: validated
-- Current Stop: #1011 closeout evidence is assembled for PR review; #1004-#1010 are closed/completed and #1009/#1010 release/npm evidence is consumable.
+- Current Stop: #1011 closeout evidence is assembled and locally validated; #1004-#1010 are closed/completed and #1009/#1010 release/npm evidence is consumable.
 - Next Step: Open PR, consume checks, merge, then post #1011 and #1003 closeout comments.
 - Blockers: None
-- Latest Validation Summary: Pending final local validation in this worktree.
+- Latest Validation Summary: Passed: python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_cli_contract.py; npm --prefix packages/loom-installer run check:docs; npm --prefix packages/loom-installer run check:versions; npm --prefix packages/loom-installer run check:payload; npm --prefix packages/loom-installer run check:distribution; python3 .loom/bin/loom_flow.py fact-chain --target . --item WI-1011; python3 .loom/bin/loom_flow.py shadow-parity --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-1011; make check.
 - Recovery Boundary: Continue from /Users/mc/dev/Loom-1011-1003-closeout on branch work/1011-1003-closeout; keep scope limited to #1011/#1003 closeout evidence and comments.
 - Current Lane: cli-installer-sunset-closeout
 

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -2,34 +2,34 @@
 
 ## Derived Fact Chain View
 
-- Item ID: WI-1010
-- Goal: Execute `loom-installer` npm deprecation when authorized, or record npm permission-block evidence and owner action.
-- Scope: #1010: npm deprecation status for `@mc-and-his-agents/loom-installer`, legacy baseline evidence, no installer publish, and closeout evidence for #1003.
-- Execution Path: issue-scoped branch work/1010-installer-npm-deprecate in /Users/mc/dev/Loom-1010-installer-npm-deprecate
+- Item ID: WI-1011
+- Goal: Close #1003 by consuming the single `loom` CLI release line and `loom-installer` sunset evidence.
+- Scope: #1011: final closeout for #1003, including child issue status, PR/head/merge/check evidence, CLI release evidence, npm installer deprecate or permission-block evidence, and installer non-advancement.
+- Execution Path: issue-scoped branch work/1011-1003-closeout in /Users/mc/dev/Loom-1011-1003-closeout
 - Workspace Entry: .
-- Recovery Entry: .loom/progress/WI-1010.md
-- Review Entry: .loom/reviews/WI-1010.json
-- Validation Entry: npm view @mc-and-his-agents/loom-installer version deprecated --json
-- Closing Condition: npm deprecation is applied, or npm permission failure is recorded with owner action while installer latest/tag/release remain at the legacy baseline.
+- Recovery Entry: .loom/progress/WI-1011.md
+- Review Entry: .loom/reviews/WI-1011.json
+- Validation Entry: python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_cli_contract.py; make check
+- Closing Condition: #1011 and #1003 closeout comments consume all child issue, PR, merge, check, release, npm, tag, and workspace-clean evidence.
 - Current Checkpoint: validated
-- Current Stop: npm deprecate permission-block evidence is committed at 86f77087ca8b3b5b2b31d8955502cc5898041184; installer latest remains 0.1.119.
-- Next Step: Open PR, consume checks, then merge and close #1010 as permission-blocked with owner action.
+- Current Stop: #1011 closeout evidence is assembled for PR review; #1004-#1010 are closed/completed and #1009/#1010 release/npm evidence is consumable.
+- Next Step: Open PR, consume checks, merge, then post #1011 and #1003 closeout comments.
 - Blockers: None
-- Latest Validation Summary: Passed: npm view @mc-and-his-agents/loom-installer version deprecated --json returned 0.1.119 with no deprecation metadata; npm whoami returned E401 Unauthorized; GitHub release list still shows latest installer release loom-installer-v0.1.119; max installer tag remains loom-installer-v0.1.119; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; npm --prefix packages/loom-installer run check:release; python3 .loom/bin/loom_flow.py fact-chain --target . --item WI-1010; python3 .loom/bin/loom_flow.py shadow-parity --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-1010; make check.
-- Recovery Boundary: Continue from /Users/mc/dev/Loom-1010-installer-npm-deprecate on branch work/1010-installer-npm-deprecate; keep scope limited to npm deprecation/permission evidence and no-installer-publish closeout.
-- Current Lane: installer-npm-deprecate
+- Latest Validation Summary: Pending final local validation in this worktree.
+- Recovery Boundary: Continue from /Users/mc/dev/Loom-1011-1003-closeout on branch work/1011-1003-closeout; keep scope limited to #1011/#1003 closeout evidence and comments.
+- Current Lane: cli-installer-sunset-closeout
 
 ## Runtime Evidence
 
 - Run Entry: not_applicable
 - Logs Entry: not_applicable
 - Diagnostics Entry: not_applicable
-- Verification Entry: npm view @mc-and-his-agents/loom-installer version deprecated --json; npm whoami; python3 tools/check_release_surface.py
+- Verification Entry: python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_cli_contract.py; make check
 - Lane Entry: not_applicable
 
 ## Sources
 
-- Static Truth: .loom/work-items/WI-1010.md
-- Dynamic Truth: .loom/progress/WI-1010.md
+- Static Truth: .loom/work-items/WI-1011.md
+- Dynamic Truth: .loom/progress/WI-1011.md
 - Locator Truth: .loom/bootstrap/init-result.json
 - Fact Chain CLI: python3 .loom/bin/loom_init.py fact-chain --target .

--- a/.loom/work-items/WI-1011.md
+++ b/.loom/work-items/WI-1011.md
@@ -1,0 +1,29 @@
+# WI-1011
+
+## Static Facts
+
+- Item ID: WI-1011
+- Goal: Close #1003 by consuming the single `loom` CLI release line and `loom-installer` sunset evidence.
+- Scope: #1011: final closeout for #1003, including child issue status, PR/head/merge/check evidence, CLI release evidence, npm installer deprecate or permission-block evidence, and installer non-advancement.
+- Execution Path: issue-scoped branch work/1011-1003-closeout in /Users/mc/dev/Loom-1011-1003-closeout
+- Workspace Entry: .
+- Recovery Entry: .loom/progress/WI-1011.md
+- Review Entry: .loom/reviews/WI-1011.json
+- Validation Entry: python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_cli_contract.py; make check
+- Closing Condition: #1011 and #1003 closeout comments consume all child issue, PR, merge, check, release, npm, tag, and workspace-clean evidence.
+
+## Associated Artifacts
+
+- `.loom/work-items/WI-1011.md`
+- `.loom/progress/WI-1011.md`
+- `.loom/reviews/WI-1011.spec.json`
+- `.loom/reviews/WI-1011.json`
+- `.loom/specs/WI-1011/spec.md`
+- `.loom/specs/WI-1011/plan.md`
+- `.loom/specs/WI-1011/implementation-contract.md`
+- `.loom/bootstrap/init-result.json`
+- `.loom/shadow/merge-ready-loom.json`
+- `.loom/shadow/closeout-loom.json`
+- `.loom/status/current.md`
+- `docs/evidence/loom-cli-installer-sunset-closeout.md`
+

--- a/docs/evidence/loom-cli-installer-sunset-closeout.md
+++ b/docs/evidence/loom-cli-installer-sunset-closeout.md
@@ -1,0 +1,91 @@
+# Loom CLI / Installer Sunset Closeout Evidence
+
+This file records the #1011 / #1003 closeout evidence for the move to a
+single active `loom` CLI release line and the `loom-installer` sunset.
+
+## Issue Tree Status
+
+Checked on 2026-05-25:
+
+| Issue | Status | Evidence |
+| --- | --- | --- |
+| #1004 | CLOSED / COMPLETED | Decision freeze recorded in issue comment. No repository change required. |
+| #1005 | CLOSED / COMPLETED | PR #1053 merged. |
+| #1006 | CLOSED / COMPLETED | PR #1056 merged. |
+| #1007 | CLOSED / COMPLETED | PR #1058 merged. |
+| #1008 | CLOSED / COMPLETED | PR #1059 merged. |
+| #1009 | CLOSED / COMPLETED | PR #1060 merged; first CLI auto release completed. |
+| #1010 | CLOSED / COMPLETED | PR #1061 merged; npm deprecate permission-block evidence recorded. |
+| #1011 | OPEN at implementation time | This closeout item consumes the evidence above. |
+
+## Implementation Chain
+
+| Issue | PR | Head SHA | Squash Merge Commit | Merge Evidence |
+| --- | --- | --- | --- | --- |
+| #1005 | #1053 | `a72547468b0ea0ac6e97b638c6bb1aca84171ffb` | `3ec408d72e647eed85250eb7bdd6cdc5109b2bc4` | Installer publishing disabled. |
+| #1006 | #1056 | `3ac4ab9b4a11c243e68f7cd22f0f9b1aab578dd2` | `f80c236e01c382193fe83197e7368964b19af4df` | Docs moved to the single CLI release line. |
+| #1007 | #1058 | `d3766d2317ed25bfaedf37fccefdc61a8551acdd` | `b1e9465b41aa611d2ce9d08dc64e0ede07cb84af` | Release/version checks reject installer as active CLI evidence. |
+| #1008 | #1059 | `d37fe95b1d56570357f6194292709533c9183453` | `f145673a3e535b345c47997a33bcf5385d7b879f` | `loom-cli-release` supports main-push publishing. |
+| #1009 | #1060 | `f783e4cd180b144594c3b9a3488afdc61ecf89a9` | `a86c08fa0f14c755f6b0a0b949768b0ea1afe683` | `VERSION` bumped to `v0.13.0`; CLI release published. |
+| #1010 | #1061 | `27008fcafe858eeaaa4b829d32f56a1c519d911b` | `93066b9e6705780ea0a4d053af8eefe7b323186a` | npm deprecate permission block and owner action recorded. |
+
+All listed PRs passed their required PR checks before merge. Merge commit checks
+were consumed for each implementation batch; #1010 main run `26420293852`
+passed after merge.
+
+## CLI Release Evidence
+
+- Root `VERSION`: `v0.13.0`.
+- `loom-cli-release` push run: `26418832058`, status `success`, event `push`,
+  head SHA `a86c08fa0f14c755f6b0a0b949768b0ea1afe683`.
+- Git tag: `v0.13.0`.
+- Tag target: `a86c08fa0f14c755f6b0a0b949768b0ea1afe683`.
+- GitHub Release: `Loom CLI v0.13.0`.
+- Release URL: https://github.com/MC-and-his-Agents/Loom/releases/tag/v0.13.0
+- Published at: `2026-05-25T20:37:43Z`.
+
+Judgment: the first `loom` CLI automatic release for this issue tree is
+complete, and its tag points at the #1009 PR squash merge commit.
+
+## Installer Sunset Evidence
+
+Checked on 2026-05-25:
+
+```sh
+npm view @mc-and-his-agents/loom-installer version deprecated --json
+```
+
+Observed output:
+
+```json
+"0.1.119"
+```
+
+Interpretation: npm `latest` remains `0.1.119`; no deprecation metadata was
+returned by this read.
+
+The highest installer tag remains:
+
+```text
+loom-installer-v0.1.119
+```
+
+GitHub Releases still show `loom-installer v0.1.119` as the latest installer
+release, while `Loom CLI v0.13.0` is the latest overall release.
+
+#1010 recorded the npm permission block:
+
+```text
+npm error code E401
+npm error 401 Unauthorized - GET https://registry.npmjs.org/-/whoami
+```
+
+Required owner action remains:
+
+```sh
+npm deprecate @mc-and-his-agents/loom-installer@"*" "Deprecated: use the Loom CLI GitHub release line instead."
+```
+
+Judgment: `loom-installer` is no longer an active or automatic release line in
+this repository, and no installer npm publish, `loom-installer-v*` tag, or
+installer GitHub Release advanced during #1003.


### PR DESCRIPTION
## Summary
- Records #1011/#1003 closeout evidence for the single active `loom` CLI release line and `loom-installer` sunset.
- Consumes #1004-#1010 issue states, PR/head/squash merge commits, checks, `v0.13.0` release evidence, npm permission-block evidence, and installer non-advancement.

## Validation
- `python3 tools/check_release_surface.py`
- `python3 tools/version_surface_check.py`
- `python3 tools/check_cli_contract.py`
- `npm --prefix packages/loom-installer run check:docs`
- `npm --prefix packages/loom-installer run check:versions`
- `npm --prefix packages/loom-installer run check:payload`
- `npm --prefix packages/loom-installer run check:distribution`
- `python3 .loom/bin/loom_flow.py fact-chain --target . --item WI-1011`
- `python3 .loom/bin/loom_flow.py shadow-parity --target .`
- `python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-1011`
- `make check`

## Risks And Follow-ups
- npm deprecate remains permission-blocked in this environment; #1010 records the owner action.
- No installer npm publish, installer tag, or installer GitHub Release is created in this PR.

## Related Work
- Work Item: WI-1011
- Refs #1011
- Refs #1003
