### PR TITLE
test(cli): guard CLI-only install surface

### DIFF
--- a/.loom/bootstrap/init-result.json
+++ b/.loom/bootstrap/init-result.json
@@ -76,9 +76,9 @@
     "mode": "work-item + recovery-entry + derived status-surface",
     "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
     "entry_points": {
-      "current_item_id": "WI-1067",
-      "work_item": ".loom/work-items/WI-1067.md",
-      "recovery_entry": ".loom/progress/WI-1067.md",
+      "current_item_id": "WI-1068",
+      "work_item": ".loom/work-items/WI-1068.md",
+      "recovery_entry": ".loom/progress/WI-1068.md",
       "status_surface": ".loom/status/current.md"
     }
   },

--- a/.loom/progress/WI-1067.md
+++ b/.loom/progress/WI-1067.md
@@ -3,12 +3,12 @@
 ## Dynamic Facts
 
 - Item ID: WI-1067
-- Current Checkpoint: document-hard-cut
-- Current Stop: Primary README/adoption docs are hard-cut to root `loom` CLI install with CLI-managed plugin/SKILLS payloads; README compatibility text is explicitly non-primary and release-neutral.
-- Next Step: Push refreshed #1067 head, wait for PR checks, then merge and close #1067 with PR/check evidence for #1068.
+- Current Checkpoint: closed
+- Current Stop: PR #1087 merged #1067 at merge commit `1dffa6a6e96ed0628521e3d553b1fa6f9bac917e`; primary README/adoption docs are hard-cut to root `loom` CLI install with CLI-managed plugin/SKILLS payloads.
+- Next Step: #1068 consumes the merged #1067 documentation hard cut as the basis for checker hardening.
 - Blockers: None
-- Latest Validation Summary: Local validation passed after rebase onto main `c3d87cce44a842011f8b2c2898d97dd172d0eaab` at #1067 head `62e5fed3ad2df0e72e5bd1dd8fa6404c093b2e71`: `python3 tools/check_release_surface.py`; `python3 tools/version_surface_check.py`; `python3 tools/host_adapter_check.py`; `python3 tools/check_cli_contract.py`; `python3 tools/check_npm_package.py`; `npm run test:package`; `npm run pack:dry-run`; `npm --prefix packages/loom-installer run check:docs`; `npm --prefix packages/loom-installer run check:versions`; `npm --prefix packages/loom-installer run check:payload`; `npm --prefix packages/loom-installer run check:distribution`; `python3 .loom/bin/loom_flow.py fact-chain --target . --item WI-1067`; `python3 .loom/bin/loom_flow.py shadow-parity --target .`; `python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-1067`; `make check`.
-- Recovery Boundary: Continue from /Users/mc/dev/Loom-1067-cli-only-doc-hard-cut on branch work/1067-cli-only-doc-hard-cut; keep scope limited to #1067 docs plus release-neutral stale doc/checker compatibility text.
+- Latest Validation Summary: PR #1087 merged with final head `b40696f1ce3611e709d7c952e4535aa1c859eee0`; merge commit checks passed for release, release-judgment, loom-check, root-self-governance, demo-bootstrap, py-compile, and repo-local-cli.
+- Recovery Boundary: Terminal #1067 carrier retained for #1068 consumption; stale worktree /Users/mc/dev/Loom-1067-cli-only-doc-hard-cut was removed after merge.
 - Current Lane: cli-only-doc-hard-cut
 
 ## Execution Ledger

--- a/.loom/progress/WI-1068.md
+++ b/.loom/progress/WI-1068.md
@@ -1,0 +1,21 @@
+# WI-1068 Progress
+
+## Dynamic Facts
+
+- Item ID: WI-1068
+- Current Checkpoint: checker-hardening
+- Current Stop: Local validation passed for CLI-only checker hardening, including release surface guards, root npm package payload guards, installer compatibility checks, Loom carrier checks, and full `make check`.
+- Next Step: Commit and push the #1068 branch, open PR, run `pr-gate`, wait for PR checks, then merge and close #1068 with evidence for #1069.
+- Blockers: None
+- Latest Validation Summary: Passed `python3 tools/check_release_surface.py`; `python3 tools/check_npm_package.py`; `python3 tools/version_surface_check.py`; `python3 tools/check_cli_contract.py`; `npm run test:package`; `npm run pack:dry-run`; installer `check:docs`, `check:versions`, `check:payload`, and `check:distribution`; `fact-chain`; `shadow-parity`; `adopt verify`; and full `make check`.
+- Recovery Boundary: Continue from /Users/mc/dev/Loom-1068-cli-only-surface-checks on branch work/1068-cli-only-surface-checks; keep scope limited to checker hardening and WI-1068 governance carriers.
+- Current Lane: cli-only-surface-checks
+
+## Execution Ledger
+
+- Ledger Binding: recovery_entry
+- Plan Locator: .loom/specs/WI-1068/plan.md
+- Acceptance Locator: .loom/specs/WI-1068/spec.md
+- Validation Evidence Locator: local command output and GitHub checks for PR #1068.
+- Handoff Notes Locator: not_applicable
+- Evidence Freshness: current

