### PR TITLE
docs: 新增 PR slicing 策略模板

### DIFF
--- a/.loom/bootstrap/init-result.json
+++ b/.loom/bootstrap/init-result.json
@@ -76,9 +76,9 @@
     "mode": "work-item + recovery-entry + derived status-surface",
     "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
     "entry_points": {
-      "current_item_id": "WI-1025",
-      "work_item": ".loom/work-items/WI-1025.md",
-      "recovery_entry": ".loom/progress/WI-1025.md",
+      "current_item_id": "WI-1026",
+      "work_item": ".loom/work-items/WI-1026.md",
+      "recovery_entry": ".loom/progress/WI-1026.md",
       "status_surface": ".loom/status/current.md"
     }
   },

--- a/.loom/progress/WI-1025.md
+++ b/.loom/progress/WI-1025.md
@@ -3,19 +3,19 @@
 ## Dynamic Facts
 
 - Item ID: WI-1025
-- Current Checkpoint: merge
-- Current Stop: Issue-tree-plan contract and scaffold drafted, locally validated, and bound to PR #1080.
-- Next Step: Consume PR checks, then merge and close out #1025 if green.
+- Current Checkpoint: closed
+- Current Stop: PR #1080 merged as edbb6156dab6ce9df84a4ec48768532b8ef3cac3 and #1025 is closed.
+- Next Step: None for WI-1025; downstream delivery planning work continues through #1026, #1027, and #1028.
 - Blockers: None recorded.
-- Latest Validation Summary: Passed before WI-1065 carrier repair: `git diff --check`; focused `rg` checks for issue-tree required fields and forbidden-use statements; `python3 tools/loom_check.py --profile source --source-surface contract-only .`; `python3 .loom/bin/loom_init.py verify --target .`; `python3 .loom/bin/loom_flow.py carrier refresh --target . --item WI-1025 --dry-run`. After WI-1065 carrier repair: `python3 .loom/bin/loom_flow.py pr-gate check --target . --head-sha fffd9fb66222cfc2d60ae87cf232f670655ae419 --branch work/1025-issue-tree-plan-template --pr 1080` showed workspace purity clean and only blocked on stale review plus unpushed PR head.
-- Recovery Boundary: #1025 issue-tree-plan template only. Do not expand into #1026 PR slicing strategy, #1027 GitHub mapping, #1028 skills routing, task carrier contracts, gate-chain, or CLI automation.
-- Current Lane: issue-tree-plan-template
+- Latest Validation Summary: PR #1080 merged as edbb6156dab6ce9df84a4ec48768532b8ef3cac3 with head 7b6cc0fae39bdbaa6fda4d6f877ce86d47767203; #1025 closeout evidence recorded on GitHub after local validation, pr-gate, PR checks, and merge checks passed.
+- Recovery Boundary: Terminal; #1025 issue-tree-plan template work is closed and must not remain an active workspace binding for later Work Items.
+- Current Lane: closed
 
 ## Execution Ledger
 
 - Ledger Binding: recovery_entry
 - Plan Locator: `.loom/specs/WI-1025/plan.md`
 - Acceptance Locator: `.loom/specs/WI-1025/spec.md`
-- Validation Evidence Locator: `.loom/progress/WI-1025.md`; `.loom/reviews/WI-1025.spec.json`; `.loom/reviews/WI-1025.json`; PR #1080; #1025 completion comment pending
+- Validation Evidence Locator: #1025 closeout comment; PR #1080; head 7b6cc0fae39bdbaa6fda4d6f877ce86d47767203; merge commit edbb6156dab6ce9df84a4ec48768532b8ef3cac3.
 - Handoff Notes Locator: not_applicable
 - Evidence Freshness: current

--- a/.loom/progress/WI-1026.md
+++ b/.loom/progress/WI-1026.md
@@ -3,9 +3,9 @@
 ## Dynamic Facts
 
 - Item ID: WI-1026
-- Current Checkpoint: build
-- Current Stop: PR slicing contract and scaffold drafted and locally validated; review records and PR are pending.
-- Next Step: Refresh review records, open PR, consume checks, merge, and close out #1026.
+- Current Checkpoint: merge
+- Current Stop: PR slicing contract and scaffold drafted, locally validated, reviewed, and bound to PR #1082.
+- Next Step: Consume PR checks, then merge and close out #1026 if green.
 - Blockers: None recorded.
 - Latest Validation Summary: Passed: `git diff --check`; focused `rg` checks for PR slicing fields, scope purity, multi-Work-Item evidence, PR body linkage, review evidence, and merge-ready references; `python3 .loom/bin/loom_init.py verify --target .`; `python3 .loom/bin/loom_flow.py carrier refresh --target . --item WI-1026 --write`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`.
 - Recovery Boundary: #1026 PR slicing strategy only. Do not expand into #1019 gate-chain implementation, #1027 GitHub mapping, #1028 skills routing, #1017 task carrier contracts, or CLI automation.
@@ -16,6 +16,6 @@
 - Ledger Binding: recovery_entry
 - Plan Locator: `.loom/specs/WI-1026/plan.md`
 - Acceptance Locator: `.loom/specs/WI-1026/spec.md`
-- Validation Evidence Locator: `.loom/progress/WI-1026.md`; `.loom/reviews/WI-1026.spec.json`; `.loom/reviews/WI-1026.json`; local command output; PR pending; #1026 completion comment pending
+- Validation Evidence Locator: `.loom/progress/WI-1026.md`; `.loom/reviews/WI-1026.spec.json`; `.loom/reviews/WI-1026.json`; local command output; PR #1082; #1026 completion comment pending
 - Handoff Notes Locator: not_applicable
 - Evidence Freshness: current

--- a/.loom/progress/WI-1026.md
+++ b/.loom/progress/WI-1026.md
@@ -1,0 +1,21 @@
+# WI-1026 Progress
+
+## Dynamic Facts
+
+- Item ID: WI-1026
+- Current Checkpoint: build
+- Current Stop: PR slicing contract and scaffold drafted locally; validation and review records pending.
+- Next Step: Run focused validation, refresh review records, open PR, consume checks, merge, and close out #1026.
+- Blockers: None recorded.
+- Latest Validation Summary: Pending.
+- Recovery Boundary: #1026 PR slicing strategy only. Do not expand into #1019 gate-chain implementation, #1027 GitHub mapping, #1028 skills routing, #1017 task carrier contracts, or CLI automation.
+- Current Lane: pr-slicing-strategy
+
+## Execution Ledger
+
+- Ledger Binding: recovery_entry
+- Plan Locator: `.loom/specs/WI-1026/plan.md`
+- Acceptance Locator: `.loom/specs/WI-1026/spec.md`
+- Validation Evidence Locator: `.loom/progress/WI-1026.md`; `.loom/reviews/WI-1026.spec.json`; `.loom/reviews/WI-1026.json`; PR pending; #1026 completion comment pending
+- Handoff Notes Locator: not_applicable
+- Evidence Freshness: current

--- a/.loom/progress/WI-1026.md
+++ b/.loom/progress/WI-1026.md
@@ -4,10 +4,10 @@
 
 - Item ID: WI-1026
 - Current Checkpoint: build
-- Current Stop: PR slicing contract and scaffold drafted locally; validation and review records pending.
-- Next Step: Run focused validation, refresh review records, open PR, consume checks, merge, and close out #1026.
+- Current Stop: PR slicing contract and scaffold drafted and locally validated; review records and PR are pending.
+- Next Step: Refresh review records, open PR, consume checks, merge, and close out #1026.
 - Blockers: None recorded.
-- Latest Validation Summary: Pending.
+- Latest Validation Summary: Passed: `git diff --check`; focused `rg` checks for PR slicing fields, scope purity, multi-Work-Item evidence, PR body linkage, review evidence, and merge-ready references; `python3 .loom/bin/loom_init.py verify --target .`; `python3 .loom/bin/loom_flow.py carrier refresh --target . --item WI-1026 --write`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`.
 - Recovery Boundary: #1026 PR slicing strategy only. Do not expand into #1019 gate-chain implementation, #1027 GitHub mapping, #1028 skills routing, #1017 task carrier contracts, or CLI automation.
 - Current Lane: pr-slicing-strategy
 