--- a/.loom/reviews/WI-1068.json
+++ b/.loom/reviews/WI-1068.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-1068",
+  "decision": "allow",
+  "kind": "code_review",
+  "summary": "Pending final review after validation.",
+  "reviewer": "codex-main-agent",
+  "reviewed_head": "pending",
+  "reviewed_validation_summary": "pending",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-1068.md",
+    "recovery_entry": ".loom/progress/WI-1068.md",
+    "status_surface": ".loom/status/current.md",
+    "build_checkpoint": "pending"
+  }
+}

--- a/.loom/reviews/WI-1068.json
+++ b/.loom/reviews/WI-1068.json
@@ -6,7 +6,7 @@
   "summary": "CLI-only checker hardening stays within #1068 scope: release surface docs now fail closed on separate SKILLS/plugin/installer install surfaces, and the root npm package check now requires CLI-managed payload files while rejecting deprecated installer manifest references.",
   "reviewer": "codex-main-agent",
   "reviewed_head": "b2f10de71c76dab0f8189b9019e90daeab6f7542",
-  "reviewed_validation_summary": "Passed local validation: check_release_surface, check_npm_package, version_surface_check, check_cli_contract, npm package smoke, dry-run pack, installer docs/version/payload/distribution checks, fact-chain, shadow-parity, adopt verify, and full make check.",
+  "reviewed_validation_summary": "Passed `python3 tools/check_release_surface.py`; `python3 tools/check_npm_package.py`; `python3 tools/version_surface_check.py`; `python3 tools/check_cli_contract.py`; `npm run test:package`; `npm run pack:dry-run`; installer `check:docs`, `check:versions`, `check:payload`, and `check:distribution`; `fact-chain`; `shadow-parity`; `adopt verify`; and full `make check`.",
   "fallback_to": null,
   "findings": [],
   "blocking_issues": [],

--- a/.loom/reviews/WI-1068.json
+++ b/.loom/reviews/WI-1068.json
@@ -3,10 +3,10 @@
   "item_id": "WI-1068",
   "decision": "allow",
   "kind": "code_review",
-  "summary": "Pending final review after validation.",
+  "summary": "CLI-only checker hardening stays within #1068 scope: release surface docs now fail closed on separate SKILLS/plugin/installer install surfaces, and the root npm package check now requires CLI-managed payload files while rejecting deprecated installer manifest references.",
   "reviewer": "codex-main-agent",
-  "reviewed_head": "pending",
-  "reviewed_validation_summary": "pending",
+  "reviewed_head": "b2f10de71c76dab0f8189b9019e90daeab6f7542",
+  "reviewed_validation_summary": "Passed local validation: check_release_surface, check_npm_package, version_surface_check, check_cli_contract, npm package smoke, dry-run pack, installer docs/version/payload/distribution checks, fact-chain, shadow-parity, adopt verify, and full make check.",
   "fallback_to": null,
   "findings": [],
   "blocking_issues": [],
@@ -15,6 +15,6 @@
     "work_item": ".loom/work-items/WI-1068.md",
     "recovery_entry": ".loom/progress/WI-1068.md",
     "status_surface": ".loom/status/current.md",
-    "build_checkpoint": "pending"
+    "build_checkpoint": "make check passed on branch work/1068-cli-only-surface-checks"
   }
 }

--- a/.loom/reviews/WI-1068.json
+++ b/.loom/reviews/WI-1068.json
@@ -5,7 +5,7 @@
   "kind": "code_review",
   "summary": "CLI-only checker hardening stays within #1068 scope: release surface docs now fail closed on separate SKILLS/plugin/installer install surfaces, and the root npm package check now requires CLI-managed payload files while rejecting deprecated installer manifest references.",
   "reviewer": "codex-main-agent",
-  "reviewed_head": "b2f10de71c76dab0f8189b9019e90daeab6f7542",
+  "reviewed_head": "8043c5e73e4481d3c386cbe86346d8124d418655",
   "reviewed_validation_summary": "Passed `python3 tools/check_release_surface.py`; `python3 tools/check_npm_package.py`; `python3 tools/version_surface_check.py`; `python3 tools/check_cli_contract.py`; `npm run test:package`; `npm run pack:dry-run`; installer `check:docs`, `check:versions`, `check:payload`, and `check:distribution`; `fact-chain`; `shadow-parity`; `adopt verify`; and full `make check`.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-1068.spec.json
+++ b/.loom/reviews/WI-1068.spec.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-1068",
+  "decision": "allow",
+  "kind": "spec_review",
+  "summary": "WI-1068 is bounded to checker hardening for CLI-only install and release surfaces, with no npm publish workflow or installer reactivation.",
+  "reviewer": "codex-main-agent",
+  "reviewed_head": "1dffa6a6e96ed0628521e3d553b1fa6f9bac917e",
+  "reviewed_validation_summary": "Spec, plan, and implementation contract reviewed before implementation on branch work/1068-cli-only-surface-checks.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "issue": "#1068",
+    "parent": "#1063",
+    "previous_work": "#1064 #1065 #1066 #1067"
+  }
+}

--- a/.loom/reviews/WI-1068.spec.json
+++ b/.loom/reviews/WI-1068.spec.json
@@ -5,7 +5,7 @@
   "kind": "spec_review",
   "summary": "WI-1068 is bounded to checker hardening for CLI-only install and release surfaces, with no npm publish workflow or installer reactivation.",
   "reviewer": "codex-main-agent",
-  "reviewed_head": "1dffa6a6e96ed0628521e3d553b1fa6f9bac917e",
+  "reviewed_head": "b2f10de71c76dab0f8189b9019e90daeab6f7542",
   "reviewed_validation_summary": "Spec, plan, and implementation contract reviewed before implementation on branch work/1068-cli-only-surface-checks.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "d4ee77bad19d864138a0e448f3d783a153ef20e62f9fa73137478a36383d8dab"
+    ".loom/status/current.md": "a310337a23f57fde3a851924cf3c7b116f9cd8727a6e86079502c05a8353d28a"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "d4ee77bad19d864138a0e448f3d783a153ef20e62f9fa73137478a36383d8dab"
+    ".loom/status/current.md": "a310337a23f57fde3a851924cf3c7b116f9cd8727a6e86079502c05a8353d28a"
   }
 }

--- a/.loom/specs/WI-1068/implementation-contract.md
+++ b/.loom/specs/WI-1068/implementation-contract.md
@@ -1,0 +1,6 @@
+# WI-1068 Implementation Contract
+
+- Owns checker hardening only.
+- May update local governance carriers for WI-1068.
+- Must not change `VERSION`, release workflows, npm publish behavior, or installer publishing.
+- Must leave `loom-installer` references allowed only as deprecated historical/evidence text.

--- a/.loom/specs/WI-1068/plan.md
+++ b/.loom/specs/WI-1068/plan.md
@@ -1,0 +1,6 @@
+# WI-1068 Plan
+
+1. Strengthen `tools/check_release_surface.py` with CLI-only active-doc coverage and negative fixtures for SKILLS/plugin/installer install surfaces.
+2. Strengthen `tools/check_npm_package.py` so root package manifest and dry-run payload remain bound to root `loom` CLI plus CLI-managed payloads.
+3. Run focused release/package/CLI checks, installer legacy checks, Loom fact-chain/shadow/adopt checks, and `make check`.
+4. Bind review and PR evidence to the final head, then merge only after GitHub checks pass.

--- a/.loom/specs/WI-1068/spec.md
+++ b/.loom/specs/WI-1068/spec.md
@@ -1,0 +1,14 @@
+# WI-1068 Spec
+
+## Acceptance
+
+- Primary install/adoption docs fail closed if they present `loom-installer`, SKILLS, or plugins as independent primary/default/recommended install surfaces.
+- Root npm package checks fail closed if `package.json` references the deprecated installer surface or omits CLI-managed `skills`, `src/skills`, or Codex plugin payload files.
+- Existing release-surface separation remains intact: `loom-installer` can appear only as deprecated historical evidence, not active CLI publish evidence.
+- The change remains checker scoped and does not add npm publish automation or reactivate installer publishing.
+
+## Non-Goals
+
+- Do not add or publish any npm package.
+- Do not change the first npm CLI release workflow.
+- Do not reactivate `loom-installer` release or migration journeys.

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -2,34 +2,34 @@
 
 ## Derived Fact Chain View
 