@@ -16,6 +16,6 @@
 - Ledger Binding: recovery_entry
 - Plan Locator: `.loom/specs/WI-1026/plan.md`
 - Acceptance Locator: `.loom/specs/WI-1026/spec.md`
-- Validation Evidence Locator: `.loom/progress/WI-1026.md`; `.loom/reviews/WI-1026.spec.json`; `.loom/reviews/WI-1026.json`; PR pending; #1026 completion comment pending
+- Validation Evidence Locator: `.loom/progress/WI-1026.md`; `.loom/reviews/WI-1026.spec.json`; `.loom/reviews/WI-1026.json`; local command output; PR pending; #1026 completion comment pending
 - Handoff Notes Locator: not_applicable
 - Evidence Freshness: current

--- a/.loom/reviews/WI-1026.json
+++ b/.loom/reviews/WI-1026.json
@@ -3,9 +3,9 @@
   "item_id": "WI-1026",
   "decision": "allow",
   "kind": "general_review",
-  "summary": "WI-1026 implementation is approved for PR: the PR slicing contract and scaffold define when Work Items may share one PR, when they must split, and which evidence is required for PR body linkage, review, merge-ready, and closeout without implementing gate logic.",
+  "summary": "WI-1026 implementation is approved for PR: the PR slicing contract and scaffold define when Work Items may share one PR, when they must split, and which evidence is required for PR body linkage, review, merge-ready, and closeout without implementing gate logic. The inherited WI-1025 recovery carrier is also corrected to its GitHub closed/Done state so workspace purity remains true before #1026 merge.",
   "reviewer": "codex-main-agent",
-  "reviewed_head": "0eec40f9172c308eb58469bdd316b01a90eabc33",
+  "reviewed_head": "193efec8454ccccf75c26be6c8ede125df51087b",
   "reviewed_validation_summary": "Passed: `git diff --check`; focused `rg` checks for PR slicing fields, scope purity, multi-Work-Item evidence, PR body linkage, review evidence, and merge-ready references; `python3 .loom/bin/loom_init.py verify --target .`; `python3 .loom/bin/loom_flow.py carrier refresh --target . --item WI-1026 --write`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`.",
   "fallback_to": null,
   "findings": [],
@@ -22,6 +22,7 @@
     "pr_slicing_contract": "docs/methodology/templates/pr-slicing.md",
     "pr_slicing_scaffold": "docs/methodology/templates/scaffold/pr-slicing.md",
     "build_checkpoint": "pass",
-    "pull_request": "#1082"
+    "pull_request": "#1082",
+    "inherited_carrier_repair": ".loom/progress/WI-1025.md"
   }
 }

--- a/.loom/reviews/WI-1026.json
+++ b/.loom/reviews/WI-1026.json
@@ -5,7 +5,7 @@
   "kind": "general_review",
   "summary": "WI-1026 implementation is approved for PR: the PR slicing contract and scaffold define when Work Items may share one PR, when they must split, and which evidence is required for PR body linkage, review, merge-ready, and closeout without implementing gate logic.",
   "reviewer": "codex-main-agent",
-  "reviewed_head": "42d7ea1f08387c8d3707c8f21242625a84d658f2",
+  "reviewed_head": "0eec40f9172c308eb58469bdd316b01a90eabc33",
   "reviewed_validation_summary": "Passed: `git diff --check`; focused `rg` checks for PR slicing fields, scope purity, multi-Work-Item evidence, PR body linkage, review evidence, and merge-ready references; `python3 .loom/bin/loom_init.py verify --target .`; `python3 .loom/bin/loom_flow.py carrier refresh --target . --item WI-1026 --write`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`.",
   "fallback_to": null,
   "findings": [],
@@ -21,6 +21,7 @@
     "status_surface": ".loom/status/current.md",
     "pr_slicing_contract": "docs/methodology/templates/pr-slicing.md",
     "pr_slicing_scaffold": "docs/methodology/templates/scaffold/pr-slicing.md",
-    "build_checkpoint": "pass"
+    "build_checkpoint": "pass",
+    "pull_request": "#1082"
   }
 }

--- a/.loom/reviews/WI-1026.json
+++ b/.loom/reviews/WI-1026.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-1026",
+  "decision": "allow",
+  "kind": "general_review",
+  "summary": "WI-1026 implementation is approved for PR: the PR slicing contract and scaffold define when Work Items may share one PR, when they must split, and which evidence is required for PR body linkage, review, merge-ready, and closeout without implementing gate logic.",
+  "reviewer": "codex-main-agent",
+  "reviewed_head": "42d7ea1f08387c8d3707c8f21242625a84d658f2",
+  "reviewed_validation_summary": "Passed: `git diff --check`; focused `rg` checks for PR slicing fields, scope purity, multi-Work-Item evidence, PR body linkage, review evidence, and merge-ready references; `python3 .loom/bin/loom_init.py verify --target .`; `python3 .loom/bin/loom_flow.py carrier refresh --target . --item WI-1026 --write`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [
+    "#1027 GitHub mapping remains pending.",
+    "#1028 skills routing remains pending.",
+    "#1019 gate-chain implementation remains pending."
+  ],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-1026.md",
+    "recovery_entry": ".loom/progress/WI-1026.md",
+    "status_surface": ".loom/status/current.md",
+    "pr_slicing_contract": "docs/methodology/templates/pr-slicing.md",
+    "pr_slicing_scaffold": "docs/methodology/templates/scaffold/pr-slicing.md",
+    "build_checkpoint": "pass"
+  }
+}