-- Item ID: WI-1067
-- Goal: Hard-cut README and primary install/adoption docs to the CLI-only install entry for #1063.
-- Scope: #1067: root `loom` CLI is the only primary install path; plugins and SKILLS are CLI-managed payloads; `loom-installer` may appear only as deprecated historical/evidence text. Minimal static doc-sync/checker needles may be updated only to stop requiring old documentation text. No #1068 checker hardening, npm publish workflow, first npm release, or installer release changes.
-- Execution Path: issue-scoped branch work/1067-cli-only-doc-hard-cut in /Users/mc/dev/Loom-1067-cli-only-doc-hard-cut
+- Item ID: WI-1068
+- Goal: Strengthen checkers so the #1063 CLI-only install and release surface cannot regress after the #1067 documentation hard cut.
+- Scope: #1068: checker-only guardrails for CLI-only install, root npm package payload, CLI-managed plugin/SKILLS payloads, and deprecated `loom-installer` evidence boundaries. No npm publish workflow, first npm release, installer publish reactivation, or broad CLI behavior rewrite.
+- Execution Path: issue-scoped branch work/1068-cli-only-surface-checks in /Users/mc/dev/Loom-1068-cli-only-surface-checks
 - Workspace Entry: .
-- Recovery Entry: .loom/progress/WI-1067.md
-- Review Entry: .loom/reviews/WI-1067.json
-- Validation Entry: python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_cli_contract.py; python3 tools/check_npm_package.py; npm run test:package; npm --prefix packages/loom-installer run check:docs; npm --prefix packages/loom-installer run check:versions; npm --prefix packages/loom-installer run check:payload; npm --prefix packages/loom-installer run check:distribution; python3 .loom/bin/loom_flow.py fact-chain --target . --item WI-1067; python3 .loom/bin/loom_flow.py shadow-parity --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-1067; make check
-- Closing Condition: #1067 is closed after its PR merges and #1068 can consume primary docs that no longer present installer, plugin, or SKILLS as separate install surfaces.
-- Current Checkpoint: document-hard-cut
-- Current Stop: Primary README/adoption docs are hard-cut to root `loom` CLI install with CLI-managed plugin/SKILLS payloads; README compatibility text is explicitly non-primary and release-neutral.
-- Next Step: Push refreshed #1067 head, wait for PR checks, then merge and close #1067 with PR/check evidence for #1068.
+- Recovery Entry: .loom/progress/WI-1068.md
+- Review Entry: .loom/reviews/WI-1068.json
+- Validation Entry: python3 tools/check_release_surface.py; python3 tools/check_npm_package.py; python3 tools/check_cli_contract.py; npm run test:package; npm run pack:dry-run; npm --prefix packages/loom-installer run check:docs; npm --prefix packages/loom-installer run check:versions; npm --prefix packages/loom-installer run check:payload; npm --prefix packages/loom-installer run check:distribution; python3 .loom/bin/loom_flow.py fact-chain --target . --item WI-1068; python3 .loom/bin/loom_flow.py shadow-parity --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-1068; make check
+- Closing Condition: #1068 is closed after its PR merges and #1069 can consume checkers that fail closed if primary docs, package payload, or release evidence drift away from the single root `loom` CLI install surface.
+- Current Checkpoint: checker-hardening
+- Current Stop: Local validation passed for CLI-only checker hardening, including release surface guards, root npm package payload guards, installer compatibility checks, Loom carrier checks, and full `make check`.
+- Next Step: Commit and push the #1068 branch, open PR, run `pr-gate`, wait for PR checks, then merge and close #1068 with evidence for #1069.
 - Blockers: None