--- a/.loom/reviews/WI-1026.spec.json
+++ b/.loom/reviews/WI-1026.spec.json
@@ -5,7 +5,7 @@
   "kind": "spec_review",
   "summary": "WI-1026 spec suite is approved: scope is limited to the PR slicing contract, scaffold, README registration, and repo-local carriers while leaving PR gate/merge-ready implementation, GitHub mapping, skills routing, task carrier, and CLI automation to downstream Work Items.",
   "reviewer": "codex-main-agent",
-  "reviewed_head": "42d7ea1f08387c8d3707c8f21242625a84d658f2",
+  "reviewed_head": "0eec40f9172c308eb58469bdd316b01a90eabc33",
   "reviewed_validation_summary": "Passed: `git diff --check`; focused `rg` checks for PR slicing fields, scope purity, multi-Work-Item evidence, PR body linkage, review evidence, and merge-ready references; `python3 .loom/bin/loom_init.py verify --target .`; `python3 .loom/bin/loom_flow.py carrier refresh --target . --item WI-1026 --write`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`.",
   "fallback_to": null,
   "findings": [],
@@ -24,6 +24,7 @@
     "implementation_contract": ".loom/specs/WI-1026/implementation-contract.md",
     "github_fr": "#1014",
     "github_work_item": "#1026",
+    "pull_request": "#1082",
     "upstream_work_items": "#1024, #1025"
   }
 }

--- a/.loom/reviews/WI-1026.spec.json
+++ b/.loom/reviews/WI-1026.spec.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-1026",
+  "decision": "allow",
+  "kind": "spec_review",
+  "summary": "WI-1026 spec suite is approved: scope is limited to the PR slicing contract, scaffold, README registration, and repo-local carriers while leaving PR gate/merge-ready implementation, GitHub mapping, skills routing, task carrier, and CLI automation to downstream Work Items.",
+  "reviewer": "codex-main-agent",
+  "reviewed_head": "42d7ea1f08387c8d3707c8f21242625a84d658f2",
+  "reviewed_validation_summary": "Passed: `git diff --check`; focused `rg` checks for PR slicing fields, scope purity, multi-Work-Item evidence, PR body linkage, review evidence, and merge-ready references; `python3 .loom/bin/loom_init.py verify --target .`; `python3 .loom/bin/loom_flow.py carrier refresh --target . --item WI-1026 --write`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [
+    "#1027 should consume PR slicing output when defining GitHub mapping.",
+    "#1028 should consume the planning boundary when updating skills routing.",
+    "#1019 remains responsible for any gate-chain implementation."
+  ],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-1026.md",
+    "recovery_entry": ".loom/progress/WI-1026.md",
+    "status_surface": ".loom/status/current.md",
+    "spec": ".loom/specs/WI-1026/spec.md",
+    "plan": ".loom/specs/WI-1026/plan.md",
+    "implementation_contract": ".loom/specs/WI-1026/implementation-contract.md",
+    "github_fr": "#1014",
+    "github_work_item": "#1026",
+    "upstream_work_items": "#1024, #1025"
+  }
+}

--- a/.loom/reviews/WI-1026.spec.json
+++ b/.loom/reviews/WI-1026.spec.json
@@ -5,7 +5,7 @@
   "kind": "spec_review",
   "summary": "WI-1026 spec suite is approved: scope is limited to the PR slicing contract, scaffold, README registration, and repo-local carriers while leaving PR gate/merge-ready implementation, GitHub mapping, skills routing, task carrier, and CLI automation to downstream Work Items.",
   "reviewer": "codex-main-agent",
-  "reviewed_head": "0eec40f9172c308eb58469bdd316b01a90eabc33",
+  "reviewed_head": "70cc8dda9b55a06e800986e59cd7560e69af8374",
   "reviewed_validation_summary": "Passed: `git diff --check`; focused `rg` checks for PR slicing fields, scope purity, multi-Work-Item evidence, PR body linkage, review evidence, and merge-ready references; `python3 .loom/bin/loom_init.py verify --target .`; `python3 .loom/bin/loom_flow.py carrier refresh --target . --item WI-1026 --write`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`.",
   "fallback_to": null,
   "findings": [],
@@ -25,6 +25,7 @@
     "github_fr": "#1014",
     "github_work_item": "#1026",
     "pull_request": "#1082",
-    "upstream_work_items": "#1024, #1025"
+    "upstream_work_items": "#1024, #1025",
+    "inherited_carrier_repair": ".loom/progress/WI-1025.md"
   }
 }

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "7f455af0e710f4108e1971ea521fa05b7553f74b97a1715b994173fbe8598dd0"
+    ".loom/status/current.md": "6cc6b481c42bfe61aea337284961101737953511eff8214a4a2526e83ee0da8a"
   }
 }

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "0e88003d495d232c747b2ea79af60dedeb11f6a73cb159aff497d3243e8c08d0"
+    ".loom/status/current.md": "7f455af0e710f4108e1971ea521fa05b7553f74b97a1715b994173fbe8598dd0"
   }
 }

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "2c2f421fd9632f488de669712da50b29267ac3edae3c1cddb377d82e9422caa5"
+    ".loom/status/current.md": "0e88003d495d232c747b2ea79af60dedeb11f6a73cb159aff497d3243e8c08d0"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "7f455af0e710f4108e1971ea521fa05b7553f74b97a1715b994173fbe8598dd0"
+    ".loom/status/current.md": "6cc6b481c42bfe61aea337284961101737953511eff8214a4a2526e83ee0da8a"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "0e88003d495d232c747b2ea79af60dedeb11f6a73cb159aff497d3243e8c08d0"
+    ".loom/status/current.md": "7f455af0e710f4108e1971ea521fa05b7553f74b97a1715b994173fbe8598dd0"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "2c2f421fd9632f488de669712da50b29267ac3edae3c1cddb377d82e9422caa5"
+    ".loom/status/current.md": "0e88003d495d232c747b2ea79af60dedeb11f6a73cb159aff497d3243e8c08d0"
   }
 }

--- a/.loom/specs/WI-1026/implementation-contract.md
+++ b/.loom/specs/WI-1026/implementation-contract.md
@@ -1,0 +1,44 @@
+# WI-1026 Implementation Contract
+
+## Work Item
+
+- GitHub Phase: #1012
+- GitHub FR: #1014
+- GitHub Work Item: #1026
+- Upstream Work Items: #1024, #1025
+- Downstream Work Items: #1027, #1028
+
+## Owned Files
+
+- `docs/methodology/templates/pr-slicing.md`
+- `docs/methodology/templates/scaffold/pr-slicing.md`
+- `docs/methodology/templates/README.md`
+- `.loom/work-items/WI-1026.md`
+- `.loom/progress/WI-1026.md`
+- `.loom/status/current.md`
+- `.loom/specs/WI-1026/`
+- `.loom/reviews/WI-1026.spec.json`
+- `.loom/reviews/WI-1026.json`
+
+## Required Outputs
+
+- PR slicing contract.
+- PR slicing scaffold template.
+- Templates README registration.
+- Repo-local governance carriers and review records.
+
+## Forbidden Outputs
+
+- No PR gate or merge-ready implementation.
+- No GitHub Project / Phase / FR / Work Item mapping implementation.
+- No skills routing changes.
+- No task carrier contract changes.
+- No CLI automation.
+- No closure of #1014 or #1012 from this Work Item alone.
+
+## Validation
+
+- `git diff --check`
+- `rg -n "PR slicing|scope purity|single PR|multiple Work Item|review risk|依赖顺序" docs .github skills src .loom`
+- `rg -n "Loom Work Item|PR body|merge-ready|review evidence" docs .github skills src .loom`
+- `python3 tools/loom_check.py --profile source --source-surface contract-only .`

--- a/.loom/specs/WI-1026/plan.md
+++ b/.loom/specs/WI-1026/plan.md
@@ -1,0 +1,76 @@
+# WI-1026 Plan
+
+## Implementation Goal
+
+Deliver the PR slicing methodology contract and scaffold template for #1026 without implementing downstream GitHub mapping, skills routing, task carrier, gate-chain, or CLI behavior.
+
+## Phases
+
+### Phase 1
+
+- Objective: Define the PR slicing contract.
+- Deliverable: `docs/methodology/templates/pr-slicing.md`.
+- Exit condition: Contract covers inputs, output fields, same-PR conditions, split-PR conditions, primary/additional Work Item handling, review risk, validation matrix, merge-ready consumption, closeout consumption, and freshness.
+
+### Phase 2
+
+- Objective: Add a directly usable scaffold.
+- Deliverable: `docs/methodology/templates/scaffold/pr-slicing.md`.
+- Exit condition: Scaffold exposes fillable fields for candidate Work Items, dependency read, same-PR decision, PR body contract, review risk, validation matrix, merge-ready consumption, and closeout consumption.
+
+### Phase 3
+
+- Objective: Register the template and bind repo-local carriers.
+- Deliverable: templates README plus WI-1026 fact chain, spec, plan, implementation contract, and review records.
+- Exit condition: Local validation and PR checks consume WI-1026 as the current Work Item.
+
+## Constraints
+
+- Architectural or governance constraints: PR slicing is a planning/execution-boundary artifact, not execution truth.
+- Workspace / rollout constraints: branch `work/1026-pr-slicing-strategy`, PR pending.
+- Purity or scope constraints: do not edit PR gate, merge-ready, GitHub mapping, skills routing, task carrier, or CLI behavior.
+
+## Validation
+
+- Automated checks: `python3 tools/loom_check.py --profile source --source-surface contract-only .`.
+- Manual checks: `git diff --check`; focused `rg` checks from #1026.
+- Runtime evidence: `.loom/progress/WI-1026.md`; `.loom/reviews/WI-1026.spec.json`; `.loom/reviews/WI-1026.json`.
+- Behavior evidence: methodology contract and scaffold contain required fields and forbidden-use statements.
+- Story scenario to evidence mapping: not_applicable.
+- Story business confirmation locator or `not_applicable` rationale: not_applicable; no product story semantics are changed.
+- Fresh verification evidence: local validation and PR checks before merge.
+- Execution ledger plan locator: `.loom/specs/WI-1026/plan.md`.
+- Execution ledger validation evidence locator: `.loom/progress/WI-1026.md`.
+
+## Test Strategy
+
+- TDD or test-first expectation: documentation/template-only change; use contract checks and focused grep.
+- Regression coverage to add or preserve: preserve source contract checks.
+- Cases that are intentionally not automated: qualitative judgment for actual PR grouping.
+- How failing tests or equivalent checks will be introduced before implementation: not_applicable; no executable behavior changes.
+- How passing tests or equivalent checks will be captured as test evidence: validation commands and review records.
+- How User Story acceptance scenarios map to tests, checks, manual validation, or `not_applicable` evidence: not_applicable.
+
+## Subagent Output Integration
+
+- Owned outputs: GitHub-only status/comment updates may be delegated; repo files are owned by main agent.
+- Integration owner: main agent.
+- Required evidence from each subagent: issue comment URL and Project status if delegated.
+- Review or reconciliation needed before merge-ready: verify GitHub issue #1026 and PR bindings.
+- Handoff notes locator, or `not_applicable`: not_applicable.
+
+## Dependencies
+
+- Blocking inputs: #1024 delivery planning contract and #1025 issue-tree-plan template.
+- Required coordination: #1027 consumes PR slicing output when defining GitHub mapping; #1028 consumes routing expectation.
+- Rollback boundary: revert this PR if PR slicing duplicates execution truth, weakens Work Item closeout, or conflicts with delivery planning/issue-tree-plan boundaries.
+
+## Ready For Implementation
+
+- [x] Spec is stable enough to implement
+- [x] Scope and non-goals are clear
+- [x] Story business semantics are confirmed or explicitly `not_applicable`
+- [x] Validation path is defined
+- [x] BDD outer-loop scenarios map to validation or `not_applicable`
+- [x] TDD inner-loop expectations map to test evidence
+- [x] Risks and dependencies are explicit

--- a/.loom/specs/WI-1026/plan.md
+++ b/.loom/specs/WI-1026/plan.md
@@ -27,7 +27,7 @@ Deliver the PR slicing methodology contract and scaffold template for #1026 with
 ## Constraints
 
 - Architectural or governance constraints: PR slicing is a planning/execution-boundary artifact, not execution truth.
-- Workspace / rollout constraints: branch `work/1026-pr-slicing-strategy`, PR pending.
+- Workspace / rollout constraints: branch `work/1026-pr-slicing-strategy`, PR #1082.
 - Purity or scope constraints: do not edit PR gate, merge-ready, GitHub mapping, skills routing, task carrier, or CLI behavior.
 
 ## Validation

--- a/.loom/specs/WI-1026/spec.md
+++ b/.loom/specs/WI-1026/spec.md
@@ -46,7 +46,7 @@ Then
 - Story scenario mapping: not_applicable; this is a methodology/template contract.
 - Story business confirmation locator or `not_applicable` rationale: not_applicable; no product story semantics are changed.
 - Scenario coverage: contract sections and scaffold fields cover same-PR, split-PR, PR body, review, merge-ready, and closeout expectations.