-- Latest Validation Summary: Local validation passed after rebase onto main `c3d87cce44a842011f8b2c2898d97dd172d0eaab` at #1067 head `62e5fed3ad2df0e72e5bd1dd8fa6404c093b2e71`: `python3 tools/check_release_surface.py`; `python3 tools/version_surface_check.py`; `python3 tools/host_adapter_check.py`; `python3 tools/check_cli_contract.py`; `python3 tools/check_npm_package.py`; `npm run test:package`; `npm run pack:dry-run`; `npm --prefix packages/loom-installer run check:docs`; `npm --prefix packages/loom-installer run check:versions`; `npm --prefix packages/loom-installer run check:payload`; `npm --prefix packages/loom-installer run check:distribution`; `python3 .loom/bin/loom_flow.py fact-chain --target . --item WI-1067`; `python3 .loom/bin/loom_flow.py shadow-parity --target .`; `python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-1067`; `make check`.
-- Recovery Boundary: Continue from /Users/mc/dev/Loom-1067-cli-only-doc-hard-cut on branch work/1067-cli-only-doc-hard-cut; keep scope limited to #1067 docs plus release-neutral stale doc/checker compatibility text.
-- Current Lane: cli-only-doc-hard-cut
+- Latest Validation Summary: Passed `python3 tools/check_release_surface.py`; `python3 tools/check_npm_package.py`; `python3 tools/version_surface_check.py`; `python3 tools/check_cli_contract.py`; `npm run test:package`; `npm run pack:dry-run`; installer `check:docs`, `check:versions`, `check:payload`, and `check:distribution`; `fact-chain`; `shadow-parity`; `adopt verify`; and full `make check`.
+- Recovery Boundary: Continue from /Users/mc/dev/Loom-1068-cli-only-surface-checks on branch work/1068-cli-only-surface-checks; keep scope limited to checker hardening and WI-1068 governance carriers.
+- Current Lane: cli-only-surface-checks
 
 ## Runtime Evidence
 
 - Run Entry: not_applicable
 - Logs Entry: not_applicable
 - Diagnostics Entry: not_applicable
-- Verification Entry: python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_cli_contract.py; python3 tools/check_npm_package.py; npm run test:package; npm --prefix packages/loom-installer run check:docs; npm --prefix packages/loom-installer run check:versions; npm --prefix packages/loom-installer run check:payload; npm --prefix packages/loom-installer run check:distribution; python3 .loom/bin/loom_flow.py fact-chain --target . --item WI-1067; python3 .loom/bin/loom_flow.py shadow-parity --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-1067; make check
+- Verification Entry: python3 tools/check_release_surface.py; python3 tools/check_npm_package.py; python3 tools/check_cli_contract.py; npm run test:package; npm run pack:dry-run; npm --prefix packages/loom-installer run check:docs; npm --prefix packages/loom-installer run check:versions; npm --prefix packages/loom-installer run check:payload; npm --prefix packages/loom-installer run check:distribution; python3 .loom/bin/loom_flow.py fact-chain --target . --item WI-1068; python3 .loom/bin/loom_flow.py shadow-parity --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-1068; make check
 - Lane Entry: not_applicable
 
 ## Sources
 
-- Static Truth: .loom/work-items/WI-1067.md
-- Dynamic Truth: .loom/progress/WI-1067.md
+- Static Truth: .loom/work-items/WI-1068.md
+- Dynamic Truth: .loom/progress/WI-1068.md
 - Locator Truth: .loom/bootstrap/init-result.json
 - Fact Chain CLI: python3 .loom/bin/loom_init.py fact-chain --target .

--- a/.loom/work-items/WI-1068.md
+++ b/.loom/work-items/WI-1068.md
@@ -1,0 +1,28 @@
+# WI-1068
+
+## Static Facts
+
+- Item ID: WI-1068
+- Goal: Strengthen checkers so the #1063 CLI-only install and release surface cannot regress after the #1067 documentation hard cut.
+- Scope: #1068: checker-only guardrails for CLI-only install, root npm package payload, CLI-managed plugin/SKILLS payloads, and deprecated `loom-installer` evidence boundaries. No npm publish workflow, first npm release, installer publish reactivation, or broad CLI behavior rewrite.
+- Execution Path: issue-scoped branch work/1068-cli-only-surface-checks in /Users/mc/dev/Loom-1068-cli-only-surface-checks
+- Workspace Entry: .
+- Recovery Entry: .loom/progress/WI-1068.md
+- Review Entry: .loom/reviews/WI-1068.json
+- Validation Entry: python3 tools/check_release_surface.py; python3 tools/check_npm_package.py; python3 tools/check_cli_contract.py; npm run test:package; npm run pack:dry-run; npm --prefix packages/loom-installer run check:docs; npm --prefix packages/loom-installer run check:versions; npm --prefix packages/loom-installer run check:payload; npm --prefix packages/loom-installer run check:distribution; python3 .loom/bin/loom_flow.py fact-chain --target . --item WI-1068; python3 .loom/bin/loom_flow.py shadow-parity --target .; python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-1068; make check
+- Closing Condition: #1068 is closed after its PR merges and #1069 can consume checkers that fail closed if primary docs, package payload, or release evidence drift away from the single root `loom` CLI install surface.
+
+## Associated Artifacts
+
+- `tools/check_release_surface.py`
+- `tools/check_npm_package.py`
+- `.loom/work-items/WI-1068.md`
+- `.loom/progress/WI-1068.md`
+- `.loom/reviews/WI-1068.spec.json`
+- `.loom/reviews/WI-1068.json`
+- `.loom/specs/WI-1068/spec.md`
+- `.loom/specs/WI-1068/plan.md`
+- `.loom/specs/WI-1068/implementation-contract.md`
+- `.loom/status/current.md`
+- `.loom/shadow/merge-ready-loom.json`
+- `.loom/shadow/closeout-loom.json`