-- Expected evidence locator: PR for #1026 and #1026 completion comment.
+- Expected evidence locator: PR #1082 and #1026 completion comment.
 - Freshness rule: stale if issue-tree plan, Work Item scope, blocked-by/blocks, Project Status, PR head, or gate-chain multi-Work-Item support changes.
 - Execution ledger acceptance locator: `.loom/specs/WI-1026/spec.md`.
 

--- a/.loom/specs/WI-1026/spec.md
+++ b/.loom/specs/WI-1026/spec.md
@@ -1,0 +1,66 @@
+# WI-1026 Spec
+
+## Goal
+
+Add a Loom-native PR slicing strategy that consumes #1024 delivery planning and #1025 issue-tree-plan output to decide when multiple Work Items may share one PR and when they must split.
+
+## Scope
+
+- In scope:
+  - Methodology contract for PR slicing.
+  - Scaffold template for PR slicing output.
+  - README registration and repo-local fact chain carriers.
+- Out of scope:
+  - PR gate or merge-ready implementation (#1019).
+  - GitHub Phase / FR / Work Item / Project mapping (#1027).
+  - Skills routing (#1028).
+  - Task carrier contracts (#1017).
+  - CLI automation.
+
+## Key Scenarios
+
+### Scenario 1
+
+Given
+- an issue-tree plan lists multiple Work Items under the same FR
+
+When
+- an agent decides whether they can share one implementation PR
+
+Then
+- the PR slicing strategy records same-PR conditions, split-PR triggers, review risk, validation matrix, PR body linkage, merge-ready consumption, and closeout consumption.
+
+### Scenario 2
+
+Given
+- one PR carries a primary Work Item and additional Work Item links
+
+When
+- review, merge-ready, and closeout consume the PR
+
+Then
+- each Work Item still has explicit evidence back to PR, head SHA, merge commit, validation, Project Status, and downstream state; PR body text alone is not treated as Loom truth.
+
+## Behavior Evidence
+
+- Story scenario mapping: not_applicable; this is a methodology/template contract.
+- Story business confirmation locator or `not_applicable` rationale: not_applicable; no product story semantics are changed.
+- Scenario coverage: contract sections and scaffold fields cover same-PR, split-PR, PR body, review, merge-ready, and closeout expectations.
+- Expected evidence locator: PR for #1026 and #1026 completion comment.
+- Freshness rule: stale if issue-tree plan, Work Item scope, blocked-by/blocks, Project Status, PR head, or gate-chain multi-Work-Item support changes.
+- Execution ledger acceptance locator: `.loom/specs/WI-1026/spec.md`.
+
+## Exceptions And Boundaries
+
+- Failure modes: strategy turns into a file-count heuristic, lets FRs directly carry implementation PRs, or lets PR body Markdown replace review/merge-ready/closeout truth.
+- Operational boundaries: no PR gate, merge-ready, GitHub mapping, or CLI implementation is introduced by this Work Item.
+- Rollback or fallback expectations: revert this PR if PR slicing duplicates execution truth or makes single PR multi-Work-Item evidence weaker than separate PRs.
+
+## Acceptance Criteria
+
+- [x] Contract defines same-PR conditions and split-PR triggers.
+- [x] Contract defines primary Work Item and additional Work Item link handling.
+- [x] Contract explains PR body, review evidence, merge-ready evidence, and closeout evidence relationships.
+- [x] Contract states PR is a host carrier, not Loom completed truth.
+- [x] Scaffold exposes fillable fields for slicing decision, review risk, validation matrix, merge-ready consumption, and closeout consumption.
+- [x] Contract avoids implementing PR gate, merge-ready, GitHub mapping, skills routing, task carrier, or CLI logic.

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -5,15 +5,15 @@
 - Item ID: WI-1026
 - Goal: Define a PR slicing strategy so Loom can decide which Work Items may share one implementation PR, which must split, and what evidence is required for multi Work Item PRs.
 - Scope: #1026 PR slicing strategy only; create the methodology contract, scaffold template, and repo-local carriers required for review. Do not implement PR gate or merge-ready logic (#1019), GitHub Phase / FR / Work Item / Project mapping (#1027), skills routing (#1028), task carrier contracts (#1017), or CLI automation.
-- Execution Path: issue #1026 -> branch work/1026-pr-slicing-strategy -> worktree /Users/mc/dev/Loom -> PR pending.
+- Execution Path: issue #1026 -> branch work/1026-pr-slicing-strategy -> worktree /Users/mc/dev/Loom -> PR #1082.
 - Workspace Entry: .
 - Recovery Entry: .loom/progress/WI-1026.md
 - Review Entry: .loom/reviews/WI-1026.json
 - Validation Entry: git diff --check; rg -n "PR slicing|scope purity|single PR|multiple Work Item|review risk|依赖顺序" docs .github skills src .loom; rg -n "Loom Work Item|PR body|merge-ready|review evidence" docs .github skills src .loom; python3 tools/loom_check.py --profile source --source-surface contract-only .
 - Closing Condition: #1026 has a PR slicing contract and scaffold covering same-PR conditions, split-PR conditions, single-PR multi-Work-Item evidence, PR body linkage, review risk, merge-ready consumption, and closeout consumption without implementing gate logic.
-- Current Checkpoint: build
-- Current Stop: PR slicing contract and scaffold drafted and locally validated; review records and PR are pending.
-- Next Step: Refresh review records, open PR, consume checks, merge, and close out #1026.
+- Current Checkpoint: merge
+- Current Stop: PR slicing contract and scaffold drafted, locally validated, reviewed, and bound to PR #1082.
+- Next Step: Consume PR checks, then merge and close out #1026 if green.
 - Blockers: None recorded.
 - Latest Validation Summary: Passed: `git diff --check`; focused `rg` checks for PR slicing fields, scope purity, multi-Work-Item evidence, PR body linkage, review evidence, and merge-ready references; `python3 .loom/bin/loom_init.py verify --target .`; `python3 .loom/bin/loom_flow.py carrier refresh --target . --item WI-1026 --write`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`.
 - Recovery Boundary: #1026 PR slicing strategy only. Do not expand into #1019 gate-chain implementation, #1027 GitHub mapping, #1028 skills routing, #1017 task carrier contracts, or CLI automation.

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -12,10 +12,10 @@
 - Validation Entry: git diff --check; rg -n "PR slicing|scope purity|single PR|multiple Work Item|review risk|依赖顺序" docs .github skills src .loom; rg -n "Loom Work Item|PR body|merge-ready|review evidence" docs .github skills src .loom; python3 tools/loom_check.py --profile source --source-surface contract-only .
 - Closing Condition: #1026 has a PR slicing contract and scaffold covering same-PR conditions, split-PR conditions, single-PR multi-Work-Item evidence, PR body linkage, review risk, merge-ready consumption, and closeout consumption without implementing gate logic.
 - Current Checkpoint: build
-- Current Stop: PR slicing contract and scaffold drafted locally; validation and review records pending.
-- Next Step: Run focused validation, refresh review records, open PR, consume checks, merge, and close out #1026.
+- Current Stop: PR slicing contract and scaffold drafted and locally validated; review records and PR are pending.
+- Next Step: Refresh review records, open PR, consume checks, merge, and close out #1026.
 - Blockers: None recorded.
-- Latest Validation Summary: Pending.
+- Latest Validation Summary: Passed: `git diff --check`; focused `rg` checks for PR slicing fields, scope purity, multi-Work-Item evidence, PR body linkage, review evidence, and merge-ready references; `python3 .loom/bin/loom_init.py verify --target .`; `python3 .loom/bin/loom_flow.py carrier refresh --target . --item WI-1026 --write`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`.
 - Recovery Boundary: #1026 PR slicing strategy only. Do not expand into #1019 gate-chain implementation, #1027 GitHub mapping, #1028 skills routing, #1017 task carrier contracts, or CLI automation.
 - Current Lane: pr-slicing-strategy
 

--- a/.loom/work-items/WI-1026.md
+++ b/.loom/work-items/WI-1026.md
@@ -5,7 +5,7 @@
 - Item ID: WI-1026
 - Goal: Define a PR slicing strategy so Loom can decide which Work Items may share one implementation PR, which must split, and what evidence is required for multi Work Item PRs.
 - Scope: #1026 PR slicing strategy only; create the methodology contract, scaffold template, and repo-local carriers required for review. Do not implement PR gate or merge-ready logic (#1019), GitHub Phase / FR / Work Item / Project mapping (#1027), skills routing (#1028), task carrier contracts (#1017), or CLI automation.
-- Execution Path: issue #1026 -> branch work/1026-pr-slicing-strategy -> worktree /Users/mc/dev/Loom -> PR pending.
+- Execution Path: issue #1026 -> branch work/1026-pr-slicing-strategy -> worktree /Users/mc/dev/Loom -> PR #1082.
 - Workspace Entry: .
 - Recovery Entry: .loom/progress/WI-1026.md
 - Review Entry: .loom/reviews/WI-1026.json

--- a/.loom/work-items/WI-1026.md
+++ b/.loom/work-items/WI-1026.md
@@ -1,6 +1,6 @@
-# Current Status
+# WI-1026
 
-## Derived Fact Chain View
+## Static Facts
 
 - Item ID: WI-1026
 - Goal: Define a PR slicing strategy so Loom can decide which Work Items may share one implementation PR, which must split, and what evidence is required for multi Work Item PRs.
@@ -11,25 +11,17 @@
 - Review Entry: .loom/reviews/WI-1026.json
 - Validation Entry: git diff --check; rg -n "PR slicing|scope purity|single PR|multiple Work Item|review risk|依赖顺序" docs .github skills src .loom; rg -n "Loom Work Item|PR body|merge-ready|review evidence" docs .github skills src .loom; python3 tools/loom_check.py --profile source --source-surface contract-only .
 - Closing Condition: #1026 has a PR slicing contract and scaffold covering same-PR conditions, split-PR conditions, single-PR multi-Work-Item evidence, PR body linkage, review risk, merge-ready consumption, and closeout consumption without implementing gate logic.
-- Current Checkpoint: build
-- Current Stop: PR slicing contract and scaffold drafted locally; validation and review records pending.
-- Next Step: Run focused validation, refresh review records, open PR, consume checks, merge, and close out #1026.
-- Blockers: None recorded.
-- Latest Validation Summary: Pending.
-- Recovery Boundary: #1026 PR slicing strategy only. Do not expand into #1019 gate-chain implementation, #1027 GitHub mapping, #1028 skills routing, #1017 task carrier contracts, or CLI automation.
-- Current Lane: pr-slicing-strategy
 
-## Runtime Evidence
+## Associated Artifacts
 
-- Run Entry: not_applicable
-- Logs Entry: not_applicable
-- Diagnostics Entry: not_applicable
-- Verification Entry: git diff --check; rg -n "PR slicing|scope purity|single PR|multiple Work Item|review risk|依赖顺序" docs .github skills src .loom; rg -n "Loom Work Item|PR body|merge-ready|review evidence" docs .github skills src .loom; python3 tools/loom_check.py --profile source --source-surface contract-only .
-- Lane Entry: not_applicable
-
-## Sources
-
-- Static Truth: .loom/work-items/WI-1026.md
-- Dynamic Truth: .loom/progress/WI-1026.md
-- Locator Truth: .loom/bootstrap/init-result.json
-- Fact Chain CLI: python3 .loom/bin/loom_init.py fact-chain --target .
+- `docs/methodology/templates/pr-slicing.md`
+- `docs/methodology/templates/scaffold/pr-slicing.md`
+- `docs/methodology/templates/README.md`
+- `.loom/work-items/WI-1026.md`
+- `.loom/progress/WI-1026.md`
+- `.loom/status/current.md`
+- `.loom/specs/WI-1026/spec.md`
+- `.loom/specs/WI-1026/plan.md`
+- `.loom/specs/WI-1026/implementation-contract.md`
+- `.loom/reviews/WI-1026.spec.json`
+- `.loom/reviews/WI-1026.json`

--- a/docs/methodology/templates/README.md
+++ b/docs/methodology/templates/README.md
@@ -16,6 +16,8 @@
   - `#1014` `#1024`
 - [issue-tree-plan.md](./issue-tree-plan.md)
   - `#1014` `#1025`
+- [pr-slicing.md](./pr-slicing.md)
+  - `#1014` `#1026`
 - [spec-template.md](./spec-template.md)
   - `#290`
 - [implementation-contract-template.md](./implementation-contract-template.md)
@@ -41,6 +43,8 @@
   - 对应 `story-intake.md` 中定义的 story intake 最小骨架；其中 User Story、Story Readiness、Story Business Confirmation 与 Delivery Consumption Boundary 是分离产物
 - [scaffold/issue-tree-plan.md](./scaffold/issue-tree-plan.md)
   - 对应 `issue-tree-plan.md` 中定义的 issue tree planning 最小骨架
+- [scaffold/pr-slicing.md](./scaffold/pr-slicing.md)
+  - 对应 `pr-slicing.md` 中定义的 PR slicing 最小骨架
 - [scaffold/release-closeout.md](./scaffold/release-closeout.md)
   - 对应 `release-closeout-template.md` 中定义的 target release closeout 最小骨架
 

--- a/docs/methodology/templates/pr-slicing.md
+++ b/docs/methodology/templates/pr-slicing.md
@@ -1,0 +1,165 @@
+# PR Slicing
+
+本文件定义 Loom 的 PR slicing 合同。
+
+PR slicing 是 delivery planning 和 issue-tree plan 之后的承接策略。它回答：哪些 `Work Item` 可以进入同一个 implementation PR，哪些必须拆成不同 PR，以及单 PR 承接多个 `Work Item` 时必须保留哪些证据。
+
+它不替代 `Work Item`、recovery、review、merge-ready 或 closeout truth。PR 是 host control carrier，不是 Loom 的完成事实源。
+
+## 1. 适用场景
+
+当 issue-tree plan 或执行准备阶段出现以下任一信号时，应做 PR slicing 判断：
+
+- 一个 FR 下有多个 `Work Item`，且看起来可能由同一个改动批次完成。
+- 多个 `Work Item` 修改同一批文件、同一接口或同一验证面。
+- 一个 `Work Item` 的输出必须先被另一个 `Work Item` 消费。
+- 一个目标需要判断是单 PR 收敛，还是拆成多 PR 降低 review 风险。
+- PR body、review evidence、merge-ready evidence 或 closeout comment 需要回链多个 issue。
+
+不需要 PR slicing 的情况：
+
+- 当前目标已经是单一明确 `Work Item`，且 PR 只服务该 Work Item。
+- 只是在 review、merge-ready、controlled merge 或 closeout 当前 PR。
+- 只是在规划 Phase / FR / Work Item tree；该职责属于 delivery planning 和 issue-tree plan。
+
+## 2. 输入
+
+PR slicing 必须消费以下输入，并记录 locator：
+
+- delivery planning 的 `pr_plan`。
+- issue-tree plan 的 `work_item_list`、`dependency_plan` 和 `pr_slicing_placeholder`。
+- 相关 `Work Item` 的 scope、non-goals、validation entry 和 closeout condition。
+- GitHub parent/sub-issue、blocked-by/blocks 与 Project Status。
+- PR template、PR body metadata 要求、review gate、merge-ready gate 和 closeout 规则。
+- 既有多 Work Item 同 PR 的历史证据；历史只能作为参考，不能成为默认规则。
+
+## 3. 输出字段
+
+PR slicing 输出至少包含以下字段：
+
+- `schema_marker`: `loom-pr-slicing/v1`。
+- `slicing_goal`: 本次要判断的 PR 承接范围。
+- `input_locators`: 被消费的 planning、issue、PR、doc 或 conversation locator。
+- `candidate_work_items`: 候选 `Work Item` 列表、parent FR、scope 和验证入口。
+- `dependency_read`: 候选项之间是 blocking dependency、sequencing only，还是 independent。
+- `same_pr_decision`: `single_pr | split_pr | defer_decision | not_applicable`。
+- `same_pr_conditions`: 若允许同 PR，必须满足的边界和证据条件。
+- `split_pr_conditions`: 必须拆 PR 的触发条件。
+- `primary_work_item`: 当前 PR gate 需要一个主 `Work Item` 时的绑定项。
+- `additional_work_item_links`: 同 PR 承接的其他 `Work Item` 及其 closeout 处理方式。
+- `pr_body_contract`: PR body 如何回链 issue、spec/plan、validation 和 follow-up。
+- `review_risk`: review 风险判断、所需 reviewer 视角和风险降级方式。
+- `validation_matrix`: 每个 `Work Item` 对应的验证证据。
+- `merge_ready_consumption`: merge-ready 如何确认 PR head、review record、validation summary 和 issue 回链一致。
+- `closeout_consumption`: closeout 如何逐个消费 PR、merge commit、Project Status 和 issue comment。
+- `freshness_rule`: 什么时候 PR slicing 结果 stale。
+
+## 4. Same PR 条件
+
+多个 `Work Item` 可以进入同一 PR，必须同时满足：
+
+- 它们服务同一个 parent FR，或 issue-tree plan 明确记录了跨 FR 同 PR 的理由。
+- scope 可以被一个清晰 PR summary 说明，不需要把多个不相关目标塞进同一 review。
+- 依赖关系不会制造不可审查的顺序风险；如果 A blocks B，同 PR 必须说明 B 只消费 A 在同一 diff 中已经稳定的合同。
+- 每个 `Work Item` 的 validation entry 都能在同一 PR head 上被覆盖。
+- PR body 明确列出 primary `Work Item` 和 additional `Work Item`，不能只写一个 issue。
+- review record 明确消费所有被同 PR 承接的 `Work Item` scope，不允许只 review 主 issue。
+- merge-ready evidence 能证明当前 PR head、review record、validation summary 和 issue 回链一致。
+- closeout 必须逐个 `Work Item` 写明 PR、head SHA、merge commit、Project Status 和剩余 downstream。
+
+## 5. 必须拆 PR 的条件
+
+出现以下任一情况时，默认拆 PR：
+
+- 候选项属于不同 FR，且没有明确的跨 FR 同 PR rationale。
+- 一个 `Work Item` 的输出需要先独立 review、merge 或 closeout，另一个才能安全开始。
+- 候选项触及不同风险域，例如行为变更、gate 逻辑、host adapter、release/publish、权限、数据或安全边界。
+- 候选项需要不同 reviewer 视角，合在一起会降低 review 精度。
+- 验证矩阵不能在同一 PR head 上清楚证明每个 `Work Item`。
+- 任一候选项仍是 deferred、not_applicable 待确认，或 scope 不稳定。
+- 合并后无法逐个 issue 做 closeout，或 Project Status 会和 Loom truth carriers 冲突。
+- 单 PR 会迫使 PR gate、merge-ready 或 closeout 读取自由 Markdown 推断事实。
+
+## 6. Primary Work Item 与 additional links
+
+当宿主 PR gate 只能读取一个 `Loom Work Item` 字段时：
+
+- `primary_work_item` 是 PR gate 的主绑定项。
+- 其他同 PR 承接项必须进入 `additional_work_item_links`，并在 PR body、review record 和 closeout comment 中显式列出。
+- additional item 不能只靠 GitHub auto-close 语义完成；closeout 必须逐项消费 merge commit 与 Project Status。
+- 如果 gate、review 或 closeout 无法稳定消费 additional item，必须拆 PR。
+
+## 7. 与 PR body 的关系
+
+PR body 是 host 展示和绑定面。
+
+必须包含：
+
+- primary `Loom Work Item`。
+- related issue / FR / Phase locator。
+- spec / plan locator。
+- validation summary。
+- additional `Work Item` links，如果存在。
+- risks and follow-ups。
+
+不得包含：
+
+- review verdict 作为 authority。
+- merge-ready verdict 作为 authority。
+- closeout result 作为 authority。
+- 从自由 Markdown 推断出的 machine truth。
+
+若 repo-specific metadata 需要被机器读取，必须使用 repo companion 合同中的 PR body HTML comment JSON machine carrier，而不是自由 Markdown。
+
+## 8. Review 与 merge-ready 消费
+
+Review 必须确认：
+
+- PR scope 是否匹配 slicing decision。
+- 每个被承接 `Work Item` 的 non-goals 没有被越界实现。
+- validation matrix 是否覆盖所有被承接项。
+- additional item 是否有独立 closeout 路径。
+
+Merge-ready 必须确认：
+
+- PR head SHA 与 review record 一致。
+- validation summary 与 recovery/status 中的最新证据一致。
+- PR body 的 primary/additional issue 回链完整。
+- GitHub required checks 已通过。
+- Project Status 不与 issue state、review、merge-ready 或 closeout truth 冲突。
+
+## 9. Closeout 消费
+
+单 PR 承接多个 `Work Item` 时，closeout 必须逐项记录：
+
+- `Work Item` issue locator。
+- PR locator。
+- PR head SHA。
+- merge commit。
+- delivered artifact locator。
+- validation evidence。
+- Project Status。
+- downstream 或 deferred/not_applicable 判断。
+
+父 FR 只能在所有 required child `Work Item` 都 closed 或明确 deferred 且非阻塞时关闭。
+
+## 10. Freshness
+
+PR slicing 结果在以下情况 stale：
+
+- issue-tree plan 的 Work Item list、dependency plan 或 PR slicing placeholder 改变。
+- 任一候选 `Work Item` scope、validation entry 或 closeout condition 改变。
+- blocked-by/blocks 关系改变。
+- Project Status 与 issue / PR / review / closeout evidence 冲突。
+- PR head 引入未被 slicing decision 覆盖的新 scope。
+- gate chain 开始支持或停止支持多 Work Item machine binding。
+
+## 11. 最小验证
+
+完成 PR slicing 合同时，至少验证：
+
+- 文档明确 same PR 条件和必须拆 PR 条件。
+- 文档明确 primary `Work Item`、additional links、PR body、review evidence、merge-ready evidence 和 closeout 的关系。
+- 文档明确 PR 是 host carrier，不替代 Loom truth。
+- 文档说明单 PR 多 `Work Item` 必须有逐项证据回链。
+- 文档没有实现 PR gate、merge-ready 或 GitHub mapping 逻辑。

--- a/docs/methodology/templates/scaffold/pr-slicing.md
+++ b/docs/methodology/templates/scaffold/pr-slicing.md
@@ -1,0 +1,109 @@
+# PR Slicing
+
+- Schema marker: loom-pr-slicing/v1
+
+## Slicing Goal
+
+- Goal:
+- Delivery planning locator:
+- Issue-tree plan locator:
+- Slicing owner:
+- Freshness status: current | stale | superseded
+
+## Input Locators
+
+- Phase locator:
+- FR locator:
+- Candidate Work Item locators:
+- Dependency / blocked-by locator:
+- Existing PR locator or `not_applicable` rationale:
+- Conversation locator or `not_applicable` rationale:
+
+## Candidate Work Items
+
+### Work Item 1
+
+- Locator:
+- Parent FR:
+- Scope:
+- Non-goals:
+- Validation entry:
+- Closeout condition:
+- Project Status:
+
+## Dependency Read
+
+- Blocking dependencies:
+- Sequencing only:
+- Independent candidates:
+- Dependency risks:
+
+## Same PR Decision
+
+- Decision: single_pr | split_pr | defer_decision | not_applicable
+- Rationale:
+- Primary Work Item:
+- Additional Work Item links:
+- Required PR count:
+
+## Same PR Conditions
+
+- Shared parent FR or cross-FR rationale:
+- Scope purity statement:
+- Review risk statement:
+- Validation coverage statement:
+- PR body requirements:
+- Closeout requirements:
+
+## Split PR Conditions
+
+- Required split triggers:
+- Risk domains that require separate PRs:
+- Independent review requirements:
+- Independent merge / closeout requirements:
+- Deferred or unstable scope:
+
+## PR Body Contract
+
+- Primary `Loom Work Item`:
+- Related Phase / FR:
+- Spec / plan locator:
+- Validation summary:
+- Additional Work Item links:
+- Risks and follow-ups:
+- Machine carrier locator or `not_applicable` rationale:
+
+## Review Risk
+
+- Required reviewer perspectives:
+- Scope risks:
+- Validation risks:
+- Host / Project status risks:
+- Risk reduction action:
+
+## Validation Matrix
+
+| Work Item | Evidence Required | Command / Locator | Status |
+|---|---|---|---|
+|  |  |  | pending |
+
+## Merge-ready Consumption
+
+- PR head SHA requirement:
+- Review record requirement:
+- Validation summary requirement:
+- PR body linkage requirement:
+- Required checks:
+- Project Status consistency:
+
+## Closeout Consumption
+
+| Work Item | PR | Head SHA | Merge Commit | Project Status | Closeout Comment |
+|---|---|---|---|---|---|
+|  |  |  |  | pending | pending |
+
+## Freshness Rule
+
+- Stale when:
+- Superseded by:
+- Revalidation entry:


### PR DESCRIPTION
## Summary

- Problem: #1026 needs a Loom-native PR slicing strategy so delivery planning can decide when Work Items share one PR, when they split, and what evidence is required for multi-Work-Item PRs.
- Scope: Add `docs/methodology/templates/pr-slicing.md`, `docs/methodology/templates/scaffold/pr-slicing.md`, template README registration, and WI-1026 fact-chain/review carriers.

## Validation

- [x] Verified locally
- [x] Verified by automation
- [ ] Not applicable

Validation details:
- `git diff --check`
- focused `rg` checks for PR slicing fields, scope purity, multi-Work-Item evidence, PR body linkage, review evidence, and merge-ready references
- `python3 .loom/bin/loom_init.py verify --target .`
- `python3 .loom/bin/loom_flow.py carrier refresh --target . --item WI-1026 --write`
- `python3 tools/loom_check.py --profile source --source-surface contract-only .`

## Risks And Follow-ups

- Risks: This is a methodology/template contract only; it does not implement multi-Work-Item PR gate support.
- Follow-ups: #1027 GitHub mapping and #1028 skills routing still need to consume this boundary; #1019 owns any future gate-chain implementation.

## Related Work

- Issue: Closes #1026; refs #1014, #1012, #1024, #1025
- Loom Work Item: WI-1026
- Spec / plan: `.loom/specs/WI-1026/spec.md`; `.loom/specs/WI-1026/plan.md`