--- a/tools/check_npm_package.py
+++ b/tools/check_npm_package.py
@@ -47,6 +47,16 @@ FORBIDDEN_PREFIXES = (
     "examples/",
     "packages/loom-installer/",
 )
+FORBIDDEN_MANIFEST_STRINGS = (
+    "@mc-and-his-agents/loom-installer",
+    "loom-installer",
+    "packages/loom-installer",
+)
+REQUIRED_MANIFEST_FILES = (
+    "skills",
+    "src/skills",
+    "plugins/loom/.codex-plugin/plugin.json",
+)
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -95,8 +105,19 @@ def main() -> int:
         fail(f"bin loom must point at {EXPECTED_BIN}")
     if package.get("publishConfig", {}).get("access") != "public":
         fail("publishConfig.access must be public")
-    if "@mc-and-his-agents/loom-installer" in json.dumps(package, sort_keys=True):
-        fail("root package manifest must not depend on loom-installer")
+    manifest_text = json.dumps(package, sort_keys=True)
+    for forbidden in FORBIDDEN_MANIFEST_STRINGS:
+        if forbidden in manifest_text:
+            fail(f"root package manifest must not reference deprecated installer surface: {forbidden}")
+    manifest_files = package.get("files")
+    if not isinstance(manifest_files, list):
+        fail("package files must explicitly enumerate the root CLI payload")
+    missing_manifest_files = sorted(item for item in REQUIRED_MANIFEST_FILES if item not in manifest_files)
+    if missing_manifest_files:
+        fail(f"package files must include CLI-managed payload surfaces: {missing_manifest_files}")
+    forbidden_manifest_files = sorted(item for item in manifest_files if isinstance(item, str) and item.startswith(FORBIDDEN_PREFIXES))
+    if forbidden_manifest_files:
+        fail(f"package files must not include forbidden repository/internal surfaces: {forbidden_manifest_files}")
 
     missing_sources = sorted(path for path in REQUIRED_FILES if not (REPO_ROOT / path).exists())
     if missing_sources:
@@ -119,6 +140,7 @@ def main() -> int:
         "bin": "loom",
         "payload_file_count": len(pack_files),
         "required_files": sorted(REQUIRED_FILES),
+        "required_manifest_files": sorted(REQUIRED_MANIFEST_FILES),
         "forbidden_prefixes": list(FORBIDDEN_PREFIXES),
     }, indent=2))
     return 0

--- a/tools/check_release_surface.py
+++ b/tools/check_release_surface.py
@@ -18,13 +18,19 @@ INSTALLER_BUMP_CHECK = ROOT / "packages" / "loom-installer" / "scripts" / "check
 README = ROOT / "README.md"
 README_ZH = ROOT / "README.zh-CN.md"
 CODEX_INSTALL = ROOT / "docs" / "adoption" / "codex-install.md"
+CLI_ONLY_CONTRACT = ROOT / "docs" / "adoption" / "cli-only-install-contract.md"
+UNIFIED_INSTALL = ROOT / "docs" / "adoption" / "unified-install-experience.md"
+HOST_ADAPTER_MATRIX = ROOT / "docs" / "adoption" / "host-adapter-matrix.md"
 
 ACTIVE_SURFACE_DOCS = (
     README,
     README_ZH,
+    CLI_ONLY_CONTRACT,
     CLI_RELEASE_DOC,
     VERSION_AUTHORITY,
     CODEX_INSTALL,
+    UNIFIED_INSTALL,
+    HOST_ADAPTER_MATRIX,
 )
 
 FORBIDDEN_ACTIVE_INSTALLER_PATTERNS = (
@@ -33,6 +39,33 @@ FORBIDDEN_ACTIVE_INSTALLER_PATTERNS = (
     re.compile(r"loom-installer-v[^\s`)]*[^.\n]*(?:publishes|proves|is evidence for)[^.\n]*(?:loom|CLI)", re.IGNORECASE),
     re.compile(r"npx\s+(?:@mc-and-his-agents/)?loom-installer[^.\n]*(?:is|as|remains)[^.\n]*(?:default|recommended|primary)[^.\n]*(?:Codex|install|path)", re.IGNORECASE),
     re.compile(r"(?:default|recommended|primary)[^.\n]*(?:Codex|install|path)[^.\n]*(?:is|uses)\s+npx\s+(?:@mc-and-his-agents/)?loom-installer", re.IGNORECASE),
+)
+
+FORBIDDEN_SEPARATE_INSTALL_SURFACE_PATTERNS = (
+    re.compile(r"(?:SKILLS|skills/|plugins?/loom|host plugins?)[^.\n]*(?:is|are|as|remain)[^.\n]*(?:primary|default|recommended)[^.\n]*(?:install|installation|surface|path)", re.IGNORECASE),
+    re.compile(r"(?:primary|default|recommended)[^.\n]*(?:install|installation|surface|path)[^.\n]*(?:SKILLS|skills/|plugins?/loom|host plugins?)", re.IGNORECASE),
+    re.compile(r"(?:install|use)\s+(?:SKILLS|skills/|plugins?/loom|host plugins?)[^.\n]*(?:directly|separately|independently|as separate)", re.IGNORECASE),
+    re.compile(r"(?:npm install|npx)\s+(?:-g\s+)?(?:@mc-and-his-agents/)?loom-installer", re.IGNORECASE),
+)
+
+NEGATED_CONTEXT_MARKERS = (
+    "no check may",
+    "must not",
+    "do not",
+    "is not",
+    "are not",
+    "not ",
+    "not a",
+    "not the",
+    "not part",
+    "without",
+    "deprecated",
+    "historical",
+    "legacy",
+    "unsupported",
+    "cli-managed",
+    "managed payload",
+    "root `loom` cli",
 )
 
 
@@ -63,7 +96,7 @@ def forbid_active_installer_evidence(path: Path, errors: list[str]) -> None:
             if line_end == -1:
                 line_end = len(text)
             line = text[line_start:line_end].lower()
-            if any(guard in line for guard in ("no check may", "must not", "do not", "is not", "not ")):
+            if any(guard in line for guard in NEGATED_CONTEXT_MARKERS):
                 continue
             snippet = " ".join(match.group(0).split())
             errors.append(
@@ -71,9 +104,59 @@ def forbid_active_installer_evidence(path: Path, errors: list[str]) -> None:
             )
 
 
+def forbid_separate_install_surfaces(path: Path, errors: list[str]) -> None:
+    text = require_file(path, errors)
+    if not text:
+        return
+    for pattern in FORBIDDEN_SEPARATE_INSTALL_SURFACE_PATTERNS:
+        for match in pattern.finditer(text):
+            line_start = text.rfind("\n", 0, match.start()) + 1
+            line_end = text.find("\n", match.end())
+            if line_end == -1:
+                line_end = len(text)
+            line = text[line_start:line_end].lower()
+            if any(guard in line for guard in NEGATED_CONTEXT_MARKERS):
+                continue
+            snippet = " ".join(match.group(0).split())
+            errors.append(
+                f"{path.relative_to(ROOT)} must not present SKILLS, plugins, or loom-installer as separate install surfaces: `{snippet}`"
+            )
+
+
+def assert_pattern_guards(errors: list[str]) -> None:
+    negative_examples = (
+        "SKILLS are managed by the root loom CLI and are not a separate install surface.",
+        "Host plugins are CLI-managed payloads, not primary install paths.",
+        "`loom-installer` is a deprecated historical artifact, not the current install path.",
+    )
+    positive_examples = (
+        "SKILLS are the recommended install surface for Loom.",
+        "The primary install path uses plugins/loom directly.",
+        "Run npx @mc-and-his-agents/loom-installer to install Loom.",
+    )
+    for example in negative_examples:
+        lowered = example.lower()
+        if any(pattern.search(example) and not any(marker in lowered for marker in NEGATED_CONTEXT_MARKERS) for pattern in FORBIDDEN_SEPARATE_INSTALL_SURFACE_PATTERNS):
+            errors.append(f"CLI-only install guard false-positive fixture failed: {example}")
+    for example in positive_examples:
+        lowered = example.lower()
+        if not any(pattern.search(example) and not any(marker in lowered for marker in NEGATED_CONTEXT_MARKERS) for pattern in FORBIDDEN_SEPARATE_INSTALL_SURFACE_PATTERNS):
+            errors.append(f"CLI-only install guard failed to reject fixture: {example}")
+
+
 def main() -> int:
     errors: list[str] = []
 
+    require_needles(
+        CLI_ONLY_CONTRACT,
+        (
+            "The only primary user-facing install surface for Loom is the root `loom` CLI",
+            "Host plugins are host adapter payloads managed by the `loom` CLI",
+            "`SKILLS` are executable scenario payloads managed, synchronized, and verified",
+            "`loom-installer` must not gain a new migration journey",
+        ),
+        errors,
+    )
     require_needles(
         CLI_RELEASE_DOC,
         (
@@ -141,12 +224,16 @@ def main() -> int:
         ),
         errors,
     )
-    require_needles(README, ("Loom CLI release surface", "loom-installer deprecated legacy line"), errors)
-    require_needles(README_ZH, ("Loom CLI 发布面", "loom-installer deprecated legacy line"), errors)
-    require_needles(CODEX_INSTALL, ("The npm installer is not the Codex default path",), errors)
+    require_needles(README, ("Loom CLI release surface", "loom-installer deprecated legacy line", "users do not install them as a separate surface"), errors)
+    require_needles(README_ZH, ("Loom CLI 发布面", "loom-installer deprecated legacy line", "用户不再把它们作为独立安装面安装"), errors)
+    require_needles(CODEX_INSTALL, ("The npm installer is not the Codex default path", "The plugin and\nSKILLS directories are CLI-managed payloads"), errors)
+    require_needles(UNIFIED_INSTALL, ("use `loom host install` to install host plugin/SKILLS payloads", "Historical: `@mc-and-his-agents/loom-installer` references retained only for deprecated evidence"), errors)
+    require_needles(HOST_ADAPTER_MATRIX, ("CLI-managed `skills/` and `plugins/loom/` payloads", "update root CLI, then rerun"), errors)
 
     for path in ACTIVE_SURFACE_DOCS:
         forbid_active_installer_evidence(path, errors)
+        forbid_separate_install_surfaces(path, errors)
+    assert_pattern_guards(errors)
 
     forbidden_installer_behavior_needles = (
         "plugins/loom/.codex-plugin/|src/skills/|skills/",


### PR DESCRIPTION
## Summary

- Problem: #1068 needs checker guardrails so the CLI-only install and release surface from #1067 cannot drift back to separate SKILLS/plugin/installer install paths.
- Scope: strengthens `tools/check_release_surface.py`, `tools/check_npm_package.py`, and WI-1068 Loom carriers only. No npm publish workflow, release version change, installer reactivation, or #1069/#1070 work.

## Validation

- [x] Verified locally
- [ ] Verified by automation
- [ ] Not applicable

Validation details:
- `python3 tools/check_release_surface.py`
- `python3 tools/check_npm_package.py`
- `python3 tools/version_surface_check.py`
- `python3 tools/check_cli_contract.py`
- `npm run test:package`
- `npm run pack:dry-run`
- `npm --prefix packages/loom-installer run check:docs`
- `npm --prefix packages/loom-installer run check:versions`
- `npm --prefix packages/loom-installer run check:payload`
- `npm --prefix packages/loom-installer run check:distribution`
- `python3 .loom/bin/loom_flow.py fact-chain --target . --item WI-1068`
- `python3 .loom/bin/loom_flow.py shadow-parity --target .`
- `python3 .loom/bin/loom_flow.py adopt verify --target . --item WI-1068`
- `python3 .loom/bin/loom_flow.py carrier refresh --target . --item WI-1068 --dry-run`
- `make check`

## Risks And Follow-ups

- Risks: regex guardrails are intentionally scoped to primary docs and package manifest/payload surfaces; they do not change runtime install behavior.
- Follow-ups: #1069 consumes these checks when adding npm publish automation.

## Related Work

- Issue: Closes #1068; parent #1063
- Loom Work Item: WI-1068
- Spec / plan: `.loom/specs/WI-1068/spec.md`, `.loom/specs/WI-1068/plan.md`, `.loom/specs/WI-1068/implementation-contract.md`

## Worktree Binding

- Work Item / issue: WI-1068 / #1068
- Branch: `work/1068-cli-only-surface-checks`
- Worktree: `/Users/mc/dev/Loom-1068-cli-only-surface-checks`
- PR head SHA: `a3229bf1efb285ea4566b493443083c3b19943bf`
- Release/package judgment: no version bump, no npm publish, no installer release reactivation; checker-only guardrail for the root `loom` CLI package and CLI-managed payload surfaces.

