### PR TITLE
docs: update WI-1050 scenario skill suite path boundaries

### DIFF
--- a/.loom/bootstrap/init-result.json
+++ b/.loom/bootstrap/init-result.json
@@ -76,9 +76,9 @@
     "mode": "work-item + recovery-entry + derived status-surface",
     "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
     "entry_points": {
-      "current_item_id": "WI-1049",
-      "work_item": ".loom/work-items/WI-1049.md",
-      "recovery_entry": ".loom/progress/WI-1049.md",
+      "current_item_id": "WI-1050",
+      "work_item": ".loom/work-items/WI-1050.md",
+      "recovery_entry": ".loom/progress/WI-1050.md",
       "status_surface": ".loom/status/current.md"
     }
   },

--- a/.loom/progress/WI-1049.md
+++ b/.loom/progress/WI-1049.md
@@ -3,12 +3,12 @@
 ## Dynamic Facts
 
 - Item ID: WI-1049
-- Current Checkpoint: merge-ready
-- Current Stop: PR #1103 opened for WI-1049 with local validation passed; remote PR gate requires Work Item binding update.
-- Next Step: Push Work Item / status / review carriers, update PR body with `Loom Work Item: WI-1049`, wait for remote checks, merge, then close #1049.
+- Current Checkpoint: closed
+- Current Stop: PR #1103 merged into `main` at 49e15873483acd158ebad136280a87d8ca970d62; #1049 closed with Project status `Done`.
+- Next Step: Terminal; #1049 is complete and must not remain an active workspace binding for WI-1050.
 - Blockers: None recorded.
-- Latest Validation Summary: Passed locally on branch `work/1049-github-task-carrier-profile`: `git diff --check`; focused `rg` for GitHub profile / task carrier / sub-issue / Project item / checklist / unique execution entry; focused `rg` for forbidden use / review / merge-ready / closeout / provenance / locator; focused `rg` for Project Status / Todo / In Progress / Done / completed truth / host agent; `python3 tools/skills_surface.py check`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`.
-- Recovery Boundary: #1049 owns GitHub task carrier profile mapping only. Do not update scenario skill routing, source/generated skills surface, drift checks, CLI command surface, or core #1014-#1019 contracts in this Work Item.
+- Latest Validation Summary: PR #1103 passed local and remote validation, then merged into `main` at 49e15873483acd158ebad136280a87d8ca970d62; #1049 closeout evidence comment recorded validation and scope exclusions.
+- Recovery Boundary: Terminal for #1049. Do not use WI-1049 as active binding for WI-1050 or later Work Items.
 - Current Lane: github-task-carrier-profile
 
 ## Execution Ledger
@@ -16,6 +16,6 @@
 - Ledger Binding: recovery_entry
 - Plan Locator: #1049 issue body
 - Acceptance Locator: #1049 acceptance criteria
-- Validation Evidence Locator: local validation commands listed in Latest Validation Summary; PR pending.
+- Validation Evidence Locator: PR #1103; merge commit 49e15873483acd158ebad136280a87d8ca970d62; #1049 closeout comment https://github.com/MC-and-his-Agents/Loom/issues/1049#issuecomment-4551647487
 - Handoff Notes Locator: #1049 workspace_entry comment https://github.com/MC-and-his-Agents/Loom/issues/1049#issuecomment-4551384358
-- Evidence Freshness: current
+- Evidence Freshness: not_applicable

--- a/.loom/progress/WI-1050.md
+++ b/.loom/progress/WI-1050.md
@@ -1,0 +1,21 @@
+# WI-1050 Progress
+
+## Dynamic Facts
+
+- Item ID: WI-1050
+- Current Checkpoint: merge-ready
+- Current Stop: Scenario skills and generated skill surface updated locally; review records are bound to the implementation baseline commit.
+- Next Step: Run checkpoint merge and PR gate, open PR, wait for checks, merge, then close #1050.
+- Blockers: None recorded.
+- Latest Validation Summary: Passed locally on branch `work/1050-scenario-skills-full-minimal`: `git diff --check`; focused `rg` checks for full/minimal suite path, scenario/acceptance mapping, `not_applicable` rationale, consumer boundary, recheck condition, and fail-closed boundaries; `python3 tools/skills_surface.py check`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`; `python3 tools/check_release_surface.py`; `python3 tools/host_adapter_check.py`; `python3 tools/version_surface_check.py`; `python3 tools/check_npm_package.py`.
+- Recovery Boundary: #1050 owns scenario skills full/minimal path consumption boundaries. Do not redefine #1014-#1019 core contracts, do not implement CLI command surface, and leave #1051 responsible for broader source/generated drift-check ownership and #1036 consumption.
+- Current Lane: scenario-skills-full-minimal
+
+## Execution Ledger
+
+- Ledger Binding: recovery_entry
+- Plan Locator: .loom/specs/WI-1050/plan.md
+- Acceptance Locator: .loom/specs/WI-1050/spec.md
+- Validation Evidence Locator: local validation commands listed in Latest Validation Summary; `.loom/reviews/WI-1050.json`; PR pending.
+- Handoff Notes Locator: #1050 workspace_entry comment https://github.com/MC-and-his-Agents/Loom/issues/1050#issuecomment-4551658499
+- Evidence Freshness: current

--- a/.loom/reviews/WI-1050.json
+++ b/.loom/reviews/WI-1050.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-1050",
+  "decision": "allow",
+  "kind": "general_review",
+  "summary": "WI-1050 is approved for PR: scenario skills now consume full/minimal suite path boundaries, full path missing required inputs fail closed, minimal path requires not_applicable rationale with consumer boundary and recheck condition, and the checked-in generated skills surface is refreshed from source. The change consumes #1016/#1018/#1019/#1049 without redefining those contracts.",
+  "reviewer": "codex-main-agent",
+  "reviewed_head": "a945417147c5b6685969834c4432b8e2cdefab78",
+  "reviewed_validation_summary": "Passed locally on branch `work/1050-scenario-skills-full-minimal`: `git diff --check`; focused `rg` checks for full/minimal suite path, scenario/acceptance mapping, `not_applicable` rationale, consumer boundary, recheck condition, and fail-closed boundaries; `python3 tools/skills_surface.py check`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`; `python3 tools/check_release_surface.py`; `python3 tools/host_adapter_check.py`; `python3 tools/version_surface_check.py`; `python3 tools/check_npm_package.py`.",
+  "fallback_to": null,
+  "findings": [
+    {
+      "id": "downstream-1051",
+      "summary": "#1051 remains responsible for broader source/generated skills surface synchronization, drift checks, and #1036 deferred sync consumption.",
+      "severity": "warn",
+      "rebuttal": null,
+      "disposition": {
+        "status": "deferred",
+        "summary": "Outside WI-1050 scope and already tracked by active child issue #1051."
+      }
+    },
+    {
+      "id": "downstream-1052",
+      "summary": "#1052 remains responsible for CLI command surface planning.",
+      "severity": "warn",
+      "rebuttal": null,
+      "disposition": {
+        "status": "deferred",
+        "summary": "Explicitly outside #1020 active child sequence for this checkpoint."
+      }
+    }
+  ],
+  "blocking_issues": [],
+  "follow_ups": [
+    "#1051 source/generated skills surface synchronization, drift checks, and #1036 consumption.",
+    "#1052 CLI command surface planning remains out of scope."
+  ],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-1050.md",
+    "recovery_entry": ".loom/progress/WI-1050.md",
+    "status_surface": ".loom/status/current.md",
+    "spec_suite": "docs/methodology/templates/spec-suite.md / #1016",
+    "evidence_map": "docs/methodology/templates/evidence-map.md / #1018",
+    "consistency_analysis": "docs/methodology/templates/consistency-analysis.md / #1018",
+    "gate_chain": "docs/methodology/harness/gate-chain.md / #1019",
+    "github_profile": "docs/adoption/github-profile.md / #1049",
+    "skills_surface": "src/skills and generated skills/"
+  }
+}

--- a/.loom/reviews/WI-1050.spec.json
+++ b/.loom/reviews/WI-1050.spec.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-1050",
+  "decision": "allow",
+  "kind": "spec_review",
+  "summary": "WI-1050 spec suite is approved: scope is limited to scenario skills consuming full/minimal suite path boundaries, full path fail-closed behavior, minimal path not_applicable rationale consumption, and generated skill surface consistency. Core #1014-#1019 contracts, #1051 drift-check ownership, #1036 source/generated sync closeout, and #1052 CLI planning remain outside this Work Item.",
+  "reviewer": "codex-main-agent",
+  "reviewed_head": "e248bf57acda41a781854b70f2584e81ddcde627",
+  "reviewed_validation_summary": "Spec review consumed `.loom/specs/WI-1050/spec.md`, `.loom/specs/WI-1050/plan.md`, and `.loom/specs/WI-1050/implementation-contract.md`; implementation validation passed locally with `git diff --check`, focused `rg` checks, `python3 tools/skills_surface.py check`, `python3 tools/loom_check.py --profile source --source-surface contract-only .`, `python3 tools/check_release_surface.py`, `python3 tools/host_adapter_check.py`, `python3 tools/version_surface_check.py`, and `python3 tools/check_npm_package.py`.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "spec": ".loom/specs/WI-1050/spec.md",
+    "plan": ".loom/specs/WI-1050/plan.md",
+    "implementation_contract": ".loom/specs/WI-1050/implementation-contract.md",
+    "work_item": ".loom/work-items/WI-1050.md",
+    "recovery_entry": ".loom/progress/WI-1050.md",
+    "upstream_full_minimal_suite": "#1016",
+    "upstream_evidence_consistency": "#1018",
+    "upstream_gate_chain": "#1019",
+    "upstream_github_task_carrier_profile": "#1049 / PR #1103"
+  }
+}

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "acd5912314c44a87f938b5a4923d338a4b00c52bc1e4395b2782e3d5930bc7d4"
+    ".loom/status/current.md": "38fdcbddafdb822caee19594888bcc0154a7fbb4f64b4052745b4dcf84237763"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "acd5912314c44a87f938b5a4923d338a4b00c52bc1e4395b2782e3d5930bc7d4"
+    ".loom/status/current.md": "38fdcbddafdb822caee19594888bcc0154a7fbb4f64b4052745b4dcf84237763"
   }
 }

--- a/.loom/specs/WI-1050/implementation-contract.md
+++ b/.loom/specs/WI-1050/implementation-contract.md
@@ -1,0 +1,52 @@
+# WI-1050 Implementation Contract
+
+## Work Item
+
+- GitHub Phase: #1012
+- GitHub FR: #1020
+- GitHub Work Item: #1050
+- Upstream Work Items: #1016, #1018, #1019, #1049
+- Downstream Work Items: #1051
+
+## Owned Files
+
+- `src/skills/route-matrix.md`
+- `src/skills/loom-story/`
+- `src/skills/loom-spec-review/`
+- `src/skills/loom-build/`
+- `src/skills/loom-pre-review/`
+- `src/skills/loom-merge-ready/`
+- `src/skills/shared/references/templates/spec-suite.md`
+- `skills/`
+- `.loom/work-items/WI-1050.md`
+- `.loom/progress/WI-1050.md`
+- `.loom/status/current.md`
+- `.loom/specs/WI-1050/`
+- `.loom/reviews/WI-1050.spec.json`
+- `.loom/reviews/WI-1050.json`
+
+## Required Outputs
+
+- Scenario skill routing and consumption boundaries for full/minimal suite paths.
+- Full path fail-closed wording for missing required artifacts, locators, provenance, evidence freshness, or consistency inputs.
+- Minimal path `not_applicable` rationale, consumer boundary, and recheck condition consumption.
+- Source and generated skill surface consistency for the changed skill contracts.
+
+## Forbidden Outputs
+
+- No redefinition of #1014-#1019 core contracts.
+- No CLI command surface planning or implementation.
+- No #1051 drift-check implementation or #1036 closeout from this Work Item.
+- No closure of #1020 or #1012 from this Work Item alone.
+
+## Validation
+
+- `git diff --check`
+- `rg -n "minimal suite|full suite|suite path|scenario -> validation|acceptance -> test|not_applicable.*recheck condition|consumer boundary" docs/methodology/templates/spec-suite.md src/skills/shared/references/templates/spec-suite.md skills/shared/references/templates/spec-suite.md`
+- `rg -n "suite path|full path|minimal path|scenario.*validation|acceptance.*test|not_applicable rationale|consumer boundary|recheck condition|fail-closed" src/skills/route-matrix.md src/skills/loom-story src/skills/loom-spec-review src/skills/loom-build src/skills/loom-pre-review src/skills/loom-merge-ready`
+- `python3 tools/skills_surface.py check`
+- `python3 tools/loom_check.py --profile source --source-surface contract-only .`
+- `python3 tools/check_release_surface.py`
+- `python3 tools/host_adapter_check.py`
+- `python3 tools/version_surface_check.py`
+- `python3 tools/check_npm_package.py`

--- a/.loom/specs/WI-1050/plan.md
+++ b/.loom/specs/WI-1050/plan.md
@@ -1,0 +1,68 @@
+# WI-1050 Plan
+
+## Implementation Goal
+
+Deliver scenario skill full/minimal suite path consumption boundaries for #1050 without redefining core contracts or implementing CLI behavior.
+
+## Phases
+
+### Phase 1
+
+- Objective: Add a shared route matrix boundary for full/minimal suite path consumption.
+- Deliverable: `src/skills/route-matrix.md`.
+- Exit condition: route matrix maps `loom-story`, `loom-spec-review`, `loom-build`, `loom-pre-review`, and `loom-merge-ready` to their full/minimal path consumption responsibilities.
+
+### Phase 2
+
+- Objective: Update scenario skill input/output and completion contracts.
+- Deliverable: `src/skills/loom-story/`, `src/skills/loom-spec-review/`, `src/skills/loom-build/`, `src/skills/loom-pre-review/`, `src/skills/loom-merge-ready/`.
+- Exit condition: skills fail closed for full path missing inputs and only accept minimal path with valid `not_applicable` rationale, consumer boundary, and recheck condition.
+
+### Phase 3
+
+- Objective: Keep checked-in generated skill surface consistent.
+- Deliverable: `skills/` regenerated from `src/skills`.
+- Exit condition: `python3 tools/skills_surface.py check` passes.
+
+## Constraints
+
+- Architectural or governance constraints: scenario skills consume `spec-suite`, `evidence-map`, `consistency-analysis`, `gate-chain`, and GitHub task carrier profile contracts; they do not redefine those contracts.
+- Workspace / rollout constraints: branch `work/1050-scenario-skills-full-minimal`.
+- Purity or scope constraints: no #1052 CLI surface implementation; no #1051 drift-check ownership beyond generated surface consistency required by this PR.
+
+## Validation
+
+- Automated checks: `python3 tools/skills_surface.py check`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`; `python3 tools/check_release_surface.py`; `python3 tools/host_adapter_check.py`; `python3 tools/version_surface_check.py`; `python3 tools/check_npm_package.py`.
+- Manual checks: `git diff --check`; focused `rg` checks for full/minimal suite path, scenario/acceptance mapping, `not_applicable` rationale, consumer boundary, recheck condition, and fail-closed boundaries.
+- Runtime evidence: `.loom/progress/WI-1050.md`; `.loom/reviews/WI-1050.json`.
+- Behavior evidence: source and generated skill surfaces expose the required consumption boundaries.
+- Story scenario to evidence mapping: not_applicable.
+- Story business confirmation locator or `not_applicable` rationale: not_applicable; no product story semantics are changed.
+- Fresh verification evidence: local validation and PR checks before merge.
+- Execution ledger plan locator: `.loom/specs/WI-1050/plan.md`.
+- Execution ledger validation evidence locator: `.loom/progress/WI-1050.md`.
+
+## Test Strategy
+
+- TDD or test-first expectation: documentation/skill contract change; use contract checks, generated-surface check, and focused grep.
+- Regression coverage to add or preserve: preserve source contract checks, generated skills surface check, release surface check, host adapter check, version surface check, npm package check, and source `loom_check`.
+- Cases that are intentionally not automated: qualitative review that wording consumes rather than redefines #1014-#1019.
+- How failing tests or equivalent checks will be introduced before implementation: not_applicable; no executable behavior change.
+- How passing tests or equivalent checks will be captured as test evidence: validation commands, review records, and PR checks.
+- How User Story acceptance scenarios map to tests, checks, manual validation, or `not_applicable` evidence: not_applicable.
+
+## Dependencies
+
+- Blocking inputs: #1016 full/minimal suite, #1018 evidence-map and consistency-analysis, #1019 gate-chain consumption, #1049 GitHub task carrier profile.
+- Required coordination: #1051 consumes source/generated drift-check closeout and #1036 deferred sync; #1052 remains CLI planning.
+- Rollback boundary: revert this PR if scenario skills become the authority for core suite, evidence-map, consistency-analysis, gate-chain, or GitHub task carrier truth.
+
+## Ready For Implementation
+
+- [x] Spec is stable enough to implement
+- [x] Scope and non-goals are clear
+- [x] Story business semantics are confirmed or explicitly `not_applicable`
+- [x] Validation path is defined
+- [x] BDD outer-loop scenarios map to validation or `not_applicable`
+- [x] TDD inner-loop expectations map to test evidence
+- [x] Risks and dependencies are explicit

--- a/.loom/specs/WI-1050/spec.md
+++ b/.loom/specs/WI-1050/spec.md
@@ -1,0 +1,78 @@
+# WI-1050 Spec
+
+## Goal
+
+Update the scenario skills so the formal spec path consumers can distinguish full path and minimal path, fail closed when full path required artifacts are missing, and consume minimal path `not_applicable` rationale without redefining the core suite, evidence-map, consistency-analysis, or gate-chain contracts.
+
+## Scope
+
+- In scope:
+  - `loom-story` story readiness and business confirmation boundary for suite path consumers.
+  - `loom-spec-review` full/minimal suite path input and output consumption.
+  - `loom-build` build readiness consumption of suite path and scenario/acceptance mappings.
+  - `loom-pre-review` admission consumption of full path evidence and minimal path rationale.
+  - `loom-merge-ready` merge gate consumption of reviewed suite evidence and minimal path rationale.
+  - Route matrix and shared runtime reference text needed for scenario skills to consume the existing contracts.
+- Out of scope:
+  - Redefining #1014-#1019 core contracts.
+  - Implementing #1052 CLI command surface planning.
+  - Owning #1051 broader source/generated drift checks or #1036 source/generated sync closeout.
+
+## Key Scenarios
+
+### Scenario 1
+
+Given
+- a Work Item selects full formal spec path
+
+When
+- `loom-spec-review`, `loom-build`, `loom-pre-review`, or `loom-merge-ready` evaluates readiness
+
+Then
+- the skill consumes suite path locator, required artifact locators, provenance, evidence-map and consistency-analysis applicability, gate-chain status, and scenario/acceptance mapping freshness; missing required inputs fail closed with `block` or an explicit fallback.
+
+### Scenario 2
+
+Given
+- a Work Item selects minimal formal spec path
+
+When
+- a scenario skill sees absent full path artifacts
+
+Then
+- the skill only treats the absence as valid when `not_applicable` includes rationale, consumer boundary, and recheck condition; unreasoned missing inputs, `deferred`, and source/generated sync backlog are not considered ready.
+
+### Scenario 3
+
+Given
+- a pure governance or documentation Work Item has no product story semantics
+
+When
+- `loom-story` produces inputs for later `spec.md` and `plan.md`
+
+Then
+- it can provide `not_applicable` story readiness and business confirmation rationale, but it does not choose suite path or create evidence-map, consistency-analysis, review, merge-ready, or closeout truth.
+
+## Behavior Evidence
+
+- Story scenario mapping: not_applicable; this Work Item changes executable skill consumption boundaries, not product story semantics.
+- Story business confirmation locator or `not_applicable` rationale: not_applicable; pure governance skill-surface update.
+- Scenario coverage: source and generated skill surfaces mention full path, minimal path, fail-closed behavior, `not_applicable` rationale, consumer boundary, recheck condition, and scenario/acceptance mapping consumption.
+- Expected evidence locator: PR for #1050 and #1050 completion comment.
+- Freshness rule: stale if source skill text, generated skill surface, or validation evidence no longer matches the PR head.
+- Execution ledger acceptance locator: `.loom/specs/WI-1050/spec.md`.
+
+## Exceptions And Boundaries
+
+- Failure modes: a skill treats missing full path artifacts as ready, accepts `deferred` as `not_applicable`, or redefines suite/evidence/gate semantics instead of consuming existing contracts.
+- Operational boundaries: generated `skills/` is refreshed from `src/skills` only to keep `tools/skills_surface.py check` green; #1051 remains responsible for broader source/generated sync closeout and #1036 consumption.
+- Rollback or fallback expectations: revert this PR if scenario skills become authoritative over full/minimal suite, evidence-map, consistency-analysis, or gate-chain truth.
+
+## Acceptance Criteria
+
+- [x] Route matrix declares full/minimal suite path consumption rules for the five scenario skills.
+- [x] `loom-story` states it produces story readiness/business confirmation inputs but does not choose suite path.
+- [x] `loom-spec-review`, `loom-build`, `loom-pre-review`, and `loom-merge-ready` fail closed for missing full path required inputs.
+- [x] Minimal path consumption requires `not_applicable` rationale, consumer boundary, and recheck condition.
+- [x] Skills do not redefine #1014-#1019 core contracts or implement CLI surface.
+- [x] Source and checked-in generated skill surfaces are consistent.

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -2,34 +2,34 @@
 
 ## Derived Fact Chain View
 
-- Item ID: WI-1049
-- Goal: Define the GitHub task carrier profile mapping for issue, sub-issue, Project item, checklist, repo-local `tasks.md`, external tracker, and `not_applicable` carriers.
-- Scope: #1049 GitHub task carrier profile mapping only; update the GitHub profile contract and repo-local carriers. Do not update scenario skills routing (#1050), source/generated skills surface (#1051), drift checks, CLI command surface (#1052), or core #1014-#1019 contracts.
-- Execution Path: issue #1049 -> branch work/1049-github-task-carrier-profile -> worktree /Users/mc/dev/Loom-worktrees/1049-github-task-carrier-profile
+- Item ID: WI-1050
+- Goal: Update scenario skills so `loom-story`, `loom-spec-review`, `loom-build`, `loom-pre-review`, and `loom-merge-ready` consume full/minimal suite path boundaries.
+- Scope: #1050 scenario skills full/minimal path consumption only. Do not redefine #1014-#1019 core contracts, do not implement CLI command surface (#1052), and do not perform #1051 drift-check ownership beyond regenerating `skills/` from `src/skills` to keep the checked-in skill surface consistent.
+- Execution Path: issue #1050 -> branch work/1050-scenario-skills-full-minimal -> worktree /Users/mc/dev/Loom-worktrees/1050-scenario-skills-full-minimal
 - Workspace Entry: .
-- Recovery Entry: .loom/progress/WI-1049.md
-- Review Entry: .loom/reviews/WI-1049.json
-- Validation Entry: git diff --check; focused rg checks for GitHub profile / task carrier / sub-issue / Project item / checklist / unique execution entry; focused rg checks for forbidden use / review / merge-ready / closeout / provenance / locator; focused rg checks for Project Status / Todo / In Progress / Done / completed truth / host agent; python3 tools/skills_surface.py check; python3 tools/loom_check.py --profile source --source-surface contract-only .
-- Closing Condition: #1049 defines GitHub task carrier profile mapping and closes after PR merge, closeout evidence comment, issue closed, and Project status reconciled.
+- Recovery Entry: .loom/progress/WI-1050.md
+- Review Entry: .loom/reviews/WI-1050.json
+- Validation Entry: git diff --check; focused rg checks for full/minimal suite path, scenario/acceptance mapping, not_applicable rationale, consumer boundary, recheck condition, and fail-closed boundaries; python3 tools/skills_surface.py check; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 tools/check_release_surface.py; python3 tools/host_adapter_check.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py.
+- Closing Condition: #1050 scenario skills consume full/minimal suite path boundaries, PR is merged, closeout evidence comment is written, issue is closed, and Project status is reconciled.
 - Current Checkpoint: merge-ready
-- Current Stop: PR #1103 opened for WI-1049 with local validation passed; remote PR gate requires Work Item binding update.
-- Next Step: Push Work Item / status / review carriers, update PR body with `Loom Work Item: WI-1049`, wait for remote checks, merge, then close #1049.
+- Current Stop: Scenario skills and generated skill surface updated locally; review records are bound to the implementation baseline commit.
+- Next Step: Run checkpoint merge and PR gate, open PR, wait for checks, merge, then close #1050.
 - Blockers: None recorded.
-- Latest Validation Summary: Passed locally on branch `work/1049-github-task-carrier-profile`: `git diff --check`; focused `rg` for GitHub profile / task carrier / sub-issue / Project item / checklist / unique execution entry; focused `rg` for forbidden use / review / merge-ready / closeout / provenance / locator; focused `rg` for Project Status / Todo / In Progress / Done / completed truth / host agent; `python3 tools/skills_surface.py check`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`.
-- Recovery Boundary: #1049 owns GitHub task carrier profile mapping only. Do not update scenario skill routing, source/generated skills surface, drift checks, CLI command surface, or core #1014-#1019 contracts in this Work Item.
-- Current Lane: github-task-carrier-profile
+- Latest Validation Summary: Passed locally on branch `work/1050-scenario-skills-full-minimal`: `git diff --check`; focused `rg` checks for full/minimal suite path, scenario/acceptance mapping, `not_applicable` rationale, consumer boundary, recheck condition, and fail-closed boundaries; `python3 tools/skills_surface.py check`; `python3 tools/loom_check.py --profile source --source-surface contract-only .`; `python3 tools/check_release_surface.py`; `python3 tools/host_adapter_check.py`; `python3 tools/version_surface_check.py`; `python3 tools/check_npm_package.py`.
+- Recovery Boundary: #1050 owns scenario skills full/minimal path consumption boundaries. Do not redefine #1014-#1019 core contracts, do not implement CLI command surface, and leave #1051 responsible for broader source/generated drift-check ownership and #1036 consumption.
+- Current Lane: scenario-skills-full-minimal
 
 ## Runtime Evidence
 
 - Run Entry: not_applicable
 - Logs Entry: not_applicable
 - Diagnostics Entry: not_applicable
-- Verification Entry: git diff --check; focused rg checks for GitHub profile / task carrier / sub-issue / Project item / checklist / unique execution entry; focused rg checks for forbidden use / review / merge-ready / closeout / provenance / locator; focused rg checks for Project Status / Todo / In Progress / Done / completed truth / host agent; python3 tools/skills_surface.py check; python3 tools/loom_check.py --profile source --source-surface contract-only .
+- Verification Entry: git diff --check; focused rg checks for full/minimal suite path, scenario/acceptance mapping, not_applicable rationale, consumer boundary, recheck condition, and fail-closed boundaries; python3 tools/skills_surface.py check; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 tools/check_release_surface.py; python3 tools/host_adapter_check.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py.
 - Lane Entry: not_applicable
 
 ## Sources
 
-- Static Truth: .loom/work-items/WI-1049.md
-- Dynamic Truth: .loom/progress/WI-1049.md
+- Static Truth: .loom/work-items/WI-1050.md
+- Dynamic Truth: .loom/progress/WI-1050.md
 - Locator Truth: .loom/bootstrap/init-result.json
 - Fact Chain CLI: python3 .loom/bin/loom_init.py fact-chain --target .

--- a/.loom/work-items/WI-1050.md
+++ b/.loom/work-items/WI-1050.md
@@ -1,0 +1,33 @@
+# WI-1050
+
+## Static Facts
+
+- Item ID: WI-1050
+- Goal: Update scenario skills so `loom-story`, `loom-spec-review`, `loom-build`, `loom-pre-review`, and `loom-merge-ready` consume full/minimal suite path boundaries.
+- Scope: #1050 scenario skills full/minimal path consumption only. Do not redefine #1014-#1019 core contracts, do not implement CLI command surface (#1052), and do not perform #1051 drift-check ownership beyond regenerating `skills/` from `src/skills` to keep the checked-in skill surface consistent.
+- Execution Path: issue #1050 -> branch work/1050-scenario-skills-full-minimal -> worktree /Users/mc/dev/Loom-worktrees/1050-scenario-skills-full-minimal
+- Workspace Entry: .
+- Recovery Entry: .loom/progress/WI-1050.md
+- Review Entry: .loom/reviews/WI-1050.json
+- Validation Entry: git diff --check; focused rg checks for full/minimal suite path, scenario/acceptance mapping, not_applicable rationale, consumer boundary, recheck condition, and fail-closed boundaries; python3 tools/skills_surface.py check; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 tools/check_release_surface.py; python3 tools/host_adapter_check.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py.
+- Closing Condition: #1050 scenario skills consume full/minimal suite path boundaries, PR is merged, closeout evidence comment is written, issue is closed, and Project status is reconciled.
+
+## Associated Artifacts
+
+- `src/skills/route-matrix.md`
+- `src/skills/loom-story/`
+- `src/skills/loom-spec-review/`
+- `src/skills/loom-build/`
+- `src/skills/loom-pre-review/`
+- `src/skills/loom-merge-ready/`
+- `src/skills/shared/references/templates/spec-suite.md`
+- `skills/`
+- `.loom/work-items/WI-1050.md`
+- `.loom/progress/WI-1050.md`
+- `.loom/progress/WI-1049.md`
+- `.loom/status/current.md`
+- `.loom/specs/WI-1050/spec.md`
+- `.loom/specs/WI-1050/plan.md`
+- `.loom/specs/WI-1050/implementation-contract.md`
+- `.loom/reviews/WI-1050.spec.json`
+- `.loom/reviews/WI-1050.json`

--- a/skills/loom-adopt/.loom-runtime/loom-build/SKILL.md
+++ b/skills/loom-adopt/.loom-runtime/loom-build/SKILL.md
@@ -55,10 +55,21 @@ subagent-driven mode 必须先声明以下字段：
 - 多个委派声明重叠 `write_ownership`
 - 多轮或多个委派报告同一 blocker signature
 - 缺少 Work Item、spec、plan、recovery、validation baseline、workspace 或 ownership constraints
+- 选择 full path 但 suite-index、必需 suite 工件、scenario-to-validation mapping、
+  task carrier profile locator、provenance 或当前 build gate 所需 evidence 缺失
+- 选择 minimal path 但 full path 附加工件缺口没有 `not_applicable` rationale、
+  consumer boundary、recheck condition 或替代验证入口
+- 把 `deferred`、source/generated sync 待办或 CLI surface 待办当作 build readiness
+  的 completed truth
 
 ## 5. 完成标准
 
 只有当 `flow build` 返回 pass，且 build evidence 证明所有委派输出已集成、无 ownership overlap、无 repeated blocker 时，才允许继续进入 pre-review / review。
+
+Build readiness 只消费 full/minimal suite path 决策，不重新定义 suite 工件、
+evidence-map、consistency-analysis 或 gate-chain。full path 必须证明必需工件可读且
+fresh；minimal path 必须保留合法 `not_applicable` rationale，并把 recheck condition
+传递给后续 pre-review / review。
 
 输入信号与输出合同见：
 

--- a/skills/loom-adopt/.loom-runtime/loom-build/references/input-signals.md
+++ b/skills/loom-adopt/.loom-runtime/loom-build/references/input-signals.md
@@ -14,4 +14,6 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - Work Item、spec、plan、recovery baseline、validation baseline、workspace 和 ownership constraints
+- suite path decision：full path 的 suite / evidence locators，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition 与替代验证入口
 - 若使用 subagent-driven mode，必须提供 delegation/build evidence locator

--- a/skills/loom-adopt/.loom-runtime/loom-build/references/output-contract.md
+++ b/skills/loom-adopt/.loom-runtime/loom-build/references/output-contract.md
@@ -26,6 +26,12 @@
   - `integration_evidence`
   - `ownership_conflicts`
   - `repeated_blocker_signal`
+- `suite_path_consumption`
+  - full path 的必需工件、scenario-to-validation mapping、task carrier locator 与
+    provenance 是否可读
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+    与替代验证入口
+  - 缺失、stale、conflict 或无理由跳过时必须阻断 build readiness
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> build-execution` 顺序列出
 

--- a/skills/loom-adopt/.loom-runtime/loom-merge-ready/SKILL.md
+++ b/skills/loom-adopt/.loom-runtime/loom-merge-ready/SKILL.md
@@ -17,6 +17,14 @@ description: 负责 merge 前统一放行。Use when Codex needs to confirm whet
 - 只输出进入 `GitHub controlled merge` 前的统一放行摘要，不替代宿主平台 merge 动作
 - PR 合并前的宿主硬门禁由 `pr-gate check` 和 `controlled-merge check|merge` 承接；它们只能消费 authored Loom review record，不能把 raw review/shadow evidence 当作 approval
 - 不新建 authored 真相源，也不直接执行平台合并
+- 消费 full/minimal suite path、evidence-map freshness、consistency-analysis
+  classification 与 gate-chain 当前状态，但不重新定义这些合同
+- full path 下，review record 必须证明已消费 suite locators、evidence-map、
+  consistency-analysis、PR head / reviewed head / validation freshness；缺失、stale 或
+  conflict 必须 fail-closed
+- minimal path 下，只有带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable` 可以跳过 full path 附加工件；missing、deferred 或 source/generated
+  sync 待办不能被当作 merge-ready
 
 输入信号与输出合同见：
 

--- a/skills/loom-adopt/.loom-runtime/loom-merge-ready/references/input-signals.md
+++ b/skills/loom-adopt/.loom-runtime/loom-merge-ready/references/input-signals.md
@@ -6,3 +6,11 @@
 - 最终放行前预检
 - 确认当前事项是否可合并
 - 确认 `GitHub controlled merge` 前置是否齐全
+
+最小输入：
+
+- 目标仓库
+- 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 reviewed suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+- PR locator、head SHA、reviewed head 与 validation freshness 证据

--- a/skills/loom-adopt/.loom-runtime/loom-merge-ready/references/output-contract.md
+++ b/skills/loom-adopt/.loom-runtime/loom-merge-ready/references/output-contract.md
@@ -28,6 +28,11 @@
   - `loom-governance-lint-status/v1` 派生证据；只消费 fact-chain 与 repo companion 的 blocking/advisory lint result，不替代 authored review record、merge checkpoint 或 host merge truth
 - `gate_chain`
   - `spec_gate`、`build_gate`、`review_gate`、`merge_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - full path 的 suite readiness、evidence-map、consistency-analysis、reviewed
+    locators、PR head / reviewed head / validation freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - missing、stale、conflict、deferred 或无理由跳过必须进入 `missing_inputs`
 - `github_controlled_merge`
   - required checks、branch protection、merge method 与 host merge 前置状态
 - `retained_host_signals`

--- a/skills/loom-adopt/.loom-runtime/loom-pre-review/SKILL.md
+++ b/skills/loom-adopt/.loom-runtime/loom-pre-review/SKILL.md
@@ -43,6 +43,7 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 不替代 reviewer 的语义判断
 - 不直接执行 merge
 - 不回写事实链、恢复入口或状态面
+- 不重新定义 full/minimal suite、evidence-map、consistency-analysis 或 gate-chain
 
 ## 4. 输出要求
 
@@ -53,6 +54,10 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 哪一步阻断了继续进入 review
 - 若阻断，应回退到哪里
 - 当前 steps 的机械结果是什么
+- full path 的 suite locator、evidence-map freshness 与 consistency-analysis
+  blocking/advisory 分类是否已经可供 review 消费
+- minimal path 的 `not_applicable` rationale、consumer boundary 与 recheck condition
+  是否足够；不足时必须 fail-closed，不能进入 review
 
 ## 5. 完成标准
 
@@ -62,6 +67,9 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - `flow pre-review` 的步骤顺序稳定为 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate`
 - 输出 JSON 能直接支撑“是否进入 review 前语义审查”的判断
 - skill 自身不复制治理真相，也不冒充 reviewer 结论
+- full path 缺少必需 suite artifact、provenance、fresh evidence 或存在 blocking
+  consistency gap 时返回 `block` / `fallback`
+- minimal path 只有在缺口具备有效 `not_applicable` rationale 时才允许进入 review
 
 输入信号与输出合同见：
 

--- a/skills/loom-adopt/.loom-runtime/loom-pre-review/references/input-signals.md
+++ b/skills/loom-adopt/.loom-runtime/loom-pre-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前 review 意图
 - 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-adopt/.loom-runtime/loom-pre-review/references/output-contract.md
+++ b/skills/loom-adopt/.loom-runtime/loom-pre-review/references/output-contract.md
@@ -16,6 +16,11 @@
   - 当前 Loom 入口自己的 scene / carrier 判定，以及 fail-closed 原因
 - `governance_lint`
   - `loom-governance-lint-status/v1` 派生证据；blocking lint 进入 `missing_inputs`，advisory lint 只进入风险摘要，不产生 reviewer 结论
+- `suite_path_consumption`
+  - full path 的 required artifacts、evidence-map freshness、consistency-analysis
+    blocking/advisory 分类
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - full path 缺必需输入或 minimal path 无有效 rationale 时必须 fail-closed
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> governance-lint` 顺序列出
 

--- a/skills/loom-adopt/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-adopt/.loom-runtime/loom-spec-review/SKILL.md
@@ -39,6 +39,12 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - formal spec 路径不存在时，`flow spec-review` 必须 fail-closed
 - spec review 只写回单一 spec review record，不替代 implementation review record
 - `reviewed_head` 与 stale 语义必须显式暴露，供后续 gate 消费
+- full path 必须消费 suite path locator、必需工件 locator、provenance，以及
+  evidence-map / consistency-analysis / gate-chain 适用性结论；缺失或不可读时
+  fail-closed，回退到 spec shaping 或 suite path 修正
+- minimal path 只能消费带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable`；无理由缺口、`deferred` 或 source/generated sync 待办不得被当作
+  spec gate 通过
 
 ## 3. 固定编排
 
@@ -57,6 +63,9 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
 - 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不重新定义 full suite、minimal suite、evidence-map、consistency-analysis 或
+  gate-chain 语义；只消费这些合同已经定义的 locator、freshness、classification
+  与 fallback 边界
 
 ## 4. 输出要求
 
@@ -66,6 +75,8 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - spec review 的机械基线结果
 - spec review record 的定位与当前结论
 - reviewed head 绑定、当前 head、是否 stale
+- suite path decision，以及 full path readiness 或 minimal path `not_applicable`
+  rationale 是否可被 spec gate 消费
 - 审查结论（`allow` / `block` / `fallback`）
 - 若当前不能继续，应回退到哪里
 

--- a/skills/loom-adopt/.loom-runtime/loom-spec-review/references/input-signals.md
+++ b/skills/loom-adopt/.loom-runtime/loom-spec-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - formal spec 路径或明确的 spec review 意图
+- suite path decision：full path 的必需工件 locator，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-adopt/.loom-runtime/loom-spec-review/references/output-contract.md
+++ b/skills/loom-adopt/.loom-runtime/loom-spec-review/references/output-contract.md
@@ -22,6 +22,11 @@
   - `checkpoint build` 的结果、摘要、阻断项与回退去向
 - `gate_chain`
   - `spec_gate`、`build_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - `path: full|minimal`
+  - full path 的 suite locator、required artifact locators、provenance 与 freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - 无理由 missing、stale、conflict 或 deferred 输入必须进入 `missing_inputs`
 - `spec_review`
   - formal spec 路径、spec review record、head 绑定、stale 语义与当前 gate 结论
 - `spec_review_authority_migration`

--- a/skills/loom-adopt/.loom-runtime/loom-story/SKILL.md
+++ b/skills/loom-adopt/.loom-runtime/loom-story/SKILL.md
@@ -85,6 +85,21 @@ User Story 主体不得包含 delivery handoff、spec locator、plan locator、r
 - `Work Item` 仍是唯一执行入口
 - issue tree、Phase / FR / Work Item / PR 切分、blocked-by/blocks 与 host carrier mapping 由 `loom-init` 的 delivery planning 路由承接
 
+## 6. Full / Minimal Suite Path 边界
+
+`loom-story` 不选择或重定义 full/minimal suite path；它只产出可被
+`spec-suite` 消费的 story readiness 与 business confirmation 输入。
+
+- full path：若 formal spec path 消费 story，必须输出 Story Readiness 与 Story
+  Business Confirmation locator，且 decision 为 `confirmed` 或明确
+  `not_applicable`。`pending` / `revision-requested` 必须 fail closed，回到 story
+  shaping 或等待业务语义确认。
+- minimal path：纯治理、维护、格式、链接修复或载体整理可以输出
+  `not_applicable`，但必须包含 bypass rationale、consumer boundary 和 recheck
+  condition，供 `spec.md`、`plan.md`、evidence-map 与后续 gate 消费。
+- `loom-story` 不把 `not_applicable` 升级成产品确认，不生成 evidence-map、
+  consistency-analysis、review、merge-ready 或 GitHub closeout truth。
+
 输入信号与输出合同见：
 
 - [references/input-signals.md](./references/input-signals.md)

--- a/skills/loom-adopt/.loom-runtime/loom-story/references/output-contract.md
+++ b/skills/loom-adopt/.loom-runtime/loom-story/references/output-contract.md
@@ -28,6 +28,8 @@
   - story scenario 到 `plan.md` validation strategy 的映射
   - spec / plan 只消费已 `confirmed` 或明确 `not_applicable` 的 story 语义
   - 任何 `pending` 或 `revision-requested` 的 readiness / confirmation 都必须 fail closed，阻止 formal spec shaping
+  - full path 需要可消费的 readiness / confirmation locator；minimal path 需要
+    `not_applicable` rationale、consumer boundary 和 recheck condition
   - `Work Item` 仍是唯一执行入口
 - `missing_inputs`
   - 当前阻断 story shaping 的缺口；无阻断时为空数组

--- a/skills/loom-adopt/.loom-runtime/route-matrix.md
+++ b/skills/loom-adopt/.loom-runtime/route-matrix.md
@@ -45,7 +45,42 @@
 - `GitHub controlled merge`
   - merge 由宿主控制面执行；Loom 只消费 required checks、review、head 绑定与 merge gate 结果
 
-## 4. `governance_surface` 公共合同
+## 4. Formal Spec Suite Path 消费边界
+
+`loom-story`、`loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+必须消费 `docs/methodology/templates/spec-suite.md` 已定义的
+`full suite` / `minimal suite` path decision，不得在 skill 中重新定义 suite
+工件、evidence-map、consistency-analysis 或 gate-chain 语义。
+
+固定消费规则：
+
+- `full path` 表示当前事项选择完整 formal spec suite。后续 skill 必须能读取
+  suite path locator、必需工件 locator、条件工件的适用性判断、provenance，以及
+  #1018/#1019 合同声明适用时的 evidence-map、consistency-analysis 与 gate-chain
+  消费结论。
+- `full path` 缺少必需工件、locator、provenance 或当前 gate 所需 evidence 时，
+  `loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+  必须 fail-closed，返回 `block` 或带明确 `fallback_to` 的 `fallback`。
+- `minimal path` 是合法路径，但只能通过带 rationale、consumer boundary 和
+  recheck condition 的 `not_applicable` 消费 full path 附加工件；无理由缺口仍是
+  `missing`，不得被当成 `not_applicable`。
+- `deferred` 不等于 `not_applicable`。deferred source/generated sync、CLI surface
+  或后续 FR 工作只能作为后续事项输入，不得被当前 skill 当成 completed truth。
+- GitHub issue、sub-issue、Project item、PR、checklist 或 repo-local carrier 只按
+  GitHub task carrier profile 读取 locator、state、provenance 和冲突状态；不得替代
+  Work Item、spec suite、review record 或 merge-ready truth。
+
+场景到消费边界：
+
+| Skill | full path 消费 | minimal path 消费 |
+| --- | --- | --- |
+| `loom-story` | 输出 Story Readiness / Business Confirmation locator，供 `spec.md` / `plan.md` 和 suite path decision 消费 | 对纯治理、维护、格式、链接类事项输出 `not_applicable` rationale、consumer boundary、recheck condition |
+| `loom-spec-review` | 消费 suite path、formal spec、plan、必需工件、evidence-map / consistency-analysis 适用性；缺必需输入时 fail-closed | 只接受有效 `not_applicable` rationale；否则回退到 spec shaping / suite path 修正 |
+| `loom-build` | 在 build readiness 前消费 full suite readiness、scenario-to-validation mapping、task carrier profile locator | 合法跳过附加工件，但必须保留 rationale 和替代验证入口 |
+| `loom-pre-review` | 在 review 前消费 full suite locator、evidence-map freshness、consistency-analysis blocking/advisory 分类 | 缺口必须是有效 `not_applicable`，否则阻断 review admission |
+| `loom-merge-ready` | 在 merge gate 消费 reviewed full suite evidence、gate-chain、PR head / reviewed head / validation freshness | 只把有效 minimal path rationale 当作合法跳过，不把 missing 或 deferred 当作 ready |
+
+## 5. `governance_surface` 公共合同
 
 以下三类入口对外暴露的公共治理读面固定命名为 `governance_surface`：
 
@@ -73,7 +108,7 @@
 - 只回答 locator 与职责边界，不复制实时停点、下一步、阻断项、验证摘要
 - 若需要回答 gate 进度，统一通过 `review_merge_surface` 或 `status control plane` 读取，不在 `governance_surface` 并行维护 authored gate 状态
 
-## 5. Planning 边界
+## 6. Planning 边界
 
 `delivery planning` 是 `loom-init` 的路由结果，不是 build、review 或 merge-ready 的前置硬门禁。
 
@@ -102,7 +137,7 @@ planning 输出只能包含：
 
 planning 输出不能声明某个 Work Item 已完成，不能替代 `spec.md` / `plan.md`，不能替代 review、merge-ready、closeout，也不能直接改写 GitHub，除非用户明确要求执行创建或更新动作。
 
-## 6. fallback 语义
+## 7. fallback 语义
 
 出现以下任一情况时，root skill 不做猜测，直接回退到 `loom-init`：
 

--- a/skills/loom-adopt/.loom-runtime/shared/references/templates/spec-suite.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/templates/spec-suite.md
@@ -18,6 +18,21 @@ Loom 当前把正式规约套件的最小内核定义为：
 
 这两个工件分别承担不同职责，不得混写。
 
+Formal spec path 有两条合法 suite path：
+
+- `minimal suite`
+  - 必含 `spec.md` 与 `plan.md`
+  - 适用于低风险、局部、纯治理或文档类事项
+  - 可用 `not_applicable` rationale 合法跳过 full path 附加工件
+- `full suite`
+  - 在 minimal suite 之上消费 suite-index、条件附加工件、evidence-map、
+    consistency-analysis 与 gate-chain consumption
+  - 适用于 formal spec、高风险、跨模块、强 review 或需要完整证据链的事项
+
+路径选择必须有 locator 与 provenance。若从 full path 降到 minimal path，必须说明
+附加工件为什么 `not_applicable`；若从 minimal path 升到 full path，必须说明触发信号
+和需要补齐的工件。
+
 ## 2. `spec.md` 最小要求
 
 `spec.md` 至少应表达：
@@ -58,6 +73,17 @@ Loom 当前把正式规约套件的最小内核定义为：
 - 不能自动化的行为必须声明人工验证路径、证据 locator 与 fresh 条件
 - 纯文档或治理规则变更可以不强制 TDD，但必须说明行为证据如何由结构检查、审查记录或示例消费
 
+映射状态必须可被后续 gate 消费：
+
+- `scenario_id` / scenario locator 映射到 automated、manual、structural 或
+  `not_applicable` validation strategy
+- `acceptance_id` / acceptance locator 映射到 test evidence、structural check、
+  manual evidence 或 `not_applicable`
+- full path 下，缺少 scenario -> validation 或 acceptance -> test mapping 默认阻断
+  build / review
+- minimal path 下，缺映射必须以 `not_applicable` rationale、替代验证入口和
+  recheck condition 解释
+
 ## 4. 套件边界规则
 
 Loom 必须区分：
@@ -74,6 +100,11 @@ Loom 当前不固化：
 
 - 所有项目都必须有同一组附加工件
 - `TODO.md` 或同类文件是永恒必选项
+
+Full path 缺少必需工件、locator、provenance 或 gate 所需 evidence 时必须
+fail-closed。Minimal path 缺少 full path 附加工件时，只有同时具备 rationale、
+consumer boundary 与 recheck condition 的 `not_applicable` 才能消解；无理由缺口
+仍是 `missing`。`deferred` 不等于 `not_applicable`，不得作为 completed truth 消费。
 
 ## 5. 行为证据与测试证据
 

--- a/skills/loom-build/.loom-runtime/loom-build/SKILL.md
+++ b/skills/loom-build/.loom-runtime/loom-build/SKILL.md
@@ -55,10 +55,21 @@ subagent-driven mode 必须先声明以下字段：
 - 多个委派声明重叠 `write_ownership`
 - 多轮或多个委派报告同一 blocker signature
 - 缺少 Work Item、spec、plan、recovery、validation baseline、workspace 或 ownership constraints
+- 选择 full path 但 suite-index、必需 suite 工件、scenario-to-validation mapping、
+  task carrier profile locator、provenance 或当前 build gate 所需 evidence 缺失
+- 选择 minimal path 但 full path 附加工件缺口没有 `not_applicable` rationale、
+  consumer boundary、recheck condition 或替代验证入口
+- 把 `deferred`、source/generated sync 待办或 CLI surface 待办当作 build readiness
+  的 completed truth
 
 ## 5. 完成标准
 
 只有当 `flow build` 返回 pass，且 build evidence 证明所有委派输出已集成、无 ownership overlap、无 repeated blocker 时，才允许继续进入 pre-review / review。
+
+Build readiness 只消费 full/minimal suite path 决策，不重新定义 suite 工件、
+evidence-map、consistency-analysis 或 gate-chain。full path 必须证明必需工件可读且
+fresh；minimal path 必须保留合法 `not_applicable` rationale，并把 recheck condition
+传递给后续 pre-review / review。
 
 输入信号与输出合同见：
 

--- a/skills/loom-build/.loom-runtime/loom-build/references/input-signals.md
+++ b/skills/loom-build/.loom-runtime/loom-build/references/input-signals.md
@@ -14,4 +14,6 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - Work Item、spec、plan、recovery baseline、validation baseline、workspace 和 ownership constraints
+- suite path decision：full path 的 suite / evidence locators，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition 与替代验证入口
 - 若使用 subagent-driven mode，必须提供 delegation/build evidence locator

--- a/skills/loom-build/.loom-runtime/loom-build/references/output-contract.md
+++ b/skills/loom-build/.loom-runtime/loom-build/references/output-contract.md
@@ -26,6 +26,12 @@
   - `integration_evidence`
   - `ownership_conflicts`
   - `repeated_blocker_signal`
+- `suite_path_consumption`
+  - full path 的必需工件、scenario-to-validation mapping、task carrier locator 与
+    provenance 是否可读
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+    与替代验证入口
+  - 缺失、stale、conflict 或无理由跳过时必须阻断 build readiness
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> build-execution` 顺序列出
 

--- a/skills/loom-build/.loom-runtime/loom-merge-ready/SKILL.md
+++ b/skills/loom-build/.loom-runtime/loom-merge-ready/SKILL.md
@@ -17,6 +17,14 @@ description: 负责 merge 前统一放行。Use when Codex needs to confirm whet
 - 只输出进入 `GitHub controlled merge` 前的统一放行摘要，不替代宿主平台 merge 动作
 - PR 合并前的宿主硬门禁由 `pr-gate check` 和 `controlled-merge check|merge` 承接；它们只能消费 authored Loom review record，不能把 raw review/shadow evidence 当作 approval
 - 不新建 authored 真相源，也不直接执行平台合并
+- 消费 full/minimal suite path、evidence-map freshness、consistency-analysis
+  classification 与 gate-chain 当前状态，但不重新定义这些合同
+- full path 下，review record 必须证明已消费 suite locators、evidence-map、
+  consistency-analysis、PR head / reviewed head / validation freshness；缺失、stale 或
+  conflict 必须 fail-closed
+- minimal path 下，只有带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable` 可以跳过 full path 附加工件；missing、deferred 或 source/generated
+  sync 待办不能被当作 merge-ready
 
 输入信号与输出合同见：
 

--- a/skills/loom-build/.loom-runtime/loom-merge-ready/references/input-signals.md
+++ b/skills/loom-build/.loom-runtime/loom-merge-ready/references/input-signals.md
@@ -6,3 +6,11 @@
 - 最终放行前预检
 - 确认当前事项是否可合并
 - 确认 `GitHub controlled merge` 前置是否齐全
+
+最小输入：
+
+- 目标仓库
+- 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 reviewed suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+- PR locator、head SHA、reviewed head 与 validation freshness 证据

--- a/skills/loom-build/.loom-runtime/loom-merge-ready/references/output-contract.md
+++ b/skills/loom-build/.loom-runtime/loom-merge-ready/references/output-contract.md
@@ -28,6 +28,11 @@
   - `loom-governance-lint-status/v1` 派生证据；只消费 fact-chain 与 repo companion 的 blocking/advisory lint result，不替代 authored review record、merge checkpoint 或 host merge truth
 - `gate_chain`
   - `spec_gate`、`build_gate`、`review_gate`、`merge_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - full path 的 suite readiness、evidence-map、consistency-analysis、reviewed
+    locators、PR head / reviewed head / validation freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - missing、stale、conflict、deferred 或无理由跳过必须进入 `missing_inputs`
 - `github_controlled_merge`
   - required checks、branch protection、merge method 与 host merge 前置状态
 - `retained_host_signals`

--- a/skills/loom-build/.loom-runtime/loom-pre-review/SKILL.md
+++ b/skills/loom-build/.loom-runtime/loom-pre-review/SKILL.md
@@ -43,6 +43,7 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 不替代 reviewer 的语义判断
 - 不直接执行 merge
 - 不回写事实链、恢复入口或状态面
+- 不重新定义 full/minimal suite、evidence-map、consistency-analysis 或 gate-chain
 
 ## 4. 输出要求
 
@@ -53,6 +54,10 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 哪一步阻断了继续进入 review
 - 若阻断，应回退到哪里
 - 当前 steps 的机械结果是什么
+- full path 的 suite locator、evidence-map freshness 与 consistency-analysis
+  blocking/advisory 分类是否已经可供 review 消费
+- minimal path 的 `not_applicable` rationale、consumer boundary 与 recheck condition
+  是否足够；不足时必须 fail-closed，不能进入 review
 
 ## 5. 完成标准
 
@@ -62,6 +67,9 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - `flow pre-review` 的步骤顺序稳定为 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate`
 - 输出 JSON 能直接支撑“是否进入 review 前语义审查”的判断
 - skill 自身不复制治理真相，也不冒充 reviewer 结论
+- full path 缺少必需 suite artifact、provenance、fresh evidence 或存在 blocking
+  consistency gap 时返回 `block` / `fallback`
+- minimal path 只有在缺口具备有效 `not_applicable` rationale 时才允许进入 review
 
 输入信号与输出合同见：
 

--- a/skills/loom-build/.loom-runtime/loom-pre-review/references/input-signals.md
+++ b/skills/loom-build/.loom-runtime/loom-pre-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前 review 意图
 - 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-build/.loom-runtime/loom-pre-review/references/output-contract.md
+++ b/skills/loom-build/.loom-runtime/loom-pre-review/references/output-contract.md
@@ -16,6 +16,11 @@
   - 当前 Loom 入口自己的 scene / carrier 判定，以及 fail-closed 原因
 - `governance_lint`
   - `loom-governance-lint-status/v1` 派生证据；blocking lint 进入 `missing_inputs`，advisory lint 只进入风险摘要，不产生 reviewer 结论
+- `suite_path_consumption`
+  - full path 的 required artifacts、evidence-map freshness、consistency-analysis
+    blocking/advisory 分类
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - full path 缺必需输入或 minimal path 无有效 rationale 时必须 fail-closed
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> governance-lint` 顺序列出
 

--- a/skills/loom-build/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-build/.loom-runtime/loom-spec-review/SKILL.md
@@ -39,6 +39,12 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - formal spec 路径不存在时，`flow spec-review` 必须 fail-closed
 - spec review 只写回单一 spec review record，不替代 implementation review record
 - `reviewed_head` 与 stale 语义必须显式暴露，供后续 gate 消费
+- full path 必须消费 suite path locator、必需工件 locator、provenance，以及
+  evidence-map / consistency-analysis / gate-chain 适用性结论；缺失或不可读时
+  fail-closed，回退到 spec shaping 或 suite path 修正
+- minimal path 只能消费带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable`；无理由缺口、`deferred` 或 source/generated sync 待办不得被当作
+  spec gate 通过
 
 ## 3. 固定编排
 
@@ -57,6 +63,9 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
 - 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不重新定义 full suite、minimal suite、evidence-map、consistency-analysis 或
+  gate-chain 语义；只消费这些合同已经定义的 locator、freshness、classification
+  与 fallback 边界
 
 ## 4. 输出要求
 
@@ -66,6 +75,8 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - spec review 的机械基线结果
 - spec review record 的定位与当前结论
 - reviewed head 绑定、当前 head、是否 stale
+- suite path decision，以及 full path readiness 或 minimal path `not_applicable`
+  rationale 是否可被 spec gate 消费
 - 审查结论（`allow` / `block` / `fallback`）
 - 若当前不能继续，应回退到哪里
 

--- a/skills/loom-build/.loom-runtime/loom-spec-review/references/input-signals.md
+++ b/skills/loom-build/.loom-runtime/loom-spec-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - formal spec 路径或明确的 spec review 意图
+- suite path decision：full path 的必需工件 locator，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-build/.loom-runtime/loom-spec-review/references/output-contract.md
+++ b/skills/loom-build/.loom-runtime/loom-spec-review/references/output-contract.md
@@ -22,6 +22,11 @@
   - `checkpoint build` 的结果、摘要、阻断项与回退去向
 - `gate_chain`
   - `spec_gate`、`build_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - `path: full|minimal`
+  - full path 的 suite locator、required artifact locators、provenance 与 freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - 无理由 missing、stale、conflict 或 deferred 输入必须进入 `missing_inputs`
 - `spec_review`
   - formal spec 路径、spec review record、head 绑定、stale 语义与当前 gate 结论
 - `spec_review_authority_migration`

--- a/skills/loom-build/.loom-runtime/loom-story/SKILL.md
+++ b/skills/loom-build/.loom-runtime/loom-story/SKILL.md
@@ -85,6 +85,21 @@ User Story 主体不得包含 delivery handoff、spec locator、plan locator、r
 - `Work Item` 仍是唯一执行入口
 - issue tree、Phase / FR / Work Item / PR 切分、blocked-by/blocks 与 host carrier mapping 由 `loom-init` 的 delivery planning 路由承接
 
+## 6. Full / Minimal Suite Path 边界
+
+`loom-story` 不选择或重定义 full/minimal suite path；它只产出可被
+`spec-suite` 消费的 story readiness 与 business confirmation 输入。
+
+- full path：若 formal spec path 消费 story，必须输出 Story Readiness 与 Story
+  Business Confirmation locator，且 decision 为 `confirmed` 或明确
+  `not_applicable`。`pending` / `revision-requested` 必须 fail closed，回到 story
+  shaping 或等待业务语义确认。
+- minimal path：纯治理、维护、格式、链接修复或载体整理可以输出
+  `not_applicable`，但必须包含 bypass rationale、consumer boundary 和 recheck
+  condition，供 `spec.md`、`plan.md`、evidence-map 与后续 gate 消费。
+- `loom-story` 不把 `not_applicable` 升级成产品确认，不生成 evidence-map、
+  consistency-analysis、review、merge-ready 或 GitHub closeout truth。
+
 输入信号与输出合同见：
 
 - [references/input-signals.md](./references/input-signals.md)

--- a/skills/loom-build/.loom-runtime/loom-story/references/output-contract.md
+++ b/skills/loom-build/.loom-runtime/loom-story/references/output-contract.md
@@ -28,6 +28,8 @@
   - story scenario 到 `plan.md` validation strategy 的映射
   - spec / plan 只消费已 `confirmed` 或明确 `not_applicable` 的 story 语义
   - 任何 `pending` 或 `revision-requested` 的 readiness / confirmation 都必须 fail closed，阻止 formal spec shaping
+  - full path 需要可消费的 readiness / confirmation locator；minimal path 需要
+    `not_applicable` rationale、consumer boundary 和 recheck condition
   - `Work Item` 仍是唯一执行入口
 - `missing_inputs`
   - 当前阻断 story shaping 的缺口；无阻断时为空数组

--- a/skills/loom-build/.loom-runtime/route-matrix.md
+++ b/skills/loom-build/.loom-runtime/route-matrix.md
@@ -45,7 +45,42 @@
 - `GitHub controlled merge`
   - merge 由宿主控制面执行；Loom 只消费 required checks、review、head 绑定与 merge gate 结果
 
-## 4. `governance_surface` 公共合同
+## 4. Formal Spec Suite Path 消费边界
+
+`loom-story`、`loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+必须消费 `docs/methodology/templates/spec-suite.md` 已定义的
+`full suite` / `minimal suite` path decision，不得在 skill 中重新定义 suite
+工件、evidence-map、consistency-analysis 或 gate-chain 语义。
+
+固定消费规则：
+
+- `full path` 表示当前事项选择完整 formal spec suite。后续 skill 必须能读取
+  suite path locator、必需工件 locator、条件工件的适用性判断、provenance，以及
+  #1018/#1019 合同声明适用时的 evidence-map、consistency-analysis 与 gate-chain
+  消费结论。
+- `full path` 缺少必需工件、locator、provenance 或当前 gate 所需 evidence 时，
+  `loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+  必须 fail-closed，返回 `block` 或带明确 `fallback_to` 的 `fallback`。
+- `minimal path` 是合法路径，但只能通过带 rationale、consumer boundary 和
+  recheck condition 的 `not_applicable` 消费 full path 附加工件；无理由缺口仍是
+  `missing`，不得被当成 `not_applicable`。
+- `deferred` 不等于 `not_applicable`。deferred source/generated sync、CLI surface
+  或后续 FR 工作只能作为后续事项输入，不得被当前 skill 当成 completed truth。
+- GitHub issue、sub-issue、Project item、PR、checklist 或 repo-local carrier 只按
+  GitHub task carrier profile 读取 locator、state、provenance 和冲突状态；不得替代
+  Work Item、spec suite、review record 或 merge-ready truth。
+
+场景到消费边界：
+
+| Skill | full path 消费 | minimal path 消费 |
+| --- | --- | --- |
+| `loom-story` | 输出 Story Readiness / Business Confirmation locator，供 `spec.md` / `plan.md` 和 suite path decision 消费 | 对纯治理、维护、格式、链接类事项输出 `not_applicable` rationale、consumer boundary、recheck condition |
+| `loom-spec-review` | 消费 suite path、formal spec、plan、必需工件、evidence-map / consistency-analysis 适用性；缺必需输入时 fail-closed | 只接受有效 `not_applicable` rationale；否则回退到 spec shaping / suite path 修正 |
+| `loom-build` | 在 build readiness 前消费 full suite readiness、scenario-to-validation mapping、task carrier profile locator | 合法跳过附加工件，但必须保留 rationale 和替代验证入口 |
+| `loom-pre-review` | 在 review 前消费 full suite locator、evidence-map freshness、consistency-analysis blocking/advisory 分类 | 缺口必须是有效 `not_applicable`，否则阻断 review admission |
+| `loom-merge-ready` | 在 merge gate 消费 reviewed full suite evidence、gate-chain、PR head / reviewed head / validation freshness | 只把有效 minimal path rationale 当作合法跳过，不把 missing 或 deferred 当作 ready |
+
+## 5. `governance_surface` 公共合同
 
 以下三类入口对外暴露的公共治理读面固定命名为 `governance_surface`：
 
@@ -73,7 +108,7 @@
 - 只回答 locator 与职责边界，不复制实时停点、下一步、阻断项、验证摘要
 - 若需要回答 gate 进度，统一通过 `review_merge_surface` 或 `status control plane` 读取，不在 `governance_surface` 并行维护 authored gate 状态
 
-## 5. Planning 边界
+## 6. Planning 边界
 
 `delivery planning` 是 `loom-init` 的路由结果，不是 build、review 或 merge-ready 的前置硬门禁。
 
@@ -102,7 +137,7 @@ planning 输出只能包含：
 
 planning 输出不能声明某个 Work Item 已完成，不能替代 `spec.md` / `plan.md`，不能替代 review、merge-ready、closeout，也不能直接改写 GitHub，除非用户明确要求执行创建或更新动作。
 
-## 6. fallback 语义
+## 7. fallback 语义
 
 出现以下任一情况时，root skill 不做猜测，直接回退到 `loom-init`：
 

--- a/skills/loom-build/.loom-runtime/shared/references/templates/spec-suite.md
+++ b/skills/loom-build/.loom-runtime/shared/references/templates/spec-suite.md
@@ -18,6 +18,21 @@ Loom 当前把正式规约套件的最小内核定义为：
 
 这两个工件分别承担不同职责，不得混写。
 
+Formal spec path 有两条合法 suite path：
+
+- `minimal suite`
+  - 必含 `spec.md` 与 `plan.md`
+  - 适用于低风险、局部、纯治理或文档类事项
+  - 可用 `not_applicable` rationale 合法跳过 full path 附加工件
+- `full suite`
+  - 在 minimal suite 之上消费 suite-index、条件附加工件、evidence-map、
+    consistency-analysis 与 gate-chain consumption
+  - 适用于 formal spec、高风险、跨模块、强 review 或需要完整证据链的事项
+
+路径选择必须有 locator 与 provenance。若从 full path 降到 minimal path，必须说明
+附加工件为什么 `not_applicable`；若从 minimal path 升到 full path，必须说明触发信号
+和需要补齐的工件。
+
 ## 2. `spec.md` 最小要求
 
 `spec.md` 至少应表达：
@@ -58,6 +73,17 @@ Loom 当前把正式规约套件的最小内核定义为：
 - 不能自动化的行为必须声明人工验证路径、证据 locator 与 fresh 条件
 - 纯文档或治理规则变更可以不强制 TDD，但必须说明行为证据如何由结构检查、审查记录或示例消费
 
+映射状态必须可被后续 gate 消费：
+
+- `scenario_id` / scenario locator 映射到 automated、manual、structural 或
+  `not_applicable` validation strategy
+- `acceptance_id` / acceptance locator 映射到 test evidence、structural check、
+  manual evidence 或 `not_applicable`
+- full path 下，缺少 scenario -> validation 或 acceptance -> test mapping 默认阻断
+  build / review
+- minimal path 下，缺映射必须以 `not_applicable` rationale、替代验证入口和
+  recheck condition 解释
+
 ## 4. 套件边界规则
 
 Loom 必须区分：
@@ -74,6 +100,11 @@ Loom 当前不固化：
 
 - 所有项目都必须有同一组附加工件
 - `TODO.md` 或同类文件是永恒必选项
+
+Full path 缺少必需工件、locator、provenance 或 gate 所需 evidence 时必须
+fail-closed。Minimal path 缺少 full path 附加工件时，只有同时具备 rationale、
+consumer boundary 与 recheck condition 的 `not_applicable` 才能消解；无理由缺口
+仍是 `missing`。`deferred` 不等于 `not_applicable`，不得作为 completed truth 消费。
 
 ## 5. 行为证据与测试证据
 

--- a/skills/loom-build/SKILL.md
+++ b/skills/loom-build/SKILL.md
@@ -55,10 +55,21 @@ subagent-driven mode 必须先声明以下字段：
 - 多个委派声明重叠 `write_ownership`
 - 多轮或多个委派报告同一 blocker signature
 - 缺少 Work Item、spec、plan、recovery、validation baseline、workspace 或 ownership constraints
+- 选择 full path 但 suite-index、必需 suite 工件、scenario-to-validation mapping、
+  task carrier profile locator、provenance 或当前 build gate 所需 evidence 缺失
+- 选择 minimal path 但 full path 附加工件缺口没有 `not_applicable` rationale、
+  consumer boundary、recheck condition 或替代验证入口
+- 把 `deferred`、source/generated sync 待办或 CLI surface 待办当作 build readiness
+  的 completed truth
 
 ## 5. 完成标准
 
 只有当 `flow build` 返回 pass，且 build evidence 证明所有委派输出已集成、无 ownership overlap、无 repeated blocker 时，才允许继续进入 pre-review / review。
+
+Build readiness 只消费 full/minimal suite path 决策，不重新定义 suite 工件、
+evidence-map、consistency-analysis 或 gate-chain。full path 必须证明必需工件可读且
+fresh；minimal path 必须保留合法 `not_applicable` rationale，并把 recheck condition
+传递给后续 pre-review / review。
 
 输入信号与输出合同见：
 

--- a/skills/loom-build/references/input-signals.md
+++ b/skills/loom-build/references/input-signals.md
@@ -14,4 +14,6 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - Work Item、spec、plan、recovery baseline、validation baseline、workspace 和 ownership constraints
+- suite path decision：full path 的 suite / evidence locators，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition 与替代验证入口
 - 若使用 subagent-driven mode，必须提供 delegation/build evidence locator

--- a/skills/loom-build/references/output-contract.md
+++ b/skills/loom-build/references/output-contract.md
@@ -26,6 +26,12 @@
   - `integration_evidence`
   - `ownership_conflicts`
   - `repeated_blocker_signal`
+- `suite_path_consumption`
+  - full path 的必需工件、scenario-to-validation mapping、task carrier locator 与
+    provenance 是否可读
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+    与替代验证入口
+  - 缺失、stale、conflict 或无理由跳过时必须阻断 build readiness
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> build-execution` 顺序列出
 

--- a/skills/loom-handoff/.loom-runtime/loom-build/SKILL.md
+++ b/skills/loom-handoff/.loom-runtime/loom-build/SKILL.md
@@ -55,10 +55,21 @@ subagent-driven mode 必须先声明以下字段：
 - 多个委派声明重叠 `write_ownership`
 - 多轮或多个委派报告同一 blocker signature
 - 缺少 Work Item、spec、plan、recovery、validation baseline、workspace 或 ownership constraints
+- 选择 full path 但 suite-index、必需 suite 工件、scenario-to-validation mapping、
+  task carrier profile locator、provenance 或当前 build gate 所需 evidence 缺失
+- 选择 minimal path 但 full path 附加工件缺口没有 `not_applicable` rationale、
+  consumer boundary、recheck condition 或替代验证入口
+- 把 `deferred`、source/generated sync 待办或 CLI surface 待办当作 build readiness
+  的 completed truth
 
 ## 5. 完成标准
 
 只有当 `flow build` 返回 pass，且 build evidence 证明所有委派输出已集成、无 ownership overlap、无 repeated blocker 时，才允许继续进入 pre-review / review。
+
+Build readiness 只消费 full/minimal suite path 决策，不重新定义 suite 工件、
+evidence-map、consistency-analysis 或 gate-chain。full path 必须证明必需工件可读且
+fresh；minimal path 必须保留合法 `not_applicable` rationale，并把 recheck condition
+传递给后续 pre-review / review。
 
 输入信号与输出合同见：
 

--- a/skills/loom-handoff/.loom-runtime/loom-build/references/input-signals.md
+++ b/skills/loom-handoff/.loom-runtime/loom-build/references/input-signals.md
@@ -14,4 +14,6 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - Work Item、spec、plan、recovery baseline、validation baseline、workspace 和 ownership constraints
+- suite path decision：full path 的 suite / evidence locators，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition 与替代验证入口
 - 若使用 subagent-driven mode，必须提供 delegation/build evidence locator

--- a/skills/loom-handoff/.loom-runtime/loom-build/references/output-contract.md
+++ b/skills/loom-handoff/.loom-runtime/loom-build/references/output-contract.md
@@ -26,6 +26,12 @@
   - `integration_evidence`
   - `ownership_conflicts`
   - `repeated_blocker_signal`
+- `suite_path_consumption`
+  - full path 的必需工件、scenario-to-validation mapping、task carrier locator 与
+    provenance 是否可读
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+    与替代验证入口
+  - 缺失、stale、conflict 或无理由跳过时必须阻断 build readiness
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> build-execution` 顺序列出
 

--- a/skills/loom-handoff/.loom-runtime/loom-merge-ready/SKILL.md
+++ b/skills/loom-handoff/.loom-runtime/loom-merge-ready/SKILL.md
@@ -17,6 +17,14 @@ description: 负责 merge 前统一放行。Use when Codex needs to confirm whet
 - 只输出进入 `GitHub controlled merge` 前的统一放行摘要，不替代宿主平台 merge 动作
 - PR 合并前的宿主硬门禁由 `pr-gate check` 和 `controlled-merge check|merge` 承接；它们只能消费 authored Loom review record，不能把 raw review/shadow evidence 当作 approval
 - 不新建 authored 真相源，也不直接执行平台合并
+- 消费 full/minimal suite path、evidence-map freshness、consistency-analysis
+  classification 与 gate-chain 当前状态，但不重新定义这些合同
+- full path 下，review record 必须证明已消费 suite locators、evidence-map、
+  consistency-analysis、PR head / reviewed head / validation freshness；缺失、stale 或
+  conflict 必须 fail-closed
+- minimal path 下，只有带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable` 可以跳过 full path 附加工件；missing、deferred 或 source/generated
+  sync 待办不能被当作 merge-ready
 
 输入信号与输出合同见：
 

--- a/skills/loom-handoff/.loom-runtime/loom-merge-ready/references/input-signals.md
+++ b/skills/loom-handoff/.loom-runtime/loom-merge-ready/references/input-signals.md
@@ -6,3 +6,11 @@
 - 最终放行前预检
 - 确认当前事项是否可合并
 - 确认 `GitHub controlled merge` 前置是否齐全
+
+最小输入：
+
+- 目标仓库
+- 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 reviewed suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+- PR locator、head SHA、reviewed head 与 validation freshness 证据

--- a/skills/loom-handoff/.loom-runtime/loom-merge-ready/references/output-contract.md
+++ b/skills/loom-handoff/.loom-runtime/loom-merge-ready/references/output-contract.md
@@ -28,6 +28,11 @@
   - `loom-governance-lint-status/v1` 派生证据；只消费 fact-chain 与 repo companion 的 blocking/advisory lint result，不替代 authored review record、merge checkpoint 或 host merge truth
 - `gate_chain`
   - `spec_gate`、`build_gate`、`review_gate`、`merge_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - full path 的 suite readiness、evidence-map、consistency-analysis、reviewed
+    locators、PR head / reviewed head / validation freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - missing、stale、conflict、deferred 或无理由跳过必须进入 `missing_inputs`
 - `github_controlled_merge`
   - required checks、branch protection、merge method 与 host merge 前置状态
 - `retained_host_signals`

--- a/skills/loom-handoff/.loom-runtime/loom-pre-review/SKILL.md
+++ b/skills/loom-handoff/.loom-runtime/loom-pre-review/SKILL.md
@@ -43,6 +43,7 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 不替代 reviewer 的语义判断
 - 不直接执行 merge
 - 不回写事实链、恢复入口或状态面
+- 不重新定义 full/minimal suite、evidence-map、consistency-analysis 或 gate-chain
 
 ## 4. 输出要求
 
@@ -53,6 +54,10 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 哪一步阻断了继续进入 review
 - 若阻断，应回退到哪里
 - 当前 steps 的机械结果是什么
+- full path 的 suite locator、evidence-map freshness 与 consistency-analysis
+  blocking/advisory 分类是否已经可供 review 消费
+- minimal path 的 `not_applicable` rationale、consumer boundary 与 recheck condition
+  是否足够；不足时必须 fail-closed，不能进入 review
 
 ## 5. 完成标准
 
@@ -62,6 +67,9 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - `flow pre-review` 的步骤顺序稳定为 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate`
 - 输出 JSON 能直接支撑“是否进入 review 前语义审查”的判断
 - skill 自身不复制治理真相，也不冒充 reviewer 结论
+- full path 缺少必需 suite artifact、provenance、fresh evidence 或存在 blocking
+  consistency gap 时返回 `block` / `fallback`
+- minimal path 只有在缺口具备有效 `not_applicable` rationale 时才允许进入 review
 
 输入信号与输出合同见：
 

--- a/skills/loom-handoff/.loom-runtime/loom-pre-review/references/input-signals.md
+++ b/skills/loom-handoff/.loom-runtime/loom-pre-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前 review 意图
 - 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-handoff/.loom-runtime/loom-pre-review/references/output-contract.md
+++ b/skills/loom-handoff/.loom-runtime/loom-pre-review/references/output-contract.md
@@ -16,6 +16,11 @@
   - 当前 Loom 入口自己的 scene / carrier 判定，以及 fail-closed 原因
 - `governance_lint`
   - `loom-governance-lint-status/v1` 派生证据；blocking lint 进入 `missing_inputs`，advisory lint 只进入风险摘要，不产生 reviewer 结论
+- `suite_path_consumption`
+  - full path 的 required artifacts、evidence-map freshness、consistency-analysis
+    blocking/advisory 分类
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - full path 缺必需输入或 minimal path 无有效 rationale 时必须 fail-closed
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> governance-lint` 顺序列出
 

--- a/skills/loom-handoff/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-handoff/.loom-runtime/loom-spec-review/SKILL.md
@@ -39,6 +39,12 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - formal spec 路径不存在时，`flow spec-review` 必须 fail-closed
 - spec review 只写回单一 spec review record，不替代 implementation review record
 - `reviewed_head` 与 stale 语义必须显式暴露，供后续 gate 消费
+- full path 必须消费 suite path locator、必需工件 locator、provenance，以及
+  evidence-map / consistency-analysis / gate-chain 适用性结论；缺失或不可读时
+  fail-closed，回退到 spec shaping 或 suite path 修正
+- minimal path 只能消费带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable`；无理由缺口、`deferred` 或 source/generated sync 待办不得被当作
+  spec gate 通过
 
 ## 3. 固定编排
 
@@ -57,6 +63,9 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
 - 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不重新定义 full suite、minimal suite、evidence-map、consistency-analysis 或
+  gate-chain 语义；只消费这些合同已经定义的 locator、freshness、classification
+  与 fallback 边界
 
 ## 4. 输出要求
 
@@ -66,6 +75,8 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - spec review 的机械基线结果
 - spec review record 的定位与当前结论
 - reviewed head 绑定、当前 head、是否 stale
+- suite path decision，以及 full path readiness 或 minimal path `not_applicable`
+  rationale 是否可被 spec gate 消费
 - 审查结论（`allow` / `block` / `fallback`）
 - 若当前不能继续，应回退到哪里
 

--- a/skills/loom-handoff/.loom-runtime/loom-spec-review/references/input-signals.md
+++ b/skills/loom-handoff/.loom-runtime/loom-spec-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - formal spec 路径或明确的 spec review 意图
+- suite path decision：full path 的必需工件 locator，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-handoff/.loom-runtime/loom-spec-review/references/output-contract.md
+++ b/skills/loom-handoff/.loom-runtime/loom-spec-review/references/output-contract.md
@@ -22,6 +22,11 @@
   - `checkpoint build` 的结果、摘要、阻断项与回退去向
 - `gate_chain`
   - `spec_gate`、`build_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - `path: full|minimal`
+  - full path 的 suite locator、required artifact locators、provenance 与 freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - 无理由 missing、stale、conflict 或 deferred 输入必须进入 `missing_inputs`
 - `spec_review`
   - formal spec 路径、spec review record、head 绑定、stale 语义与当前 gate 结论
 - `spec_review_authority_migration`

--- a/skills/loom-handoff/.loom-runtime/loom-story/SKILL.md
+++ b/skills/loom-handoff/.loom-runtime/loom-story/SKILL.md
@@ -85,6 +85,21 @@ User Story 主体不得包含 delivery handoff、spec locator、plan locator、r
 - `Work Item` 仍是唯一执行入口
 - issue tree、Phase / FR / Work Item / PR 切分、blocked-by/blocks 与 host carrier mapping 由 `loom-init` 的 delivery planning 路由承接
 
+## 6. Full / Minimal Suite Path 边界
+
+`loom-story` 不选择或重定义 full/minimal suite path；它只产出可被
+`spec-suite` 消费的 story readiness 与 business confirmation 输入。
+
+- full path：若 formal spec path 消费 story，必须输出 Story Readiness 与 Story
+  Business Confirmation locator，且 decision 为 `confirmed` 或明确
+  `not_applicable`。`pending` / `revision-requested` 必须 fail closed，回到 story
+  shaping 或等待业务语义确认。
+- minimal path：纯治理、维护、格式、链接修复或载体整理可以输出
+  `not_applicable`，但必须包含 bypass rationale、consumer boundary 和 recheck
+  condition，供 `spec.md`、`plan.md`、evidence-map 与后续 gate 消费。
+- `loom-story` 不把 `not_applicable` 升级成产品确认，不生成 evidence-map、
+  consistency-analysis、review、merge-ready 或 GitHub closeout truth。
+
 输入信号与输出合同见：
 
 - [references/input-signals.md](./references/input-signals.md)

--- a/skills/loom-handoff/.loom-runtime/loom-story/references/output-contract.md
+++ b/skills/loom-handoff/.loom-runtime/loom-story/references/output-contract.md
@@ -28,6 +28,8 @@
   - story scenario 到 `plan.md` validation strategy 的映射
   - spec / plan 只消费已 `confirmed` 或明确 `not_applicable` 的 story 语义
   - 任何 `pending` 或 `revision-requested` 的 readiness / confirmation 都必须 fail closed，阻止 formal spec shaping
+  - full path 需要可消费的 readiness / confirmation locator；minimal path 需要
+    `not_applicable` rationale、consumer boundary 和 recheck condition
   - `Work Item` 仍是唯一执行入口
 - `missing_inputs`
   - 当前阻断 story shaping 的缺口；无阻断时为空数组

--- a/skills/loom-handoff/.loom-runtime/route-matrix.md
+++ b/skills/loom-handoff/.loom-runtime/route-matrix.md
@@ -45,7 +45,42 @@
 - `GitHub controlled merge`
   - merge 由宿主控制面执行；Loom 只消费 required checks、review、head 绑定与 merge gate 结果
 
-## 4. `governance_surface` 公共合同
+## 4. Formal Spec Suite Path 消费边界
+
+`loom-story`、`loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+必须消费 `docs/methodology/templates/spec-suite.md` 已定义的
+`full suite` / `minimal suite` path decision，不得在 skill 中重新定义 suite
+工件、evidence-map、consistency-analysis 或 gate-chain 语义。
+
+固定消费规则：
+
+- `full path` 表示当前事项选择完整 formal spec suite。后续 skill 必须能读取
+  suite path locator、必需工件 locator、条件工件的适用性判断、provenance，以及
+  #1018/#1019 合同声明适用时的 evidence-map、consistency-analysis 与 gate-chain
+  消费结论。
+- `full path` 缺少必需工件、locator、provenance 或当前 gate 所需 evidence 时，
+  `loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+  必须 fail-closed，返回 `block` 或带明确 `fallback_to` 的 `fallback`。
+- `minimal path` 是合法路径，但只能通过带 rationale、consumer boundary 和
+  recheck condition 的 `not_applicable` 消费 full path 附加工件；无理由缺口仍是
+  `missing`，不得被当成 `not_applicable`。
+- `deferred` 不等于 `not_applicable`。deferred source/generated sync、CLI surface
+  或后续 FR 工作只能作为后续事项输入，不得被当前 skill 当成 completed truth。
+- GitHub issue、sub-issue、Project item、PR、checklist 或 repo-local carrier 只按
+  GitHub task carrier profile 读取 locator、state、provenance 和冲突状态；不得替代
+  Work Item、spec suite、review record 或 merge-ready truth。
+
+场景到消费边界：
+
+| Skill | full path 消费 | minimal path 消费 |
+| --- | --- | --- |
+| `loom-story` | 输出 Story Readiness / Business Confirmation locator，供 `spec.md` / `plan.md` 和 suite path decision 消费 | 对纯治理、维护、格式、链接类事项输出 `not_applicable` rationale、consumer boundary、recheck condition |
+| `loom-spec-review` | 消费 suite path、formal spec、plan、必需工件、evidence-map / consistency-analysis 适用性；缺必需输入时 fail-closed | 只接受有效 `not_applicable` rationale；否则回退到 spec shaping / suite path 修正 |
+| `loom-build` | 在 build readiness 前消费 full suite readiness、scenario-to-validation mapping、task carrier profile locator | 合法跳过附加工件，但必须保留 rationale 和替代验证入口 |
+| `loom-pre-review` | 在 review 前消费 full suite locator、evidence-map freshness、consistency-analysis blocking/advisory 分类 | 缺口必须是有效 `not_applicable`，否则阻断 review admission |
+| `loom-merge-ready` | 在 merge gate 消费 reviewed full suite evidence、gate-chain、PR head / reviewed head / validation freshness | 只把有效 minimal path rationale 当作合法跳过，不把 missing 或 deferred 当作 ready |
+
+## 5. `governance_surface` 公共合同
 
 以下三类入口对外暴露的公共治理读面固定命名为 `governance_surface`：
 
@@ -73,7 +108,7 @@
 - 只回答 locator 与职责边界，不复制实时停点、下一步、阻断项、验证摘要
 - 若需要回答 gate 进度，统一通过 `review_merge_surface` 或 `status control plane` 读取，不在 `governance_surface` 并行维护 authored gate 状态
 
-## 5. Planning 边界
+## 6. Planning 边界
 
 `delivery planning` 是 `loom-init` 的路由结果，不是 build、review 或 merge-ready 的前置硬门禁。
 
@@ -102,7 +137,7 @@ planning 输出只能包含：
 
 planning 输出不能声明某个 Work Item 已完成，不能替代 `spec.md` / `plan.md`，不能替代 review、merge-ready、closeout，也不能直接改写 GitHub，除非用户明确要求执行创建或更新动作。
 
-## 6. fallback 语义
+## 7. fallback 语义
 
 出现以下任一情况时，root skill 不做猜测，直接回退到 `loom-init`：
 

--- a/skills/loom-handoff/.loom-runtime/shared/references/templates/spec-suite.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/templates/spec-suite.md
@@ -18,6 +18,21 @@ Loom 当前把正式规约套件的最小内核定义为：
 
 这两个工件分别承担不同职责，不得混写。
 
+Formal spec path 有两条合法 suite path：
+
+- `minimal suite`
+  - 必含 `spec.md` 与 `plan.md`
+  - 适用于低风险、局部、纯治理或文档类事项
+  - 可用 `not_applicable` rationale 合法跳过 full path 附加工件
+- `full suite`
+  - 在 minimal suite 之上消费 suite-index、条件附加工件、evidence-map、
+    consistency-analysis 与 gate-chain consumption
+  - 适用于 formal spec、高风险、跨模块、强 review 或需要完整证据链的事项
+
+路径选择必须有 locator 与 provenance。若从 full path 降到 minimal path，必须说明
+附加工件为什么 `not_applicable`；若从 minimal path 升到 full path，必须说明触发信号
+和需要补齐的工件。
+
 ## 2. `spec.md` 最小要求
 
 `spec.md` 至少应表达：
@@ -58,6 +73,17 @@ Loom 当前把正式规约套件的最小内核定义为：
 - 不能自动化的行为必须声明人工验证路径、证据 locator 与 fresh 条件
 - 纯文档或治理规则变更可以不强制 TDD，但必须说明行为证据如何由结构检查、审查记录或示例消费
 
+映射状态必须可被后续 gate 消费：
+
+- `scenario_id` / scenario locator 映射到 automated、manual、structural 或
+  `not_applicable` validation strategy
+- `acceptance_id` / acceptance locator 映射到 test evidence、structural check、
+  manual evidence 或 `not_applicable`
+- full path 下，缺少 scenario -> validation 或 acceptance -> test mapping 默认阻断
+  build / review
+- minimal path 下，缺映射必须以 `not_applicable` rationale、替代验证入口和
+  recheck condition 解释
+
 ## 4. 套件边界规则
 
 Loom 必须区分：
@@ -74,6 +100,11 @@ Loom 当前不固化：
 
 - 所有项目都必须有同一组附加工件
 - `TODO.md` 或同类文件是永恒必选项
+
+Full path 缺少必需工件、locator、provenance 或 gate 所需 evidence 时必须
+fail-closed。Minimal path 缺少 full path 附加工件时，只有同时具备 rationale、
+consumer boundary 与 recheck condition 的 `not_applicable` 才能消解；无理由缺口
+仍是 `missing`。`deferred` 不等于 `not_applicable`，不得作为 completed truth 消费。
 
 ## 5. 行为证据与测试证据
 

--- a/skills/loom-init/.loom-runtime/loom-build/SKILL.md
+++ b/skills/loom-init/.loom-runtime/loom-build/SKILL.md
@@ -55,10 +55,21 @@ subagent-driven mode 必须先声明以下字段：
 - 多个委派声明重叠 `write_ownership`
 - 多轮或多个委派报告同一 blocker signature
 - 缺少 Work Item、spec、plan、recovery、validation baseline、workspace 或 ownership constraints
+- 选择 full path 但 suite-index、必需 suite 工件、scenario-to-validation mapping、
+  task carrier profile locator、provenance 或当前 build gate 所需 evidence 缺失
+- 选择 minimal path 但 full path 附加工件缺口没有 `not_applicable` rationale、
+  consumer boundary、recheck condition 或替代验证入口
+- 把 `deferred`、source/generated sync 待办或 CLI surface 待办当作 build readiness
+  的 completed truth
 
 ## 5. 完成标准
 
 只有当 `flow build` 返回 pass，且 build evidence 证明所有委派输出已集成、无 ownership overlap、无 repeated blocker 时，才允许继续进入 pre-review / review。
+
+Build readiness 只消费 full/minimal suite path 决策，不重新定义 suite 工件、
+evidence-map、consistency-analysis 或 gate-chain。full path 必须证明必需工件可读且
+fresh；minimal path 必须保留合法 `not_applicable` rationale，并把 recheck condition
+传递给后续 pre-review / review。
 
 输入信号与输出合同见：
 

--- a/skills/loom-init/.loom-runtime/loom-build/references/input-signals.md
+++ b/skills/loom-init/.loom-runtime/loom-build/references/input-signals.md
@@ -14,4 +14,6 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - Work Item、spec、plan、recovery baseline、validation baseline、workspace 和 ownership constraints
+- suite path decision：full path 的 suite / evidence locators，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition 与替代验证入口
 - 若使用 subagent-driven mode，必须提供 delegation/build evidence locator

--- a/skills/loom-init/.loom-runtime/loom-build/references/output-contract.md
+++ b/skills/loom-init/.loom-runtime/loom-build/references/output-contract.md
@@ -26,6 +26,12 @@
   - `integration_evidence`
   - `ownership_conflicts`
   - `repeated_blocker_signal`
+- `suite_path_consumption`
+  - full path 的必需工件、scenario-to-validation mapping、task carrier locator 与
+    provenance 是否可读
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+    与替代验证入口
+  - 缺失、stale、conflict 或无理由跳过时必须阻断 build readiness
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> build-execution` 顺序列出
 

--- a/skills/loom-init/.loom-runtime/loom-merge-ready/SKILL.md
+++ b/skills/loom-init/.loom-runtime/loom-merge-ready/SKILL.md
@@ -17,6 +17,14 @@ description: 负责 merge 前统一放行。Use when Codex needs to confirm whet
 - 只输出进入 `GitHub controlled merge` 前的统一放行摘要，不替代宿主平台 merge 动作
 - PR 合并前的宿主硬门禁由 `pr-gate check` 和 `controlled-merge check|merge` 承接；它们只能消费 authored Loom review record，不能把 raw review/shadow evidence 当作 approval
 - 不新建 authored 真相源，也不直接执行平台合并
+- 消费 full/minimal suite path、evidence-map freshness、consistency-analysis
+  classification 与 gate-chain 当前状态，但不重新定义这些合同
+- full path 下，review record 必须证明已消费 suite locators、evidence-map、
+  consistency-analysis、PR head / reviewed head / validation freshness；缺失、stale 或
+  conflict 必须 fail-closed
+- minimal path 下，只有带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable` 可以跳过 full path 附加工件；missing、deferred 或 source/generated
+  sync 待办不能被当作 merge-ready
 
 输入信号与输出合同见：
 

--- a/skills/loom-init/.loom-runtime/loom-merge-ready/references/input-signals.md
+++ b/skills/loom-init/.loom-runtime/loom-merge-ready/references/input-signals.md
@@ -6,3 +6,11 @@
 - 最终放行前预检
 - 确认当前事项是否可合并
 - 确认 `GitHub controlled merge` 前置是否齐全
+
+最小输入：
+
+- 目标仓库
+- 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 reviewed suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+- PR locator、head SHA、reviewed head 与 validation freshness 证据

--- a/skills/loom-init/.loom-runtime/loom-merge-ready/references/output-contract.md
+++ b/skills/loom-init/.loom-runtime/loom-merge-ready/references/output-contract.md
@@ -28,6 +28,11 @@
   - `loom-governance-lint-status/v1` 派生证据；只消费 fact-chain 与 repo companion 的 blocking/advisory lint result，不替代 authored review record、merge checkpoint 或 host merge truth
 - `gate_chain`
   - `spec_gate`、`build_gate`、`review_gate`、`merge_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - full path 的 suite readiness、evidence-map、consistency-analysis、reviewed
+    locators、PR head / reviewed head / validation freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - missing、stale、conflict、deferred 或无理由跳过必须进入 `missing_inputs`
 - `github_controlled_merge`
   - required checks、branch protection、merge method 与 host merge 前置状态
 - `retained_host_signals`

--- a/skills/loom-init/.loom-runtime/loom-pre-review/SKILL.md
+++ b/skills/loom-init/.loom-runtime/loom-pre-review/SKILL.md
@@ -43,6 +43,7 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 不替代 reviewer 的语义判断
 - 不直接执行 merge
 - 不回写事实链、恢复入口或状态面
+- 不重新定义 full/minimal suite、evidence-map、consistency-analysis 或 gate-chain
 
 ## 4. 输出要求
 
@@ -53,6 +54,10 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 哪一步阻断了继续进入 review
 - 若阻断，应回退到哪里
 - 当前 steps 的机械结果是什么
+- full path 的 suite locator、evidence-map freshness 与 consistency-analysis
+  blocking/advisory 分类是否已经可供 review 消费
+- minimal path 的 `not_applicable` rationale、consumer boundary 与 recheck condition
+  是否足够；不足时必须 fail-closed，不能进入 review
 
 ## 5. 完成标准
 
@@ -62,6 +67,9 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - `flow pre-review` 的步骤顺序稳定为 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate`
 - 输出 JSON 能直接支撑“是否进入 review 前语义审查”的判断
 - skill 自身不复制治理真相，也不冒充 reviewer 结论
+- full path 缺少必需 suite artifact、provenance、fresh evidence 或存在 blocking
+  consistency gap 时返回 `block` / `fallback`
+- minimal path 只有在缺口具备有效 `not_applicable` rationale 时才允许进入 review
 
 输入信号与输出合同见：
 

--- a/skills/loom-init/.loom-runtime/loom-pre-review/references/input-signals.md
+++ b/skills/loom-init/.loom-runtime/loom-pre-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前 review 意图
 - 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-init/.loom-runtime/loom-pre-review/references/output-contract.md
+++ b/skills/loom-init/.loom-runtime/loom-pre-review/references/output-contract.md
@@ -16,6 +16,11 @@
   - 当前 Loom 入口自己的 scene / carrier 判定，以及 fail-closed 原因
 - `governance_lint`
   - `loom-governance-lint-status/v1` 派生证据；blocking lint 进入 `missing_inputs`，advisory lint 只进入风险摘要，不产生 reviewer 结论
+- `suite_path_consumption`
+  - full path 的 required artifacts、evidence-map freshness、consistency-analysis
+    blocking/advisory 分类
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - full path 缺必需输入或 minimal path 无有效 rationale 时必须 fail-closed
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> governance-lint` 顺序列出
 

--- a/skills/loom-init/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-init/.loom-runtime/loom-spec-review/SKILL.md
@@ -39,6 +39,12 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - formal spec 路径不存在时，`flow spec-review` 必须 fail-closed
 - spec review 只写回单一 spec review record，不替代 implementation review record
 - `reviewed_head` 与 stale 语义必须显式暴露，供后续 gate 消费
+- full path 必须消费 suite path locator、必需工件 locator、provenance，以及
+  evidence-map / consistency-analysis / gate-chain 适用性结论；缺失或不可读时
+  fail-closed，回退到 spec shaping 或 suite path 修正
+- minimal path 只能消费带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable`；无理由缺口、`deferred` 或 source/generated sync 待办不得被当作
+  spec gate 通过
 
 ## 3. 固定编排
 
@@ -57,6 +63,9 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
 - 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不重新定义 full suite、minimal suite、evidence-map、consistency-analysis 或
+  gate-chain 语义；只消费这些合同已经定义的 locator、freshness、classification
+  与 fallback 边界
 
 ## 4. 输出要求
 
@@ -66,6 +75,8 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - spec review 的机械基线结果
 - spec review record 的定位与当前结论
 - reviewed head 绑定、当前 head、是否 stale
+- suite path decision，以及 full path readiness 或 minimal path `not_applicable`
+  rationale 是否可被 spec gate 消费
 - 审查结论（`allow` / `block` / `fallback`）
 - 若当前不能继续，应回退到哪里
 

--- a/skills/loom-init/.loom-runtime/loom-spec-review/references/input-signals.md
+++ b/skills/loom-init/.loom-runtime/loom-spec-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - formal spec 路径或明确的 spec review 意图
+- suite path decision：full path 的必需工件 locator，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-init/.loom-runtime/loom-spec-review/references/output-contract.md
+++ b/skills/loom-init/.loom-runtime/loom-spec-review/references/output-contract.md
@@ -22,6 +22,11 @@
   - `checkpoint build` 的结果、摘要、阻断项与回退去向
 - `gate_chain`
   - `spec_gate`、`build_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - `path: full|minimal`
+  - full path 的 suite locator、required artifact locators、provenance 与 freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - 无理由 missing、stale、conflict 或 deferred 输入必须进入 `missing_inputs`
 - `spec_review`
   - formal spec 路径、spec review record、head 绑定、stale 语义与当前 gate 结论
 - `spec_review_authority_migration`

--- a/skills/loom-init/.loom-runtime/loom-story/SKILL.md
+++ b/skills/loom-init/.loom-runtime/loom-story/SKILL.md
@@ -85,6 +85,21 @@ User Story 主体不得包含 delivery handoff、spec locator、plan locator、r
 - `Work Item` 仍是唯一执行入口
 - issue tree、Phase / FR / Work Item / PR 切分、blocked-by/blocks 与 host carrier mapping 由 `loom-init` 的 delivery planning 路由承接
 
+## 6. Full / Minimal Suite Path 边界
+
+`loom-story` 不选择或重定义 full/minimal suite path；它只产出可被
+`spec-suite` 消费的 story readiness 与 business confirmation 输入。
+
+- full path：若 formal spec path 消费 story，必须输出 Story Readiness 与 Story
+  Business Confirmation locator，且 decision 为 `confirmed` 或明确
+  `not_applicable`。`pending` / `revision-requested` 必须 fail closed，回到 story
+  shaping 或等待业务语义确认。
+- minimal path：纯治理、维护、格式、链接修复或载体整理可以输出
+  `not_applicable`，但必须包含 bypass rationale、consumer boundary 和 recheck
+  condition，供 `spec.md`、`plan.md`、evidence-map 与后续 gate 消费。
+- `loom-story` 不把 `not_applicable` 升级成产品确认，不生成 evidence-map、
+  consistency-analysis、review、merge-ready 或 GitHub closeout truth。
+
 输入信号与输出合同见：
 
 - [references/input-signals.md](./references/input-signals.md)

--- a/skills/loom-init/.loom-runtime/loom-story/references/output-contract.md
+++ b/skills/loom-init/.loom-runtime/loom-story/references/output-contract.md
@@ -28,6 +28,8 @@
   - story scenario 到 `plan.md` validation strategy 的映射
   - spec / plan 只消费已 `confirmed` 或明确 `not_applicable` 的 story 语义
   - 任何 `pending` 或 `revision-requested` 的 readiness / confirmation 都必须 fail closed，阻止 formal spec shaping
+  - full path 需要可消费的 readiness / confirmation locator；minimal path 需要
+    `not_applicable` rationale、consumer boundary 和 recheck condition
   - `Work Item` 仍是唯一执行入口
 - `missing_inputs`
   - 当前阻断 story shaping 的缺口；无阻断时为空数组

--- a/skills/loom-init/.loom-runtime/route-matrix.md
+++ b/skills/loom-init/.loom-runtime/route-matrix.md
@@ -45,7 +45,42 @@
 - `GitHub controlled merge`
   - merge 由宿主控制面执行；Loom 只消费 required checks、review、head 绑定与 merge gate 结果
 
-## 4. `governance_surface` 公共合同
+## 4. Formal Spec Suite Path 消费边界
+
+`loom-story`、`loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+必须消费 `docs/methodology/templates/spec-suite.md` 已定义的
+`full suite` / `minimal suite` path decision，不得在 skill 中重新定义 suite
+工件、evidence-map、consistency-analysis 或 gate-chain 语义。
+
+固定消费规则：
+
+- `full path` 表示当前事项选择完整 formal spec suite。后续 skill 必须能读取
+  suite path locator、必需工件 locator、条件工件的适用性判断、provenance，以及
+  #1018/#1019 合同声明适用时的 evidence-map、consistency-analysis 与 gate-chain
+  消费结论。
+- `full path` 缺少必需工件、locator、provenance 或当前 gate 所需 evidence 时，
+  `loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+  必须 fail-closed，返回 `block` 或带明确 `fallback_to` 的 `fallback`。
+- `minimal path` 是合法路径，但只能通过带 rationale、consumer boundary 和
+  recheck condition 的 `not_applicable` 消费 full path 附加工件；无理由缺口仍是
+  `missing`，不得被当成 `not_applicable`。
+- `deferred` 不等于 `not_applicable`。deferred source/generated sync、CLI surface
+  或后续 FR 工作只能作为后续事项输入，不得被当前 skill 当成 completed truth。
+- GitHub issue、sub-issue、Project item、PR、checklist 或 repo-local carrier 只按
+  GitHub task carrier profile 读取 locator、state、provenance 和冲突状态；不得替代
+  Work Item、spec suite、review record 或 merge-ready truth。
+
+场景到消费边界：
+
+| Skill | full path 消费 | minimal path 消费 |
+| --- | --- | --- |
+| `loom-story` | 输出 Story Readiness / Business Confirmation locator，供 `spec.md` / `plan.md` 和 suite path decision 消费 | 对纯治理、维护、格式、链接类事项输出 `not_applicable` rationale、consumer boundary、recheck condition |
+| `loom-spec-review` | 消费 suite path、formal spec、plan、必需工件、evidence-map / consistency-analysis 适用性；缺必需输入时 fail-closed | 只接受有效 `not_applicable` rationale；否则回退到 spec shaping / suite path 修正 |
+| `loom-build` | 在 build readiness 前消费 full suite readiness、scenario-to-validation mapping、task carrier profile locator | 合法跳过附加工件，但必须保留 rationale 和替代验证入口 |
+| `loom-pre-review` | 在 review 前消费 full suite locator、evidence-map freshness、consistency-analysis blocking/advisory 分类 | 缺口必须是有效 `not_applicable`，否则阻断 review admission |
+| `loom-merge-ready` | 在 merge gate 消费 reviewed full suite evidence、gate-chain、PR head / reviewed head / validation freshness | 只把有效 minimal path rationale 当作合法跳过，不把 missing 或 deferred 当作 ready |
+
+## 5. `governance_surface` 公共合同
 
 以下三类入口对外暴露的公共治理读面固定命名为 `governance_surface`：
 
@@ -73,7 +108,7 @@
 - 只回答 locator 与职责边界，不复制实时停点、下一步、阻断项、验证摘要
 - 若需要回答 gate 进度，统一通过 `review_merge_surface` 或 `status control plane` 读取，不在 `governance_surface` 并行维护 authored gate 状态
 
-## 5. Planning 边界
+## 6. Planning 边界
 
 `delivery planning` 是 `loom-init` 的路由结果，不是 build、review 或 merge-ready 的前置硬门禁。
 
@@ -102,7 +137,7 @@ planning 输出只能包含：
 
 planning 输出不能声明某个 Work Item 已完成，不能替代 `spec.md` / `plan.md`，不能替代 review、merge-ready、closeout，也不能直接改写 GitHub，除非用户明确要求执行创建或更新动作。
 
-## 6. fallback 语义
+## 7. fallback 语义
 
 出现以下任一情况时，root skill 不做猜测，直接回退到 `loom-init`：
 

--- a/skills/loom-init/.loom-runtime/shared/references/templates/spec-suite.md
+++ b/skills/loom-init/.loom-runtime/shared/references/templates/spec-suite.md
@@ -18,6 +18,21 @@ Loom 当前把正式规约套件的最小内核定义为：
 
 这两个工件分别承担不同职责，不得混写。
 
+Formal spec path 有两条合法 suite path：
+
+- `minimal suite`
+  - 必含 `spec.md` 与 `plan.md`
+  - 适用于低风险、局部、纯治理或文档类事项
+  - 可用 `not_applicable` rationale 合法跳过 full path 附加工件
+- `full suite`
+  - 在 minimal suite 之上消费 suite-index、条件附加工件、evidence-map、
+    consistency-analysis 与 gate-chain consumption
+  - 适用于 formal spec、高风险、跨模块、强 review 或需要完整证据链的事项
+
+路径选择必须有 locator 与 provenance。若从 full path 降到 minimal path，必须说明
+附加工件为什么 `not_applicable`；若从 minimal path 升到 full path，必须说明触发信号
+和需要补齐的工件。
+
 ## 2. `spec.md` 最小要求
 
 `spec.md` 至少应表达：
@@ -58,6 +73,17 @@ Loom 当前把正式规约套件的最小内核定义为：
 - 不能自动化的行为必须声明人工验证路径、证据 locator 与 fresh 条件
 - 纯文档或治理规则变更可以不强制 TDD，但必须说明行为证据如何由结构检查、审查记录或示例消费
 
+映射状态必须可被后续 gate 消费：
+
+- `scenario_id` / scenario locator 映射到 automated、manual、structural 或
+  `not_applicable` validation strategy
+- `acceptance_id` / acceptance locator 映射到 test evidence、structural check、
+  manual evidence 或 `not_applicable`
+- full path 下，缺少 scenario -> validation 或 acceptance -> test mapping 默认阻断
+  build / review
+- minimal path 下，缺映射必须以 `not_applicable` rationale、替代验证入口和
+  recheck condition 解释
+
 ## 4. 套件边界规则
 
 Loom 必须区分：
@@ -74,6 +100,11 @@ Loom 当前不固化：
 
 - 所有项目都必须有同一组附加工件
 - `TODO.md` 或同类文件是永恒必选项
+
+Full path 缺少必需工件、locator、provenance 或 gate 所需 evidence 时必须
+fail-closed。Minimal path 缺少 full path 附加工件时，只有同时具备 rationale、
+consumer boundary 与 recheck condition 的 `not_applicable` 才能消解；无理由缺口
+仍是 `missing`。`deferred` 不等于 `not_applicable`，不得作为 completed truth 消费。
 
 ## 5. 行为证据与测试证据
 

--- a/skills/loom-merge-ready/.loom-runtime/loom-build/SKILL.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-build/SKILL.md
@@ -55,10 +55,21 @@ subagent-driven mode 必须先声明以下字段：
 - 多个委派声明重叠 `write_ownership`
 - 多轮或多个委派报告同一 blocker signature
 - 缺少 Work Item、spec、plan、recovery、validation baseline、workspace 或 ownership constraints
+- 选择 full path 但 suite-index、必需 suite 工件、scenario-to-validation mapping、
+  task carrier profile locator、provenance 或当前 build gate 所需 evidence 缺失
+- 选择 minimal path 但 full path 附加工件缺口没有 `not_applicable` rationale、
+  consumer boundary、recheck condition 或替代验证入口
+- 把 `deferred`、source/generated sync 待办或 CLI surface 待办当作 build readiness
+  的 completed truth
 
 ## 5. 完成标准
 
 只有当 `flow build` 返回 pass，且 build evidence 证明所有委派输出已集成、无 ownership overlap、无 repeated blocker 时，才允许继续进入 pre-review / review。
+
+Build readiness 只消费 full/minimal suite path 决策，不重新定义 suite 工件、
+evidence-map、consistency-analysis 或 gate-chain。full path 必须证明必需工件可读且
+fresh；minimal path 必须保留合法 `not_applicable` rationale，并把 recheck condition
+传递给后续 pre-review / review。
 
 输入信号与输出合同见：
 

--- a/skills/loom-merge-ready/.loom-runtime/loom-build/references/input-signals.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-build/references/input-signals.md
@@ -14,4 +14,6 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - Work Item、spec、plan、recovery baseline、validation baseline、workspace 和 ownership constraints
+- suite path decision：full path 的 suite / evidence locators，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition 与替代验证入口
 - 若使用 subagent-driven mode，必须提供 delegation/build evidence locator

--- a/skills/loom-merge-ready/.loom-runtime/loom-build/references/output-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-build/references/output-contract.md
@@ -26,6 +26,12 @@
   - `integration_evidence`
   - `ownership_conflicts`
   - `repeated_blocker_signal`
+- `suite_path_consumption`
+  - full path 的必需工件、scenario-to-validation mapping、task carrier locator 与
+    provenance 是否可读
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+    与替代验证入口
+  - 缺失、stale、conflict 或无理由跳过时必须阻断 build readiness
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> build-execution` 顺序列出
 

--- a/skills/loom-merge-ready/.loom-runtime/loom-merge-ready/SKILL.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-merge-ready/SKILL.md
@@ -17,6 +17,14 @@ description: 负责 merge 前统一放行。Use when Codex needs to confirm whet
 - 只输出进入 `GitHub controlled merge` 前的统一放行摘要，不替代宿主平台 merge 动作
 - PR 合并前的宿主硬门禁由 `pr-gate check` 和 `controlled-merge check|merge` 承接；它们只能消费 authored Loom review record，不能把 raw review/shadow evidence 当作 approval
 - 不新建 authored 真相源，也不直接执行平台合并
+- 消费 full/minimal suite path、evidence-map freshness、consistency-analysis
+  classification 与 gate-chain 当前状态，但不重新定义这些合同
+- full path 下，review record 必须证明已消费 suite locators、evidence-map、
+  consistency-analysis、PR head / reviewed head / validation freshness；缺失、stale 或
+  conflict 必须 fail-closed
+- minimal path 下，只有带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable` 可以跳过 full path 附加工件；missing、deferred 或 source/generated
+  sync 待办不能被当作 merge-ready
 
 输入信号与输出合同见：
 

--- a/skills/loom-merge-ready/.loom-runtime/loom-merge-ready/references/input-signals.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-merge-ready/references/input-signals.md
@@ -6,3 +6,11 @@
 - 最终放行前预检
 - 确认当前事项是否可合并
 - 确认 `GitHub controlled merge` 前置是否齐全
+
+最小输入：
+
+- 目标仓库
+- 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 reviewed suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+- PR locator、head SHA、reviewed head 与 validation freshness 证据

--- a/skills/loom-merge-ready/.loom-runtime/loom-merge-ready/references/output-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-merge-ready/references/output-contract.md
@@ -28,6 +28,11 @@
   - `loom-governance-lint-status/v1` 派生证据；只消费 fact-chain 与 repo companion 的 blocking/advisory lint result，不替代 authored review record、merge checkpoint 或 host merge truth
 - `gate_chain`
   - `spec_gate`、`build_gate`、`review_gate`、`merge_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - full path 的 suite readiness、evidence-map、consistency-analysis、reviewed
+    locators、PR head / reviewed head / validation freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - missing、stale、conflict、deferred 或无理由跳过必须进入 `missing_inputs`
 - `github_controlled_merge`
   - required checks、branch protection、merge method 与 host merge 前置状态
 - `retained_host_signals`

--- a/skills/loom-merge-ready/.loom-runtime/loom-pre-review/SKILL.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-pre-review/SKILL.md
@@ -43,6 +43,7 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 不替代 reviewer 的语义判断
 - 不直接执行 merge
 - 不回写事实链、恢复入口或状态面
+- 不重新定义 full/minimal suite、evidence-map、consistency-analysis 或 gate-chain
 
 ## 4. 输出要求
 
@@ -53,6 +54,10 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 哪一步阻断了继续进入 review
 - 若阻断，应回退到哪里
 - 当前 steps 的机械结果是什么
+- full path 的 suite locator、evidence-map freshness 与 consistency-analysis
+  blocking/advisory 分类是否已经可供 review 消费
+- minimal path 的 `not_applicable` rationale、consumer boundary 与 recheck condition
+  是否足够；不足时必须 fail-closed，不能进入 review
 
 ## 5. 完成标准
 
@@ -62,6 +67,9 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - `flow pre-review` 的步骤顺序稳定为 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate`
 - 输出 JSON 能直接支撑“是否进入 review 前语义审查”的判断
 - skill 自身不复制治理真相，也不冒充 reviewer 结论
+- full path 缺少必需 suite artifact、provenance、fresh evidence 或存在 blocking
+  consistency gap 时返回 `block` / `fallback`
+- minimal path 只有在缺口具备有效 `not_applicable` rationale 时才允许进入 review
 
 输入信号与输出合同见：
 

--- a/skills/loom-merge-ready/.loom-runtime/loom-pre-review/references/input-signals.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-pre-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前 review 意图
 - 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-merge-ready/.loom-runtime/loom-pre-review/references/output-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-pre-review/references/output-contract.md
@@ -16,6 +16,11 @@
   - 当前 Loom 入口自己的 scene / carrier 判定，以及 fail-closed 原因
 - `governance_lint`
   - `loom-governance-lint-status/v1` 派生证据；blocking lint 进入 `missing_inputs`，advisory lint 只进入风险摘要，不产生 reviewer 结论
+- `suite_path_consumption`
+  - full path 的 required artifacts、evidence-map freshness、consistency-analysis
+    blocking/advisory 分类
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - full path 缺必需输入或 minimal path 无有效 rationale 时必须 fail-closed
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> governance-lint` 顺序列出
 

--- a/skills/loom-merge-ready/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-spec-review/SKILL.md
@@ -39,6 +39,12 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - formal spec 路径不存在时，`flow spec-review` 必须 fail-closed
 - spec review 只写回单一 spec review record，不替代 implementation review record
 - `reviewed_head` 与 stale 语义必须显式暴露，供后续 gate 消费
+- full path 必须消费 suite path locator、必需工件 locator、provenance，以及
+  evidence-map / consistency-analysis / gate-chain 适用性结论；缺失或不可读时
+  fail-closed，回退到 spec shaping 或 suite path 修正
+- minimal path 只能消费带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable`；无理由缺口、`deferred` 或 source/generated sync 待办不得被当作
+  spec gate 通过
 
 ## 3. 固定编排
 
@@ -57,6 +63,9 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
 - 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不重新定义 full suite、minimal suite、evidence-map、consistency-analysis 或
+  gate-chain 语义；只消费这些合同已经定义的 locator、freshness、classification
+  与 fallback 边界
 
 ## 4. 输出要求
 
@@ -66,6 +75,8 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - spec review 的机械基线结果
 - spec review record 的定位与当前结论
 - reviewed head 绑定、当前 head、是否 stale
+- suite path decision，以及 full path readiness 或 minimal path `not_applicable`
+  rationale 是否可被 spec gate 消费
 - 审查结论（`allow` / `block` / `fallback`）
 - 若当前不能继续，应回退到哪里
 

--- a/skills/loom-merge-ready/.loom-runtime/loom-spec-review/references/input-signals.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-spec-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - formal spec 路径或明确的 spec review 意图
+- suite path decision：full path 的必需工件 locator，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-merge-ready/.loom-runtime/loom-spec-review/references/output-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-spec-review/references/output-contract.md
@@ -22,6 +22,11 @@
   - `checkpoint build` 的结果、摘要、阻断项与回退去向
 - `gate_chain`
   - `spec_gate`、`build_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - `path: full|minimal`
+  - full path 的 suite locator、required artifact locators、provenance 与 freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - 无理由 missing、stale、conflict 或 deferred 输入必须进入 `missing_inputs`
 - `spec_review`
   - formal spec 路径、spec review record、head 绑定、stale 语义与当前 gate 结论
 - `spec_review_authority_migration`

--- a/skills/loom-merge-ready/.loom-runtime/loom-story/SKILL.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-story/SKILL.md
@@ -85,6 +85,21 @@ User Story 主体不得包含 delivery handoff、spec locator、plan locator、r
 - `Work Item` 仍是唯一执行入口
 - issue tree、Phase / FR / Work Item / PR 切分、blocked-by/blocks 与 host carrier mapping 由 `loom-init` 的 delivery planning 路由承接
 
+## 6. Full / Minimal Suite Path 边界
+
+`loom-story` 不选择或重定义 full/minimal suite path；它只产出可被
+`spec-suite` 消费的 story readiness 与 business confirmation 输入。
+
+- full path：若 formal spec path 消费 story，必须输出 Story Readiness 与 Story
+  Business Confirmation locator，且 decision 为 `confirmed` 或明确
+  `not_applicable`。`pending` / `revision-requested` 必须 fail closed，回到 story
+  shaping 或等待业务语义确认。
+- minimal path：纯治理、维护、格式、链接修复或载体整理可以输出
+  `not_applicable`，但必须包含 bypass rationale、consumer boundary 和 recheck
+  condition，供 `spec.md`、`plan.md`、evidence-map 与后续 gate 消费。
+- `loom-story` 不把 `not_applicable` 升级成产品确认，不生成 evidence-map、
+  consistency-analysis、review、merge-ready 或 GitHub closeout truth。
+
 输入信号与输出合同见：
 
 - [references/input-signals.md](./references/input-signals.md)

--- a/skills/loom-merge-ready/.loom-runtime/loom-story/references/output-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/loom-story/references/output-contract.md
@@ -28,6 +28,8 @@
   - story scenario 到 `plan.md` validation strategy 的映射
   - spec / plan 只消费已 `confirmed` 或明确 `not_applicable` 的 story 语义
   - 任何 `pending` 或 `revision-requested` 的 readiness / confirmation 都必须 fail closed，阻止 formal spec shaping
+  - full path 需要可消费的 readiness / confirmation locator；minimal path 需要
+    `not_applicable` rationale、consumer boundary 和 recheck condition
   - `Work Item` 仍是唯一执行入口
 - `missing_inputs`
   - 当前阻断 story shaping 的缺口；无阻断时为空数组

--- a/skills/loom-merge-ready/.loom-runtime/route-matrix.md
+++ b/skills/loom-merge-ready/.loom-runtime/route-matrix.md
@@ -45,7 +45,42 @@
 - `GitHub controlled merge`
   - merge 由宿主控制面执行；Loom 只消费 required checks、review、head 绑定与 merge gate 结果
 
-## 4. `governance_surface` 公共合同
+## 4. Formal Spec Suite Path 消费边界
+
+`loom-story`、`loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+必须消费 `docs/methodology/templates/spec-suite.md` 已定义的
+`full suite` / `minimal suite` path decision，不得在 skill 中重新定义 suite
+工件、evidence-map、consistency-analysis 或 gate-chain 语义。
+
+固定消费规则：
+
+- `full path` 表示当前事项选择完整 formal spec suite。后续 skill 必须能读取
+  suite path locator、必需工件 locator、条件工件的适用性判断、provenance，以及
+  #1018/#1019 合同声明适用时的 evidence-map、consistency-analysis 与 gate-chain
+  消费结论。
+- `full path` 缺少必需工件、locator、provenance 或当前 gate 所需 evidence 时，
+  `loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+  必须 fail-closed，返回 `block` 或带明确 `fallback_to` 的 `fallback`。
+- `minimal path` 是合法路径，但只能通过带 rationale、consumer boundary 和
+  recheck condition 的 `not_applicable` 消费 full path 附加工件；无理由缺口仍是
+  `missing`，不得被当成 `not_applicable`。
+- `deferred` 不等于 `not_applicable`。deferred source/generated sync、CLI surface
+  或后续 FR 工作只能作为后续事项输入，不得被当前 skill 当成 completed truth。
+- GitHub issue、sub-issue、Project item、PR、checklist 或 repo-local carrier 只按
+  GitHub task carrier profile 读取 locator、state、provenance 和冲突状态；不得替代
+  Work Item、spec suite、review record 或 merge-ready truth。
+
+场景到消费边界：
+
+| Skill | full path 消费 | minimal path 消费 |
+| --- | --- | --- |
+| `loom-story` | 输出 Story Readiness / Business Confirmation locator，供 `spec.md` / `plan.md` 和 suite path decision 消费 | 对纯治理、维护、格式、链接类事项输出 `not_applicable` rationale、consumer boundary、recheck condition |
+| `loom-spec-review` | 消费 suite path、formal spec、plan、必需工件、evidence-map / consistency-analysis 适用性；缺必需输入时 fail-closed | 只接受有效 `not_applicable` rationale；否则回退到 spec shaping / suite path 修正 |
+| `loom-build` | 在 build readiness 前消费 full suite readiness、scenario-to-validation mapping、task carrier profile locator | 合法跳过附加工件，但必须保留 rationale 和替代验证入口 |
+| `loom-pre-review` | 在 review 前消费 full suite locator、evidence-map freshness、consistency-analysis blocking/advisory 分类 | 缺口必须是有效 `not_applicable`，否则阻断 review admission |
+| `loom-merge-ready` | 在 merge gate 消费 reviewed full suite evidence、gate-chain、PR head / reviewed head / validation freshness | 只把有效 minimal path rationale 当作合法跳过，不把 missing 或 deferred 当作 ready |
+
+## 5. `governance_surface` 公共合同
 
 以下三类入口对外暴露的公共治理读面固定命名为 `governance_surface`：
 
@@ -73,7 +108,7 @@
 - 只回答 locator 与职责边界，不复制实时停点、下一步、阻断项、验证摘要
 - 若需要回答 gate 进度，统一通过 `review_merge_surface` 或 `status control plane` 读取，不在 `governance_surface` 并行维护 authored gate 状态
 
-## 5. Planning 边界
+## 6. Planning 边界
 
 `delivery planning` 是 `loom-init` 的路由结果，不是 build、review 或 merge-ready 的前置硬门禁。
 
@@ -102,7 +137,7 @@ planning 输出只能包含：
 
 planning 输出不能声明某个 Work Item 已完成，不能替代 `spec.md` / `plan.md`，不能替代 review、merge-ready、closeout，也不能直接改写 GitHub，除非用户明确要求执行创建或更新动作。
 
-## 6. fallback 语义
+## 7. fallback 语义
 
 出现以下任一情况时，root skill 不做猜测，直接回退到 `loom-init`：
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/templates/spec-suite.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/templates/spec-suite.md
@@ -18,6 +18,21 @@ Loom 当前把正式规约套件的最小内核定义为：
 
 这两个工件分别承担不同职责，不得混写。
 
+Formal spec path 有两条合法 suite path：
+
+- `minimal suite`
+  - 必含 `spec.md` 与 `plan.md`
+  - 适用于低风险、局部、纯治理或文档类事项
+  - 可用 `not_applicable` rationale 合法跳过 full path 附加工件
+- `full suite`
+  - 在 minimal suite 之上消费 suite-index、条件附加工件、evidence-map、
+    consistency-analysis 与 gate-chain consumption
+  - 适用于 formal spec、高风险、跨模块、强 review 或需要完整证据链的事项
+
+路径选择必须有 locator 与 provenance。若从 full path 降到 minimal path，必须说明
+附加工件为什么 `not_applicable`；若从 minimal path 升到 full path，必须说明触发信号
+和需要补齐的工件。
+
 ## 2. `spec.md` 最小要求
 
 `spec.md` 至少应表达：
@@ -58,6 +73,17 @@ Loom 当前把正式规约套件的最小内核定义为：
 - 不能自动化的行为必须声明人工验证路径、证据 locator 与 fresh 条件
 - 纯文档或治理规则变更可以不强制 TDD，但必须说明行为证据如何由结构检查、审查记录或示例消费
 
+映射状态必须可被后续 gate 消费：
+
+- `scenario_id` / scenario locator 映射到 automated、manual、structural 或
+  `not_applicable` validation strategy
+- `acceptance_id` / acceptance locator 映射到 test evidence、structural check、
+  manual evidence 或 `not_applicable`
+- full path 下，缺少 scenario -> validation 或 acceptance -> test mapping 默认阻断
+  build / review
+- minimal path 下，缺映射必须以 `not_applicable` rationale、替代验证入口和
+  recheck condition 解释
+
 ## 4. 套件边界规则
 
 Loom 必须区分：
@@ -74,6 +100,11 @@ Loom 当前不固化：
 
 - 所有项目都必须有同一组附加工件
 - `TODO.md` 或同类文件是永恒必选项
+
+Full path 缺少必需工件、locator、provenance 或 gate 所需 evidence 时必须
+fail-closed。Minimal path 缺少 full path 附加工件时，只有同时具备 rationale、
+consumer boundary 与 recheck condition 的 `not_applicable` 才能消解；无理由缺口
+仍是 `missing`。`deferred` 不等于 `not_applicable`，不得作为 completed truth 消费。
 
 ## 5. 行为证据与测试证据
 

--- a/skills/loom-merge-ready/SKILL.md
+++ b/skills/loom-merge-ready/SKILL.md
@@ -17,6 +17,14 @@ description: 负责 merge 前统一放行。Use when Codex needs to confirm whet
 - 只输出进入 `GitHub controlled merge` 前的统一放行摘要，不替代宿主平台 merge 动作
 - PR 合并前的宿主硬门禁由 `pr-gate check` 和 `controlled-merge check|merge` 承接；它们只能消费 authored Loom review record，不能把 raw review/shadow evidence 当作 approval
 - 不新建 authored 真相源，也不直接执行平台合并
+- 消费 full/minimal suite path、evidence-map freshness、consistency-analysis
+  classification 与 gate-chain 当前状态，但不重新定义这些合同
+- full path 下，review record 必须证明已消费 suite locators、evidence-map、
+  consistency-analysis、PR head / reviewed head / validation freshness；缺失、stale 或
+  conflict 必须 fail-closed
+- minimal path 下，只有带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable` 可以跳过 full path 附加工件；missing、deferred 或 source/generated
+  sync 待办不能被当作 merge-ready
 
 输入信号与输出合同见：
 

--- a/skills/loom-merge-ready/references/input-signals.md
+++ b/skills/loom-merge-ready/references/input-signals.md
@@ -6,3 +6,11 @@
 - 最终放行前预检
 - 确认当前事项是否可合并
 - 确认 `GitHub controlled merge` 前置是否齐全
+
+最小输入：
+
+- 目标仓库
+- 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 reviewed suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+- PR locator、head SHA、reviewed head 与 validation freshness 证据

--- a/skills/loom-merge-ready/references/output-contract.md
+++ b/skills/loom-merge-ready/references/output-contract.md
@@ -28,6 +28,11 @@
   - `loom-governance-lint-status/v1` 派生证据；只消费 fact-chain 与 repo companion 的 blocking/advisory lint result，不替代 authored review record、merge checkpoint 或 host merge truth
 - `gate_chain`
   - `spec_gate`、`build_gate`、`review_gate`、`merge_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - full path 的 suite readiness、evidence-map、consistency-analysis、reviewed
+    locators、PR head / reviewed head / validation freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - missing、stale、conflict、deferred 或无理由跳过必须进入 `missing_inputs`
 - `github_controlled_merge`
   - required checks、branch protection、merge method 与 host merge 前置状态
 - `retained_host_signals`

--- a/skills/loom-pre-review/.loom-runtime/loom-build/SKILL.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-build/SKILL.md
@@ -55,10 +55,21 @@ subagent-driven mode 必须先声明以下字段：
 - 多个委派声明重叠 `write_ownership`
 - 多轮或多个委派报告同一 blocker signature
 - 缺少 Work Item、spec、plan、recovery、validation baseline、workspace 或 ownership constraints
+- 选择 full path 但 suite-index、必需 suite 工件、scenario-to-validation mapping、
+  task carrier profile locator、provenance 或当前 build gate 所需 evidence 缺失
+- 选择 minimal path 但 full path 附加工件缺口没有 `not_applicable` rationale、
+  consumer boundary、recheck condition 或替代验证入口
+- 把 `deferred`、source/generated sync 待办或 CLI surface 待办当作 build readiness
+  的 completed truth
 
 ## 5. 完成标准
 
 只有当 `flow build` 返回 pass，且 build evidence 证明所有委派输出已集成、无 ownership overlap、无 repeated blocker 时，才允许继续进入 pre-review / review。
+
+Build readiness 只消费 full/minimal suite path 决策，不重新定义 suite 工件、
+evidence-map、consistency-analysis 或 gate-chain。full path 必须证明必需工件可读且
+fresh；minimal path 必须保留合法 `not_applicable` rationale，并把 recheck condition
+传递给后续 pre-review / review。
 
 输入信号与输出合同见：
 

--- a/skills/loom-pre-review/.loom-runtime/loom-build/references/input-signals.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-build/references/input-signals.md
@@ -14,4 +14,6 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - Work Item、spec、plan、recovery baseline、validation baseline、workspace 和 ownership constraints
+- suite path decision：full path 的 suite / evidence locators，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition 与替代验证入口
 - 若使用 subagent-driven mode，必须提供 delegation/build evidence locator

--- a/skills/loom-pre-review/.loom-runtime/loom-build/references/output-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-build/references/output-contract.md
@@ -26,6 +26,12 @@
   - `integration_evidence`
   - `ownership_conflicts`
   - `repeated_blocker_signal`
+- `suite_path_consumption`
+  - full path 的必需工件、scenario-to-validation mapping、task carrier locator 与
+    provenance 是否可读
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+    与替代验证入口
+  - 缺失、stale、conflict 或无理由跳过时必须阻断 build readiness
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> build-execution` 顺序列出
 

--- a/skills/loom-pre-review/.loom-runtime/loom-merge-ready/SKILL.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-merge-ready/SKILL.md
@@ -17,6 +17,14 @@ description: 负责 merge 前统一放行。Use when Codex needs to confirm whet
 - 只输出进入 `GitHub controlled merge` 前的统一放行摘要，不替代宿主平台 merge 动作
 - PR 合并前的宿主硬门禁由 `pr-gate check` 和 `controlled-merge check|merge` 承接；它们只能消费 authored Loom review record，不能把 raw review/shadow evidence 当作 approval
 - 不新建 authored 真相源，也不直接执行平台合并
+- 消费 full/minimal suite path、evidence-map freshness、consistency-analysis
+  classification 与 gate-chain 当前状态，但不重新定义这些合同
+- full path 下，review record 必须证明已消费 suite locators、evidence-map、
+  consistency-analysis、PR head / reviewed head / validation freshness；缺失、stale 或
+  conflict 必须 fail-closed
+- minimal path 下，只有带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable` 可以跳过 full path 附加工件；missing、deferred 或 source/generated
+  sync 待办不能被当作 merge-ready
 
 输入信号与输出合同见：
 

--- a/skills/loom-pre-review/.loom-runtime/loom-merge-ready/references/input-signals.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-merge-ready/references/input-signals.md
@@ -6,3 +6,11 @@
 - 最终放行前预检
 - 确认当前事项是否可合并
 - 确认 `GitHub controlled merge` 前置是否齐全
+
+最小输入：
+
+- 目标仓库
+- 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 reviewed suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+- PR locator、head SHA、reviewed head 与 validation freshness 证据

--- a/skills/loom-pre-review/.loom-runtime/loom-merge-ready/references/output-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-merge-ready/references/output-contract.md
@@ -28,6 +28,11 @@
   - `loom-governance-lint-status/v1` 派生证据；只消费 fact-chain 与 repo companion 的 blocking/advisory lint result，不替代 authored review record、merge checkpoint 或 host merge truth
 - `gate_chain`
   - `spec_gate`、`build_gate`、`review_gate`、`merge_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - full path 的 suite readiness、evidence-map、consistency-analysis、reviewed
+    locators、PR head / reviewed head / validation freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - missing、stale、conflict、deferred 或无理由跳过必须进入 `missing_inputs`
 - `github_controlled_merge`
   - required checks、branch protection、merge method 与 host merge 前置状态
 - `retained_host_signals`

--- a/skills/loom-pre-review/.loom-runtime/loom-pre-review/SKILL.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-pre-review/SKILL.md
@@ -43,6 +43,7 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 不替代 reviewer 的语义判断
 - 不直接执行 merge
 - 不回写事实链、恢复入口或状态面
+- 不重新定义 full/minimal suite、evidence-map、consistency-analysis 或 gate-chain
 
 ## 4. 输出要求
 
@@ -53,6 +54,10 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 哪一步阻断了继续进入 review
 - 若阻断，应回退到哪里
 - 当前 steps 的机械结果是什么
+- full path 的 suite locator、evidence-map freshness 与 consistency-analysis
+  blocking/advisory 分类是否已经可供 review 消费
+- minimal path 的 `not_applicable` rationale、consumer boundary 与 recheck condition
+  是否足够；不足时必须 fail-closed，不能进入 review
 
 ## 5. 完成标准
 
@@ -62,6 +67,9 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - `flow pre-review` 的步骤顺序稳定为 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate`
 - 输出 JSON 能直接支撑“是否进入 review 前语义审查”的判断
 - skill 自身不复制治理真相，也不冒充 reviewer 结论
+- full path 缺少必需 suite artifact、provenance、fresh evidence 或存在 blocking
+  consistency gap 时返回 `block` / `fallback`
+- minimal path 只有在缺口具备有效 `not_applicable` rationale 时才允许进入 review
 
 输入信号与输出合同见：
 

--- a/skills/loom-pre-review/.loom-runtime/loom-pre-review/references/input-signals.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-pre-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前 review 意图
 - 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-pre-review/.loom-runtime/loom-pre-review/references/output-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-pre-review/references/output-contract.md
@@ -16,6 +16,11 @@
   - 当前 Loom 入口自己的 scene / carrier 判定，以及 fail-closed 原因
 - `governance_lint`
   - `loom-governance-lint-status/v1` 派生证据；blocking lint 进入 `missing_inputs`，advisory lint 只进入风险摘要，不产生 reviewer 结论
+- `suite_path_consumption`
+  - full path 的 required artifacts、evidence-map freshness、consistency-analysis
+    blocking/advisory 分类
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - full path 缺必需输入或 minimal path 无有效 rationale 时必须 fail-closed
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> governance-lint` 顺序列出
 

--- a/skills/loom-pre-review/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-spec-review/SKILL.md
@@ -39,6 +39,12 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - formal spec 路径不存在时，`flow spec-review` 必须 fail-closed
 - spec review 只写回单一 spec review record，不替代 implementation review record
 - `reviewed_head` 与 stale 语义必须显式暴露，供后续 gate 消费
+- full path 必须消费 suite path locator、必需工件 locator、provenance，以及
+  evidence-map / consistency-analysis / gate-chain 适用性结论；缺失或不可读时
+  fail-closed，回退到 spec shaping 或 suite path 修正
+- minimal path 只能消费带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable`；无理由缺口、`deferred` 或 source/generated sync 待办不得被当作
+  spec gate 通过
 
 ## 3. 固定编排
 
@@ -57,6 +63,9 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
 - 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不重新定义 full suite、minimal suite、evidence-map、consistency-analysis 或
+  gate-chain 语义；只消费这些合同已经定义的 locator、freshness、classification
+  与 fallback 边界
 
 ## 4. 输出要求
 
@@ -66,6 +75,8 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - spec review 的机械基线结果
 - spec review record 的定位与当前结论
 - reviewed head 绑定、当前 head、是否 stale
+- suite path decision，以及 full path readiness 或 minimal path `not_applicable`
+  rationale 是否可被 spec gate 消费
 - 审查结论（`allow` / `block` / `fallback`）
 - 若当前不能继续，应回退到哪里
 

--- a/skills/loom-pre-review/.loom-runtime/loom-spec-review/references/input-signals.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-spec-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - formal spec 路径或明确的 spec review 意图
+- suite path decision：full path 的必需工件 locator，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-pre-review/.loom-runtime/loom-spec-review/references/output-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-spec-review/references/output-contract.md
@@ -22,6 +22,11 @@
   - `checkpoint build` 的结果、摘要、阻断项与回退去向
 - `gate_chain`
   - `spec_gate`、`build_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - `path: full|minimal`
+  - full path 的 suite locator、required artifact locators、provenance 与 freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - 无理由 missing、stale、conflict 或 deferred 输入必须进入 `missing_inputs`
 - `spec_review`
   - formal spec 路径、spec review record、head 绑定、stale 语义与当前 gate 结论
 - `spec_review_authority_migration`

--- a/skills/loom-pre-review/.loom-runtime/loom-story/SKILL.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-story/SKILL.md
@@ -85,6 +85,21 @@ User Story 主体不得包含 delivery handoff、spec locator、plan locator、r
 - `Work Item` 仍是唯一执行入口
 - issue tree、Phase / FR / Work Item / PR 切分、blocked-by/blocks 与 host carrier mapping 由 `loom-init` 的 delivery planning 路由承接
 
+## 6. Full / Minimal Suite Path 边界
+
+`loom-story` 不选择或重定义 full/minimal suite path；它只产出可被
+`spec-suite` 消费的 story readiness 与 business confirmation 输入。
+
+- full path：若 formal spec path 消费 story，必须输出 Story Readiness 与 Story
+  Business Confirmation locator，且 decision 为 `confirmed` 或明确
+  `not_applicable`。`pending` / `revision-requested` 必须 fail closed，回到 story
+  shaping 或等待业务语义确认。
+- minimal path：纯治理、维护、格式、链接修复或载体整理可以输出
+  `not_applicable`，但必须包含 bypass rationale、consumer boundary 和 recheck
+  condition，供 `spec.md`、`plan.md`、evidence-map 与后续 gate 消费。
+- `loom-story` 不把 `not_applicable` 升级成产品确认，不生成 evidence-map、
+  consistency-analysis、review、merge-ready 或 GitHub closeout truth。
+
 输入信号与输出合同见：
 
 - [references/input-signals.md](./references/input-signals.md)

--- a/skills/loom-pre-review/.loom-runtime/loom-story/references/output-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/loom-story/references/output-contract.md
@@ -28,6 +28,8 @@
   - story scenario 到 `plan.md` validation strategy 的映射
   - spec / plan 只消费已 `confirmed` 或明确 `not_applicable` 的 story 语义
   - 任何 `pending` 或 `revision-requested` 的 readiness / confirmation 都必须 fail closed，阻止 formal spec shaping
+  - full path 需要可消费的 readiness / confirmation locator；minimal path 需要
+    `not_applicable` rationale、consumer boundary 和 recheck condition
   - `Work Item` 仍是唯一执行入口
 - `missing_inputs`
   - 当前阻断 story shaping 的缺口；无阻断时为空数组

--- a/skills/loom-pre-review/.loom-runtime/route-matrix.md
+++ b/skills/loom-pre-review/.loom-runtime/route-matrix.md
@@ -45,7 +45,42 @@
 - `GitHub controlled merge`
   - merge 由宿主控制面执行；Loom 只消费 required checks、review、head 绑定与 merge gate 结果
 
-## 4. `governance_surface` 公共合同
+## 4. Formal Spec Suite Path 消费边界
+
+`loom-story`、`loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+必须消费 `docs/methodology/templates/spec-suite.md` 已定义的
+`full suite` / `minimal suite` path decision，不得在 skill 中重新定义 suite
+工件、evidence-map、consistency-analysis 或 gate-chain 语义。
+
+固定消费规则：
+
+- `full path` 表示当前事项选择完整 formal spec suite。后续 skill 必须能读取
+  suite path locator、必需工件 locator、条件工件的适用性判断、provenance，以及
+  #1018/#1019 合同声明适用时的 evidence-map、consistency-analysis 与 gate-chain
+  消费结论。
+- `full path` 缺少必需工件、locator、provenance 或当前 gate 所需 evidence 时，
+  `loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+  必须 fail-closed，返回 `block` 或带明确 `fallback_to` 的 `fallback`。
+- `minimal path` 是合法路径，但只能通过带 rationale、consumer boundary 和
+  recheck condition 的 `not_applicable` 消费 full path 附加工件；无理由缺口仍是
+  `missing`，不得被当成 `not_applicable`。
+- `deferred` 不等于 `not_applicable`。deferred source/generated sync、CLI surface
+  或后续 FR 工作只能作为后续事项输入，不得被当前 skill 当成 completed truth。
+- GitHub issue、sub-issue、Project item、PR、checklist 或 repo-local carrier 只按
+  GitHub task carrier profile 读取 locator、state、provenance 和冲突状态；不得替代
+  Work Item、spec suite、review record 或 merge-ready truth。
+
+场景到消费边界：
+
+| Skill | full path 消费 | minimal path 消费 |
+| --- | --- | --- |
+| `loom-story` | 输出 Story Readiness / Business Confirmation locator，供 `spec.md` / `plan.md` 和 suite path decision 消费 | 对纯治理、维护、格式、链接类事项输出 `not_applicable` rationale、consumer boundary、recheck condition |
+| `loom-spec-review` | 消费 suite path、formal spec、plan、必需工件、evidence-map / consistency-analysis 适用性；缺必需输入时 fail-closed | 只接受有效 `not_applicable` rationale；否则回退到 spec shaping / suite path 修正 |
+| `loom-build` | 在 build readiness 前消费 full suite readiness、scenario-to-validation mapping、task carrier profile locator | 合法跳过附加工件，但必须保留 rationale 和替代验证入口 |
+| `loom-pre-review` | 在 review 前消费 full suite locator、evidence-map freshness、consistency-analysis blocking/advisory 分类 | 缺口必须是有效 `not_applicable`，否则阻断 review admission |
+| `loom-merge-ready` | 在 merge gate 消费 reviewed full suite evidence、gate-chain、PR head / reviewed head / validation freshness | 只把有效 minimal path rationale 当作合法跳过，不把 missing 或 deferred 当作 ready |
+
+## 5. `governance_surface` 公共合同
 
 以下三类入口对外暴露的公共治理读面固定命名为 `governance_surface`：
 
@@ -73,7 +108,7 @@
 - 只回答 locator 与职责边界，不复制实时停点、下一步、阻断项、验证摘要
 - 若需要回答 gate 进度，统一通过 `review_merge_surface` 或 `status control plane` 读取，不在 `governance_surface` 并行维护 authored gate 状态
 
-## 5. Planning 边界
+## 6. Planning 边界
 
 `delivery planning` 是 `loom-init` 的路由结果，不是 build、review 或 merge-ready 的前置硬门禁。
 
@@ -102,7 +137,7 @@ planning 输出只能包含：
 
 planning 输出不能声明某个 Work Item 已完成，不能替代 `spec.md` / `plan.md`，不能替代 review、merge-ready、closeout，也不能直接改写 GitHub，除非用户明确要求执行创建或更新动作。
 
-## 6. fallback 语义
+## 7. fallback 语义
 
 出现以下任一情况时，root skill 不做猜测，直接回退到 `loom-init`：
 

--- a/skills/loom-pre-review/.loom-runtime/shared/references/templates/spec-suite.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/templates/spec-suite.md
@@ -18,6 +18,21 @@ Loom 当前把正式规约套件的最小内核定义为：
 
 这两个工件分别承担不同职责，不得混写。
 
+Formal spec path 有两条合法 suite path：
+
+- `minimal suite`
+  - 必含 `spec.md` 与 `plan.md`
+  - 适用于低风险、局部、纯治理或文档类事项
+  - 可用 `not_applicable` rationale 合法跳过 full path 附加工件
+- `full suite`
+  - 在 minimal suite 之上消费 suite-index、条件附加工件、evidence-map、
+    consistency-analysis 与 gate-chain consumption
+  - 适用于 formal spec、高风险、跨模块、强 review 或需要完整证据链的事项
+
+路径选择必须有 locator 与 provenance。若从 full path 降到 minimal path，必须说明
+附加工件为什么 `not_applicable`；若从 minimal path 升到 full path，必须说明触发信号
+和需要补齐的工件。
+
 ## 2. `spec.md` 最小要求
 
 `spec.md` 至少应表达：
@@ -58,6 +73,17 @@ Loom 当前把正式规约套件的最小内核定义为：
 - 不能自动化的行为必须声明人工验证路径、证据 locator 与 fresh 条件
 - 纯文档或治理规则变更可以不强制 TDD，但必须说明行为证据如何由结构检查、审查记录或示例消费
 
+映射状态必须可被后续 gate 消费：
+
+- `scenario_id` / scenario locator 映射到 automated、manual、structural 或
+  `not_applicable` validation strategy
+- `acceptance_id` / acceptance locator 映射到 test evidence、structural check、
+  manual evidence 或 `not_applicable`
+- full path 下，缺少 scenario -> validation 或 acceptance -> test mapping 默认阻断
+  build / review
+- minimal path 下，缺映射必须以 `not_applicable` rationale、替代验证入口和
+  recheck condition 解释
+
 ## 4. 套件边界规则
 
 Loom 必须区分：
@@ -74,6 +100,11 @@ Loom 当前不固化：
 
 - 所有项目都必须有同一组附加工件
 - `TODO.md` 或同类文件是永恒必选项
+
+Full path 缺少必需工件、locator、provenance 或 gate 所需 evidence 时必须
+fail-closed。Minimal path 缺少 full path 附加工件时，只有同时具备 rationale、
+consumer boundary 与 recheck condition 的 `not_applicable` 才能消解；无理由缺口
+仍是 `missing`。`deferred` 不等于 `not_applicable`，不得作为 completed truth 消费。
 
 ## 5. 行为证据与测试证据
 

--- a/skills/loom-pre-review/SKILL.md
+++ b/skills/loom-pre-review/SKILL.md
@@ -43,6 +43,7 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 不替代 reviewer 的语义判断
 - 不直接执行 merge
 - 不回写事实链、恢复入口或状态面
+- 不重新定义 full/minimal suite、evidence-map、consistency-analysis 或 gate-chain
 
 ## 4. 输出要求
 
@@ -53,6 +54,10 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 哪一步阻断了继续进入 review
 - 若阻断，应回退到哪里
 - 当前 steps 的机械结果是什么
+- full path 的 suite locator、evidence-map freshness 与 consistency-analysis
+  blocking/advisory 分类是否已经可供 review 消费
+- minimal path 的 `not_applicable` rationale、consumer boundary 与 recheck condition
+  是否足够；不足时必须 fail-closed，不能进入 review
 
 ## 5. 完成标准
 
@@ -62,6 +67,9 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - `flow pre-review` 的步骤顺序稳定为 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate`
 - 输出 JSON 能直接支撑“是否进入 review 前语义审查”的判断
 - skill 自身不复制治理真相，也不冒充 reviewer 结论
+- full path 缺少必需 suite artifact、provenance、fresh evidence 或存在 blocking
+  consistency gap 时返回 `block` / `fallback`
+- minimal path 只有在缺口具备有效 `not_applicable` rationale 时才允许进入 review
 
 输入信号与输出合同见：
 

--- a/skills/loom-pre-review/references/input-signals.md
+++ b/skills/loom-pre-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前 review 意图
 - 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-pre-review/references/output-contract.md
+++ b/skills/loom-pre-review/references/output-contract.md
@@ -16,6 +16,11 @@
   - 当前 Loom 入口自己的 scene / carrier 判定，以及 fail-closed 原因
 - `governance_lint`
   - `loom-governance-lint-status/v1` 派生证据；blocking lint 进入 `missing_inputs`，advisory lint 只进入风险摘要，不产生 reviewer 结论
+- `suite_path_consumption`
+  - full path 的 required artifacts、evidence-map freshness、consistency-analysis
+    blocking/advisory 分类
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - full path 缺必需输入或 minimal path 无有效 rationale 时必须 fail-closed
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> governance-lint` 顺序列出
 

--- a/skills/loom-resume/.loom-runtime/loom-build/SKILL.md
+++ b/skills/loom-resume/.loom-runtime/loom-build/SKILL.md
@@ -55,10 +55,21 @@ subagent-driven mode 必须先声明以下字段：
 - 多个委派声明重叠 `write_ownership`
 - 多轮或多个委派报告同一 blocker signature
 - 缺少 Work Item、spec、plan、recovery、validation baseline、workspace 或 ownership constraints
+- 选择 full path 但 suite-index、必需 suite 工件、scenario-to-validation mapping、
+  task carrier profile locator、provenance 或当前 build gate 所需 evidence 缺失
+- 选择 minimal path 但 full path 附加工件缺口没有 `not_applicable` rationale、
+  consumer boundary、recheck condition 或替代验证入口
+- 把 `deferred`、source/generated sync 待办或 CLI surface 待办当作 build readiness
+  的 completed truth
 
 ## 5. 完成标准
 
 只有当 `flow build` 返回 pass，且 build evidence 证明所有委派输出已集成、无 ownership overlap、无 repeated blocker 时，才允许继续进入 pre-review / review。
+
+Build readiness 只消费 full/minimal suite path 决策，不重新定义 suite 工件、
+evidence-map、consistency-analysis 或 gate-chain。full path 必须证明必需工件可读且
+fresh；minimal path 必须保留合法 `not_applicable` rationale，并把 recheck condition
+传递给后续 pre-review / review。
 
 输入信号与输出合同见：
 

--- a/skills/loom-resume/.loom-runtime/loom-build/references/input-signals.md
+++ b/skills/loom-resume/.loom-runtime/loom-build/references/input-signals.md
@@ -14,4 +14,6 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - Work Item、spec、plan、recovery baseline、validation baseline、workspace 和 ownership constraints
+- suite path decision：full path 的 suite / evidence locators，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition 与替代验证入口
 - 若使用 subagent-driven mode，必须提供 delegation/build evidence locator

--- a/skills/loom-resume/.loom-runtime/loom-build/references/output-contract.md
+++ b/skills/loom-resume/.loom-runtime/loom-build/references/output-contract.md
@@ -26,6 +26,12 @@
   - `integration_evidence`
   - `ownership_conflicts`
   - `repeated_blocker_signal`
+- `suite_path_consumption`
+  - full path 的必需工件、scenario-to-validation mapping、task carrier locator 与
+    provenance 是否可读
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+    与替代验证入口
+  - 缺失、stale、conflict 或无理由跳过时必须阻断 build readiness
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> build-execution` 顺序列出
 

--- a/skills/loom-resume/.loom-runtime/loom-merge-ready/SKILL.md
+++ b/skills/loom-resume/.loom-runtime/loom-merge-ready/SKILL.md
@@ -17,6 +17,14 @@ description: 负责 merge 前统一放行。Use when Codex needs to confirm whet
 - 只输出进入 `GitHub controlled merge` 前的统一放行摘要，不替代宿主平台 merge 动作
 - PR 合并前的宿主硬门禁由 `pr-gate check` 和 `controlled-merge check|merge` 承接；它们只能消费 authored Loom review record，不能把 raw review/shadow evidence 当作 approval
 - 不新建 authored 真相源，也不直接执行平台合并
+- 消费 full/minimal suite path、evidence-map freshness、consistency-analysis
+  classification 与 gate-chain 当前状态，但不重新定义这些合同
+- full path 下，review record 必须证明已消费 suite locators、evidence-map、
+  consistency-analysis、PR head / reviewed head / validation freshness；缺失、stale 或
+  conflict 必须 fail-closed
+- minimal path 下，只有带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable` 可以跳过 full path 附加工件；missing、deferred 或 source/generated
+  sync 待办不能被当作 merge-ready
 
 输入信号与输出合同见：
 

--- a/skills/loom-resume/.loom-runtime/loom-merge-ready/references/input-signals.md
+++ b/skills/loom-resume/.loom-runtime/loom-merge-ready/references/input-signals.md
@@ -6,3 +6,11 @@
 - 最终放行前预检
 - 确认当前事项是否可合并
 - 确认 `GitHub controlled merge` 前置是否齐全
+
+最小输入：
+
+- 目标仓库
+- 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 reviewed suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+- PR locator、head SHA、reviewed head 与 validation freshness 证据

--- a/skills/loom-resume/.loom-runtime/loom-merge-ready/references/output-contract.md
+++ b/skills/loom-resume/.loom-runtime/loom-merge-ready/references/output-contract.md
@@ -28,6 +28,11 @@
   - `loom-governance-lint-status/v1` 派生证据；只消费 fact-chain 与 repo companion 的 blocking/advisory lint result，不替代 authored review record、merge checkpoint 或 host merge truth
 - `gate_chain`
   - `spec_gate`、`build_gate`、`review_gate`、`merge_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - full path 的 suite readiness、evidence-map、consistency-analysis、reviewed
+    locators、PR head / reviewed head / validation freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - missing、stale、conflict、deferred 或无理由跳过必须进入 `missing_inputs`
 - `github_controlled_merge`
   - required checks、branch protection、merge method 与 host merge 前置状态
 - `retained_host_signals`

--- a/skills/loom-resume/.loom-runtime/loom-pre-review/SKILL.md
+++ b/skills/loom-resume/.loom-runtime/loom-pre-review/SKILL.md
@@ -43,6 +43,7 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 不替代 reviewer 的语义判断
 - 不直接执行 merge
 - 不回写事实链、恢复入口或状态面
+- 不重新定义 full/minimal suite、evidence-map、consistency-analysis 或 gate-chain
 
 ## 4. 输出要求
 
@@ -53,6 +54,10 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 哪一步阻断了继续进入 review
 - 若阻断，应回退到哪里
 - 当前 steps 的机械结果是什么
+- full path 的 suite locator、evidence-map freshness 与 consistency-analysis
+  blocking/advisory 分类是否已经可供 review 消费
+- minimal path 的 `not_applicable` rationale、consumer boundary 与 recheck condition
+  是否足够；不足时必须 fail-closed，不能进入 review
 
 ## 5. 完成标准
 
@@ -62,6 +67,9 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - `flow pre-review` 的步骤顺序稳定为 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate`
 - 输出 JSON 能直接支撑“是否进入 review 前语义审查”的判断
 - skill 自身不复制治理真相，也不冒充 reviewer 结论
+- full path 缺少必需 suite artifact、provenance、fresh evidence 或存在 blocking
+  consistency gap 时返回 `block` / `fallback`
+- minimal path 只有在缺口具备有效 `not_applicable` rationale 时才允许进入 review
 
 输入信号与输出合同见：
 

--- a/skills/loom-resume/.loom-runtime/loom-pre-review/references/input-signals.md
+++ b/skills/loom-resume/.loom-runtime/loom-pre-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前 review 意图
 - 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-resume/.loom-runtime/loom-pre-review/references/output-contract.md
+++ b/skills/loom-resume/.loom-runtime/loom-pre-review/references/output-contract.md
@@ -16,6 +16,11 @@
   - 当前 Loom 入口自己的 scene / carrier 判定，以及 fail-closed 原因
 - `governance_lint`
   - `loom-governance-lint-status/v1` 派生证据；blocking lint 进入 `missing_inputs`，advisory lint 只进入风险摘要，不产生 reviewer 结论
+- `suite_path_consumption`
+  - full path 的 required artifacts、evidence-map freshness、consistency-analysis
+    blocking/advisory 分类
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - full path 缺必需输入或 minimal path 无有效 rationale 时必须 fail-closed
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> governance-lint` 顺序列出
 

--- a/skills/loom-resume/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-resume/.loom-runtime/loom-spec-review/SKILL.md
@@ -39,6 +39,12 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - formal spec 路径不存在时，`flow spec-review` 必须 fail-closed
 - spec review 只写回单一 spec review record，不替代 implementation review record
 - `reviewed_head` 与 stale 语义必须显式暴露，供后续 gate 消费
+- full path 必须消费 suite path locator、必需工件 locator、provenance，以及
+  evidence-map / consistency-analysis / gate-chain 适用性结论；缺失或不可读时
+  fail-closed，回退到 spec shaping 或 suite path 修正
+- minimal path 只能消费带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable`；无理由缺口、`deferred` 或 source/generated sync 待办不得被当作
+  spec gate 通过
 
 ## 3. 固定编排
 
@@ -57,6 +63,9 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
 - 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不重新定义 full suite、minimal suite、evidence-map、consistency-analysis 或
+  gate-chain 语义；只消费这些合同已经定义的 locator、freshness、classification
+  与 fallback 边界
 
 ## 4. 输出要求
 
@@ -66,6 +75,8 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - spec review 的机械基线结果
 - spec review record 的定位与当前结论
 - reviewed head 绑定、当前 head、是否 stale
+- suite path decision，以及 full path readiness 或 minimal path `not_applicable`
+  rationale 是否可被 spec gate 消费
 - 审查结论（`allow` / `block` / `fallback`）
 - 若当前不能继续，应回退到哪里
 

--- a/skills/loom-resume/.loom-runtime/loom-spec-review/references/input-signals.md
+++ b/skills/loom-resume/.loom-runtime/loom-spec-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - formal spec 路径或明确的 spec review 意图
+- suite path decision：full path 的必需工件 locator，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-resume/.loom-runtime/loom-spec-review/references/output-contract.md
+++ b/skills/loom-resume/.loom-runtime/loom-spec-review/references/output-contract.md
@@ -22,6 +22,11 @@
   - `checkpoint build` 的结果、摘要、阻断项与回退去向
 - `gate_chain`
   - `spec_gate`、`build_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - `path: full|minimal`
+  - full path 的 suite locator、required artifact locators、provenance 与 freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - 无理由 missing、stale、conflict 或 deferred 输入必须进入 `missing_inputs`
 - `spec_review`
   - formal spec 路径、spec review record、head 绑定、stale 语义与当前 gate 结论
 - `spec_review_authority_migration`

--- a/skills/loom-resume/.loom-runtime/loom-story/SKILL.md
+++ b/skills/loom-resume/.loom-runtime/loom-story/SKILL.md
@@ -85,6 +85,21 @@ User Story 主体不得包含 delivery handoff、spec locator、plan locator、r
 - `Work Item` 仍是唯一执行入口
 - issue tree、Phase / FR / Work Item / PR 切分、blocked-by/blocks 与 host carrier mapping 由 `loom-init` 的 delivery planning 路由承接
 
+## 6. Full / Minimal Suite Path 边界
+
+`loom-story` 不选择或重定义 full/minimal suite path；它只产出可被
+`spec-suite` 消费的 story readiness 与 business confirmation 输入。
+
+- full path：若 formal spec path 消费 story，必须输出 Story Readiness 与 Story
+  Business Confirmation locator，且 decision 为 `confirmed` 或明确
+  `not_applicable`。`pending` / `revision-requested` 必须 fail closed，回到 story
+  shaping 或等待业务语义确认。
+- minimal path：纯治理、维护、格式、链接修复或载体整理可以输出
+  `not_applicable`，但必须包含 bypass rationale、consumer boundary 和 recheck
+  condition，供 `spec.md`、`plan.md`、evidence-map 与后续 gate 消费。
+- `loom-story` 不把 `not_applicable` 升级成产品确认，不生成 evidence-map、
+  consistency-analysis、review、merge-ready 或 GitHub closeout truth。
+
 输入信号与输出合同见：
 
 - [references/input-signals.md](./references/input-signals.md)

--- a/skills/loom-resume/.loom-runtime/loom-story/references/output-contract.md
+++ b/skills/loom-resume/.loom-runtime/loom-story/references/output-contract.md
@@ -28,6 +28,8 @@
   - story scenario 到 `plan.md` validation strategy 的映射
   - spec / plan 只消费已 `confirmed` 或明确 `not_applicable` 的 story 语义
   - 任何 `pending` 或 `revision-requested` 的 readiness / confirmation 都必须 fail closed，阻止 formal spec shaping
+  - full path 需要可消费的 readiness / confirmation locator；minimal path 需要
+    `not_applicable` rationale、consumer boundary 和 recheck condition
   - `Work Item` 仍是唯一执行入口
 - `missing_inputs`
   - 当前阻断 story shaping 的缺口；无阻断时为空数组

--- a/skills/loom-resume/.loom-runtime/route-matrix.md
+++ b/skills/loom-resume/.loom-runtime/route-matrix.md
@@ -45,7 +45,42 @@
 - `GitHub controlled merge`
   - merge 由宿主控制面执行；Loom 只消费 required checks、review、head 绑定与 merge gate 结果
 
-## 4. `governance_surface` 公共合同
+## 4. Formal Spec Suite Path 消费边界
+
+`loom-story`、`loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+必须消费 `docs/methodology/templates/spec-suite.md` 已定义的
+`full suite` / `minimal suite` path decision，不得在 skill 中重新定义 suite
+工件、evidence-map、consistency-analysis 或 gate-chain 语义。
+
+固定消费规则：
+
+- `full path` 表示当前事项选择完整 formal spec suite。后续 skill 必须能读取
+  suite path locator、必需工件 locator、条件工件的适用性判断、provenance，以及
+  #1018/#1019 合同声明适用时的 evidence-map、consistency-analysis 与 gate-chain
+  消费结论。
+- `full path` 缺少必需工件、locator、provenance 或当前 gate 所需 evidence 时，
+  `loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+  必须 fail-closed，返回 `block` 或带明确 `fallback_to` 的 `fallback`。
+- `minimal path` 是合法路径，但只能通过带 rationale、consumer boundary 和
+  recheck condition 的 `not_applicable` 消费 full path 附加工件；无理由缺口仍是
+  `missing`，不得被当成 `not_applicable`。
+- `deferred` 不等于 `not_applicable`。deferred source/generated sync、CLI surface
+  或后续 FR 工作只能作为后续事项输入，不得被当前 skill 当成 completed truth。
+- GitHub issue、sub-issue、Project item、PR、checklist 或 repo-local carrier 只按
+  GitHub task carrier profile 读取 locator、state、provenance 和冲突状态；不得替代
+  Work Item、spec suite、review record 或 merge-ready truth。
+
+场景到消费边界：
+
+| Skill | full path 消费 | minimal path 消费 |
+| --- | --- | --- |
+| `loom-story` | 输出 Story Readiness / Business Confirmation locator，供 `spec.md` / `plan.md` 和 suite path decision 消费 | 对纯治理、维护、格式、链接类事项输出 `not_applicable` rationale、consumer boundary、recheck condition |
+| `loom-spec-review` | 消费 suite path、formal spec、plan、必需工件、evidence-map / consistency-analysis 适用性；缺必需输入时 fail-closed | 只接受有效 `not_applicable` rationale；否则回退到 spec shaping / suite path 修正 |
+| `loom-build` | 在 build readiness 前消费 full suite readiness、scenario-to-validation mapping、task carrier profile locator | 合法跳过附加工件，但必须保留 rationale 和替代验证入口 |
+| `loom-pre-review` | 在 review 前消费 full suite locator、evidence-map freshness、consistency-analysis blocking/advisory 分类 | 缺口必须是有效 `not_applicable`，否则阻断 review admission |
+| `loom-merge-ready` | 在 merge gate 消费 reviewed full suite evidence、gate-chain、PR head / reviewed head / validation freshness | 只把有效 minimal path rationale 当作合法跳过，不把 missing 或 deferred 当作 ready |
+
+## 5. `governance_surface` 公共合同
 
 以下三类入口对外暴露的公共治理读面固定命名为 `governance_surface`：
 
@@ -73,7 +108,7 @@
 - 只回答 locator 与职责边界，不复制实时停点、下一步、阻断项、验证摘要
 - 若需要回答 gate 进度，统一通过 `review_merge_surface` 或 `status control plane` 读取，不在 `governance_surface` 并行维护 authored gate 状态
 
-## 5. Planning 边界
+## 6. Planning 边界
 
 `delivery planning` 是 `loom-init` 的路由结果，不是 build、review 或 merge-ready 的前置硬门禁。
 
@@ -102,7 +137,7 @@ planning 输出只能包含：
 
 planning 输出不能声明某个 Work Item 已完成，不能替代 `spec.md` / `plan.md`，不能替代 review、merge-ready、closeout，也不能直接改写 GitHub，除非用户明确要求执行创建或更新动作。
 
-## 6. fallback 语义
+## 7. fallback 语义
 
 出现以下任一情况时，root skill 不做猜测，直接回退到 `loom-init`：
 

--- a/skills/loom-resume/.loom-runtime/shared/references/templates/spec-suite.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/templates/spec-suite.md
@@ -18,6 +18,21 @@ Loom 当前把正式规约套件的最小内核定义为：
 
 这两个工件分别承担不同职责，不得混写。
 
+Formal spec path 有两条合法 suite path：
+
+- `minimal suite`
+  - 必含 `spec.md` 与 `plan.md`
+  - 适用于低风险、局部、纯治理或文档类事项
+  - 可用 `not_applicable` rationale 合法跳过 full path 附加工件
+- `full suite`
+  - 在 minimal suite 之上消费 suite-index、条件附加工件、evidence-map、
+    consistency-analysis 与 gate-chain consumption
+  - 适用于 formal spec、高风险、跨模块、强 review 或需要完整证据链的事项
+
+路径选择必须有 locator 与 provenance。若从 full path 降到 minimal path，必须说明
+附加工件为什么 `not_applicable`；若从 minimal path 升到 full path，必须说明触发信号
+和需要补齐的工件。
+
 ## 2. `spec.md` 最小要求
 
 `spec.md` 至少应表达：
@@ -58,6 +73,17 @@ Loom 当前把正式规约套件的最小内核定义为：
 - 不能自动化的行为必须声明人工验证路径、证据 locator 与 fresh 条件
 - 纯文档或治理规则变更可以不强制 TDD，但必须说明行为证据如何由结构检查、审查记录或示例消费
 
+映射状态必须可被后续 gate 消费：
+
+- `scenario_id` / scenario locator 映射到 automated、manual、structural 或
+  `not_applicable` validation strategy
+- `acceptance_id` / acceptance locator 映射到 test evidence、structural check、
+  manual evidence 或 `not_applicable`
+- full path 下，缺少 scenario -> validation 或 acceptance -> test mapping 默认阻断
+  build / review
+- minimal path 下，缺映射必须以 `not_applicable` rationale、替代验证入口和
+  recheck condition 解释
+
 ## 4. 套件边界规则
 
 Loom 必须区分：
@@ -74,6 +100,11 @@ Loom 当前不固化：
 
 - 所有项目都必须有同一组附加工件
 - `TODO.md` 或同类文件是永恒必选项
+
+Full path 缺少必需工件、locator、provenance 或 gate 所需 evidence 时必须
+fail-closed。Minimal path 缺少 full path 附加工件时，只有同时具备 rationale、
+consumer boundary 与 recheck condition 的 `not_applicable` 才能消解；无理由缺口
+仍是 `missing`。`deferred` 不等于 `not_applicable`，不得作为 completed truth 消费。
 
 ## 5. 行为证据与测试证据
 

--- a/skills/loom-retire/.loom-runtime/loom-build/SKILL.md
+++ b/skills/loom-retire/.loom-runtime/loom-build/SKILL.md
@@ -55,10 +55,21 @@ subagent-driven mode 必须先声明以下字段：
 - 多个委派声明重叠 `write_ownership`
 - 多轮或多个委派报告同一 blocker signature
 - 缺少 Work Item、spec、plan、recovery、validation baseline、workspace 或 ownership constraints
+- 选择 full path 但 suite-index、必需 suite 工件、scenario-to-validation mapping、
+  task carrier profile locator、provenance 或当前 build gate 所需 evidence 缺失
+- 选择 minimal path 但 full path 附加工件缺口没有 `not_applicable` rationale、
+  consumer boundary、recheck condition 或替代验证入口
+- 把 `deferred`、source/generated sync 待办或 CLI surface 待办当作 build readiness
+  的 completed truth
 
 ## 5. 完成标准
 
 只有当 `flow build` 返回 pass，且 build evidence 证明所有委派输出已集成、无 ownership overlap、无 repeated blocker 时，才允许继续进入 pre-review / review。
+
+Build readiness 只消费 full/minimal suite path 决策，不重新定义 suite 工件、
+evidence-map、consistency-analysis 或 gate-chain。full path 必须证明必需工件可读且
+fresh；minimal path 必须保留合法 `not_applicable` rationale，并把 recheck condition
+传递给后续 pre-review / review。
 
 输入信号与输出合同见：
 

--- a/skills/loom-retire/.loom-runtime/loom-build/references/input-signals.md
+++ b/skills/loom-retire/.loom-runtime/loom-build/references/input-signals.md
@@ -14,4 +14,6 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - Work Item、spec、plan、recovery baseline、validation baseline、workspace 和 ownership constraints
+- suite path decision：full path 的 suite / evidence locators，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition 与替代验证入口
 - 若使用 subagent-driven mode，必须提供 delegation/build evidence locator

--- a/skills/loom-retire/.loom-runtime/loom-build/references/output-contract.md
+++ b/skills/loom-retire/.loom-runtime/loom-build/references/output-contract.md
@@ -26,6 +26,12 @@
   - `integration_evidence`
   - `ownership_conflicts`
   - `repeated_blocker_signal`
+- `suite_path_consumption`
+  - full path 的必需工件、scenario-to-validation mapping、task carrier locator 与
+    provenance 是否可读
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+    与替代验证入口
+  - 缺失、stale、conflict 或无理由跳过时必须阻断 build readiness
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> build-execution` 顺序列出
 

--- a/skills/loom-retire/.loom-runtime/loom-merge-ready/SKILL.md
+++ b/skills/loom-retire/.loom-runtime/loom-merge-ready/SKILL.md
@@ -17,6 +17,14 @@ description: 负责 merge 前统一放行。Use when Codex needs to confirm whet
 - 只输出进入 `GitHub controlled merge` 前的统一放行摘要，不替代宿主平台 merge 动作
 - PR 合并前的宿主硬门禁由 `pr-gate check` 和 `controlled-merge check|merge` 承接；它们只能消费 authored Loom review record，不能把 raw review/shadow evidence 当作 approval
 - 不新建 authored 真相源，也不直接执行平台合并
+- 消费 full/minimal suite path、evidence-map freshness、consistency-analysis
+  classification 与 gate-chain 当前状态，但不重新定义这些合同
+- full path 下，review record 必须证明已消费 suite locators、evidence-map、
+  consistency-analysis、PR head / reviewed head / validation freshness；缺失、stale 或
+  conflict 必须 fail-closed
+- minimal path 下，只有带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable` 可以跳过 full path 附加工件；missing、deferred 或 source/generated
+  sync 待办不能被当作 merge-ready
 
 输入信号与输出合同见：
 

--- a/skills/loom-retire/.loom-runtime/loom-merge-ready/references/input-signals.md
+++ b/skills/loom-retire/.loom-runtime/loom-merge-ready/references/input-signals.md
@@ -6,3 +6,11 @@
 - 最终放行前预检
 - 确认当前事项是否可合并
 - 确认 `GitHub controlled merge` 前置是否齐全
+
+最小输入：
+
+- 目标仓库
+- 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 reviewed suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+- PR locator、head SHA、reviewed head 与 validation freshness 证据

--- a/skills/loom-retire/.loom-runtime/loom-merge-ready/references/output-contract.md
+++ b/skills/loom-retire/.loom-runtime/loom-merge-ready/references/output-contract.md
@@ -28,6 +28,11 @@
   - `loom-governance-lint-status/v1` 派生证据；只消费 fact-chain 与 repo companion 的 blocking/advisory lint result，不替代 authored review record、merge checkpoint 或 host merge truth
 - `gate_chain`
   - `spec_gate`、`build_gate`、`review_gate`、`merge_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - full path 的 suite readiness、evidence-map、consistency-analysis、reviewed
+    locators、PR head / reviewed head / validation freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - missing、stale、conflict、deferred 或无理由跳过必须进入 `missing_inputs`
 - `github_controlled_merge`
   - required checks、branch protection、merge method 与 host merge 前置状态
 - `retained_host_signals`

--- a/skills/loom-retire/.loom-runtime/loom-pre-review/SKILL.md
+++ b/skills/loom-retire/.loom-runtime/loom-pre-review/SKILL.md
@@ -43,6 +43,7 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 不替代 reviewer 的语义判断
 - 不直接执行 merge
 - 不回写事实链、恢复入口或状态面
+- 不重新定义 full/minimal suite、evidence-map、consistency-analysis 或 gate-chain
 
 ## 4. 输出要求
 
@@ -53,6 +54,10 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 哪一步阻断了继续进入 review
 - 若阻断，应回退到哪里
 - 当前 steps 的机械结果是什么
+- full path 的 suite locator、evidence-map freshness 与 consistency-analysis
+  blocking/advisory 分类是否已经可供 review 消费
+- minimal path 的 `not_applicable` rationale、consumer boundary 与 recheck condition
+  是否足够；不足时必须 fail-closed，不能进入 review
 
 ## 5. 完成标准
 
@@ -62,6 +67,9 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - `flow pre-review` 的步骤顺序稳定为 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate`
 - 输出 JSON 能直接支撑“是否进入 review 前语义审查”的判断
 - skill 自身不复制治理真相，也不冒充 reviewer 结论
+- full path 缺少必需 suite artifact、provenance、fresh evidence 或存在 blocking
+  consistency gap 时返回 `block` / `fallback`
+- minimal path 只有在缺口具备有效 `not_applicable` rationale 时才允许进入 review
 
 输入信号与输出合同见：
 

--- a/skills/loom-retire/.loom-runtime/loom-pre-review/references/input-signals.md
+++ b/skills/loom-retire/.loom-runtime/loom-pre-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前 review 意图
 - 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-retire/.loom-runtime/loom-pre-review/references/output-contract.md
+++ b/skills/loom-retire/.loom-runtime/loom-pre-review/references/output-contract.md
@@ -16,6 +16,11 @@
   - 当前 Loom 入口自己的 scene / carrier 判定，以及 fail-closed 原因
 - `governance_lint`
   - `loom-governance-lint-status/v1` 派生证据；blocking lint 进入 `missing_inputs`，advisory lint 只进入风险摘要，不产生 reviewer 结论
+- `suite_path_consumption`
+  - full path 的 required artifacts、evidence-map freshness、consistency-analysis
+    blocking/advisory 分类
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - full path 缺必需输入或 minimal path 无有效 rationale 时必须 fail-closed
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> governance-lint` 顺序列出
 

--- a/skills/loom-retire/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-retire/.loom-runtime/loom-spec-review/SKILL.md
@@ -39,6 +39,12 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - formal spec 路径不存在时，`flow spec-review` 必须 fail-closed
 - spec review 只写回单一 spec review record，不替代 implementation review record
 - `reviewed_head` 与 stale 语义必须显式暴露，供后续 gate 消费
+- full path 必须消费 suite path locator、必需工件 locator、provenance，以及
+  evidence-map / consistency-analysis / gate-chain 适用性结论；缺失或不可读时
+  fail-closed，回退到 spec shaping 或 suite path 修正
+- minimal path 只能消费带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable`；无理由缺口、`deferred` 或 source/generated sync 待办不得被当作
+  spec gate 通过
 
 ## 3. 固定编排
 
@@ -57,6 +63,9 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
 - 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不重新定义 full suite、minimal suite、evidence-map、consistency-analysis 或
+  gate-chain 语义；只消费这些合同已经定义的 locator、freshness、classification
+  与 fallback 边界
 
 ## 4. 输出要求
 
@@ -66,6 +75,8 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - spec review 的机械基线结果
 - spec review record 的定位与当前结论
 - reviewed head 绑定、当前 head、是否 stale
+- suite path decision，以及 full path readiness 或 minimal path `not_applicable`
+  rationale 是否可被 spec gate 消费
 - 审查结论（`allow` / `block` / `fallback`）
 - 若当前不能继续，应回退到哪里
 

--- a/skills/loom-retire/.loom-runtime/loom-spec-review/references/input-signals.md
+++ b/skills/loom-retire/.loom-runtime/loom-spec-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - formal spec 路径或明确的 spec review 意图
+- suite path decision：full path 的必需工件 locator，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-retire/.loom-runtime/loom-spec-review/references/output-contract.md
+++ b/skills/loom-retire/.loom-runtime/loom-spec-review/references/output-contract.md
@@ -22,6 +22,11 @@
   - `checkpoint build` 的结果、摘要、阻断项与回退去向
 - `gate_chain`
   - `spec_gate`、`build_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - `path: full|minimal`
+  - full path 的 suite locator、required artifact locators、provenance 与 freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - 无理由 missing、stale、conflict 或 deferred 输入必须进入 `missing_inputs`
 - `spec_review`
   - formal spec 路径、spec review record、head 绑定、stale 语义与当前 gate 结论
 - `spec_review_authority_migration`

--- a/skills/loom-retire/.loom-runtime/loom-story/SKILL.md
+++ b/skills/loom-retire/.loom-runtime/loom-story/SKILL.md
@@ -85,6 +85,21 @@ User Story 主体不得包含 delivery handoff、spec locator、plan locator、r
 - `Work Item` 仍是唯一执行入口
 - issue tree、Phase / FR / Work Item / PR 切分、blocked-by/blocks 与 host carrier mapping 由 `loom-init` 的 delivery planning 路由承接
 
+## 6. Full / Minimal Suite Path 边界
+
+`loom-story` 不选择或重定义 full/minimal suite path；它只产出可被
+`spec-suite` 消费的 story readiness 与 business confirmation 输入。
+
+- full path：若 formal spec path 消费 story，必须输出 Story Readiness 与 Story
+  Business Confirmation locator，且 decision 为 `confirmed` 或明确
+  `not_applicable`。`pending` / `revision-requested` 必须 fail closed，回到 story
+  shaping 或等待业务语义确认。
+- minimal path：纯治理、维护、格式、链接修复或载体整理可以输出
+  `not_applicable`，但必须包含 bypass rationale、consumer boundary 和 recheck
+  condition，供 `spec.md`、`plan.md`、evidence-map 与后续 gate 消费。
+- `loom-story` 不把 `not_applicable` 升级成产品确认，不生成 evidence-map、
+  consistency-analysis、review、merge-ready 或 GitHub closeout truth。
+
 输入信号与输出合同见：
 
 - [references/input-signals.md](./references/input-signals.md)

--- a/skills/loom-retire/.loom-runtime/loom-story/references/output-contract.md
+++ b/skills/loom-retire/.loom-runtime/loom-story/references/output-contract.md
@@ -28,6 +28,8 @@
   - story scenario 到 `plan.md` validation strategy 的映射
   - spec / plan 只消费已 `confirmed` 或明确 `not_applicable` 的 story 语义
   - 任何 `pending` 或 `revision-requested` 的 readiness / confirmation 都必须 fail closed，阻止 formal spec shaping
+  - full path 需要可消费的 readiness / confirmation locator；minimal path 需要
+    `not_applicable` rationale、consumer boundary 和 recheck condition
   - `Work Item` 仍是唯一执行入口
 - `missing_inputs`
   - 当前阻断 story shaping 的缺口；无阻断时为空数组

--- a/skills/loom-retire/.loom-runtime/route-matrix.md
+++ b/skills/loom-retire/.loom-runtime/route-matrix.md
@@ -45,7 +45,42 @@
 - `GitHub controlled merge`
   - merge 由宿主控制面执行；Loom 只消费 required checks、review、head 绑定与 merge gate 结果
 
-## 4. `governance_surface` 公共合同
+## 4. Formal Spec Suite Path 消费边界
+
+`loom-story`、`loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+必须消费 `docs/methodology/templates/spec-suite.md` 已定义的
+`full suite` / `minimal suite` path decision，不得在 skill 中重新定义 suite
+工件、evidence-map、consistency-analysis 或 gate-chain 语义。
+
+固定消费规则：
+
+- `full path` 表示当前事项选择完整 formal spec suite。后续 skill 必须能读取
+  suite path locator、必需工件 locator、条件工件的适用性判断、provenance，以及
+  #1018/#1019 合同声明适用时的 evidence-map、consistency-analysis 与 gate-chain
+  消费结论。
+- `full path` 缺少必需工件、locator、provenance 或当前 gate 所需 evidence 时，
+  `loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+  必须 fail-closed，返回 `block` 或带明确 `fallback_to` 的 `fallback`。
+- `minimal path` 是合法路径，但只能通过带 rationale、consumer boundary 和
+  recheck condition 的 `not_applicable` 消费 full path 附加工件；无理由缺口仍是
+  `missing`，不得被当成 `not_applicable`。
+- `deferred` 不等于 `not_applicable`。deferred source/generated sync、CLI surface
+  或后续 FR 工作只能作为后续事项输入，不得被当前 skill 当成 completed truth。
+- GitHub issue、sub-issue、Project item、PR、checklist 或 repo-local carrier 只按
+  GitHub task carrier profile 读取 locator、state、provenance 和冲突状态；不得替代
+  Work Item、spec suite、review record 或 merge-ready truth。
+
+场景到消费边界：
+
+| Skill | full path 消费 | minimal path 消费 |
+| --- | --- | --- |
+| `loom-story` | 输出 Story Readiness / Business Confirmation locator，供 `spec.md` / `plan.md` 和 suite path decision 消费 | 对纯治理、维护、格式、链接类事项输出 `not_applicable` rationale、consumer boundary、recheck condition |
+| `loom-spec-review` | 消费 suite path、formal spec、plan、必需工件、evidence-map / consistency-analysis 适用性；缺必需输入时 fail-closed | 只接受有效 `not_applicable` rationale；否则回退到 spec shaping / suite path 修正 |
+| `loom-build` | 在 build readiness 前消费 full suite readiness、scenario-to-validation mapping、task carrier profile locator | 合法跳过附加工件，但必须保留 rationale 和替代验证入口 |
+| `loom-pre-review` | 在 review 前消费 full suite locator、evidence-map freshness、consistency-analysis blocking/advisory 分类 | 缺口必须是有效 `not_applicable`，否则阻断 review admission |
+| `loom-merge-ready` | 在 merge gate 消费 reviewed full suite evidence、gate-chain、PR head / reviewed head / validation freshness | 只把有效 minimal path rationale 当作合法跳过，不把 missing 或 deferred 当作 ready |
+
+## 5. `governance_surface` 公共合同
 
 以下三类入口对外暴露的公共治理读面固定命名为 `governance_surface`：
 
@@ -73,7 +108,7 @@
 - 只回答 locator 与职责边界，不复制实时停点、下一步、阻断项、验证摘要
 - 若需要回答 gate 进度，统一通过 `review_merge_surface` 或 `status control plane` 读取，不在 `governance_surface` 并行维护 authored gate 状态
 
-## 5. Planning 边界
+## 6. Planning 边界
 
 `delivery planning` 是 `loom-init` 的路由结果，不是 build、review 或 merge-ready 的前置硬门禁。
 
@@ -102,7 +137,7 @@ planning 输出只能包含：
 
 planning 输出不能声明某个 Work Item 已完成，不能替代 `spec.md` / `plan.md`，不能替代 review、merge-ready、closeout，也不能直接改写 GitHub，除非用户明确要求执行创建或更新动作。
 
-## 6. fallback 语义
+## 7. fallback 语义
 
 出现以下任一情况时，root skill 不做猜测，直接回退到 `loom-init`：
 

--- a/skills/loom-retire/.loom-runtime/shared/references/templates/spec-suite.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/templates/spec-suite.md
@@ -18,6 +18,21 @@ Loom 当前把正式规约套件的最小内核定义为：
 
 这两个工件分别承担不同职责，不得混写。
 
+Formal spec path 有两条合法 suite path：
+
+- `minimal suite`
+  - 必含 `spec.md` 与 `plan.md`
+  - 适用于低风险、局部、纯治理或文档类事项
+  - 可用 `not_applicable` rationale 合法跳过 full path 附加工件
+- `full suite`
+  - 在 minimal suite 之上消费 suite-index、条件附加工件、evidence-map、
+    consistency-analysis 与 gate-chain consumption
+  - 适用于 formal spec、高风险、跨模块、强 review 或需要完整证据链的事项
+
+路径选择必须有 locator 与 provenance。若从 full path 降到 minimal path，必须说明
+附加工件为什么 `not_applicable`；若从 minimal path 升到 full path，必须说明触发信号
+和需要补齐的工件。
+
 ## 2. `spec.md` 最小要求
 
 `spec.md` 至少应表达：
@@ -58,6 +73,17 @@ Loom 当前把正式规约套件的最小内核定义为：
 - 不能自动化的行为必须声明人工验证路径、证据 locator 与 fresh 条件
 - 纯文档或治理规则变更可以不强制 TDD，但必须说明行为证据如何由结构检查、审查记录或示例消费
 
+映射状态必须可被后续 gate 消费：
+
+- `scenario_id` / scenario locator 映射到 automated、manual、structural 或
+  `not_applicable` validation strategy
+- `acceptance_id` / acceptance locator 映射到 test evidence、structural check、
+  manual evidence 或 `not_applicable`
+- full path 下，缺少 scenario -> validation 或 acceptance -> test mapping 默认阻断
+  build / review
+- minimal path 下，缺映射必须以 `not_applicable` rationale、替代验证入口和
+  recheck condition 解释
+
 ## 4. 套件边界规则
 
 Loom 必须区分：
@@ -74,6 +100,11 @@ Loom 当前不固化：
 
 - 所有项目都必须有同一组附加工件
 - `TODO.md` 或同类文件是永恒必选项
+
+Full path 缺少必需工件、locator、provenance 或 gate 所需 evidence 时必须
+fail-closed。Minimal path 缺少 full path 附加工件时，只有同时具备 rationale、
+consumer boundary 与 recheck condition 的 `not_applicable` 才能消解；无理由缺口
+仍是 `missing`。`deferred` 不等于 `not_applicable`，不得作为 completed truth 消费。
 
 ## 5. 行为证据与测试证据
 

--- a/skills/loom-review/.loom-runtime/loom-build/SKILL.md
+++ b/skills/loom-review/.loom-runtime/loom-build/SKILL.md
@@ -55,10 +55,21 @@ subagent-driven mode 必须先声明以下字段：
 - 多个委派声明重叠 `write_ownership`
 - 多轮或多个委派报告同一 blocker signature
 - 缺少 Work Item、spec、plan、recovery、validation baseline、workspace 或 ownership constraints
+- 选择 full path 但 suite-index、必需 suite 工件、scenario-to-validation mapping、
+  task carrier profile locator、provenance 或当前 build gate 所需 evidence 缺失
+- 选择 minimal path 但 full path 附加工件缺口没有 `not_applicable` rationale、
+  consumer boundary、recheck condition 或替代验证入口
+- 把 `deferred`、source/generated sync 待办或 CLI surface 待办当作 build readiness
+  的 completed truth
 
 ## 5. 完成标准
 
 只有当 `flow build` 返回 pass，且 build evidence 证明所有委派输出已集成、无 ownership overlap、无 repeated blocker 时，才允许继续进入 pre-review / review。
+
+Build readiness 只消费 full/minimal suite path 决策，不重新定义 suite 工件、
+evidence-map、consistency-analysis 或 gate-chain。full path 必须证明必需工件可读且
+fresh；minimal path 必须保留合法 `not_applicable` rationale，并把 recheck condition
+传递给后续 pre-review / review。
 
 输入信号与输出合同见：
 

--- a/skills/loom-review/.loom-runtime/loom-build/references/input-signals.md
+++ b/skills/loom-review/.loom-runtime/loom-build/references/input-signals.md
@@ -14,4 +14,6 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - Work Item、spec、plan、recovery baseline、validation baseline、workspace 和 ownership constraints
+- suite path decision：full path 的 suite / evidence locators，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition 与替代验证入口
 - 若使用 subagent-driven mode，必须提供 delegation/build evidence locator

--- a/skills/loom-review/.loom-runtime/loom-build/references/output-contract.md
+++ b/skills/loom-review/.loom-runtime/loom-build/references/output-contract.md
@@ -26,6 +26,12 @@
   - `integration_evidence`
   - `ownership_conflicts`
   - `repeated_blocker_signal`
+- `suite_path_consumption`
+  - full path 的必需工件、scenario-to-validation mapping、task carrier locator 与
+    provenance 是否可读
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+    与替代验证入口
+  - 缺失、stale、conflict 或无理由跳过时必须阻断 build readiness
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> build-execution` 顺序列出
 

--- a/skills/loom-review/.loom-runtime/loom-merge-ready/SKILL.md
+++ b/skills/loom-review/.loom-runtime/loom-merge-ready/SKILL.md
@@ -17,6 +17,14 @@ description: 负责 merge 前统一放行。Use when Codex needs to confirm whet
 - 只输出进入 `GitHub controlled merge` 前的统一放行摘要，不替代宿主平台 merge 动作
 - PR 合并前的宿主硬门禁由 `pr-gate check` 和 `controlled-merge check|merge` 承接；它们只能消费 authored Loom review record，不能把 raw review/shadow evidence 当作 approval
 - 不新建 authored 真相源，也不直接执行平台合并
+- 消费 full/minimal suite path、evidence-map freshness、consistency-analysis
+  classification 与 gate-chain 当前状态，但不重新定义这些合同
+- full path 下，review record 必须证明已消费 suite locators、evidence-map、
+  consistency-analysis、PR head / reviewed head / validation freshness；缺失、stale 或
+  conflict 必须 fail-closed
+- minimal path 下，只有带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable` 可以跳过 full path 附加工件；missing、deferred 或 source/generated
+  sync 待办不能被当作 merge-ready
 
 输入信号与输出合同见：
 

--- a/skills/loom-review/.loom-runtime/loom-merge-ready/references/input-signals.md
+++ b/skills/loom-review/.loom-runtime/loom-merge-ready/references/input-signals.md
@@ -6,3 +6,11 @@
 - 最终放行前预检
 - 确认当前事项是否可合并
 - 确认 `GitHub controlled merge` 前置是否齐全
+
+最小输入：
+
+- 目标仓库
+- 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 reviewed suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+- PR locator、head SHA、reviewed head 与 validation freshness 证据

--- a/skills/loom-review/.loom-runtime/loom-merge-ready/references/output-contract.md
+++ b/skills/loom-review/.loom-runtime/loom-merge-ready/references/output-contract.md
@@ -28,6 +28,11 @@
   - `loom-governance-lint-status/v1` 派生证据；只消费 fact-chain 与 repo companion 的 blocking/advisory lint result，不替代 authored review record、merge checkpoint 或 host merge truth
 - `gate_chain`
   - `spec_gate`、`build_gate`、`review_gate`、`merge_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - full path 的 suite readiness、evidence-map、consistency-analysis、reviewed
+    locators、PR head / reviewed head / validation freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - missing、stale、conflict、deferred 或无理由跳过必须进入 `missing_inputs`
 - `github_controlled_merge`
   - required checks、branch protection、merge method 与 host merge 前置状态
 - `retained_host_signals`

--- a/skills/loom-review/.loom-runtime/loom-pre-review/SKILL.md
+++ b/skills/loom-review/.loom-runtime/loom-pre-review/SKILL.md
@@ -43,6 +43,7 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 不替代 reviewer 的语义判断
 - 不直接执行 merge
 - 不回写事实链、恢复入口或状态面
+- 不重新定义 full/minimal suite、evidence-map、consistency-analysis 或 gate-chain
 
 ## 4. 输出要求
 
@@ -53,6 +54,10 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 哪一步阻断了继续进入 review
 - 若阻断，应回退到哪里
 - 当前 steps 的机械结果是什么
+- full path 的 suite locator、evidence-map freshness 与 consistency-analysis
+  blocking/advisory 分类是否已经可供 review 消费
+- minimal path 的 `not_applicable` rationale、consumer boundary 与 recheck condition
+  是否足够；不足时必须 fail-closed，不能进入 review
 
 ## 5. 完成标准
 
@@ -62,6 +67,9 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - `flow pre-review` 的步骤顺序稳定为 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate`
 - 输出 JSON 能直接支撑“是否进入 review 前语义审查”的判断
 - skill 自身不复制治理真相，也不冒充 reviewer 结论
+- full path 缺少必需 suite artifact、provenance、fresh evidence 或存在 blocking
+  consistency gap 时返回 `block` / `fallback`
+- minimal path 只有在缺口具备有效 `not_applicable` rationale 时才允许进入 review
 
 输入信号与输出合同见：
 

--- a/skills/loom-review/.loom-runtime/loom-pre-review/references/input-signals.md
+++ b/skills/loom-review/.loom-runtime/loom-pre-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前 review 意图
 - 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-review/.loom-runtime/loom-pre-review/references/output-contract.md
+++ b/skills/loom-review/.loom-runtime/loom-pre-review/references/output-contract.md
@@ -16,6 +16,11 @@
   - 当前 Loom 入口自己的 scene / carrier 判定，以及 fail-closed 原因
 - `governance_lint`
   - `loom-governance-lint-status/v1` 派生证据；blocking lint 进入 `missing_inputs`，advisory lint 只进入风险摘要，不产生 reviewer 结论
+- `suite_path_consumption`
+  - full path 的 required artifacts、evidence-map freshness、consistency-analysis
+    blocking/advisory 分类
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - full path 缺必需输入或 minimal path 无有效 rationale 时必须 fail-closed
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> governance-lint` 顺序列出
 

--- a/skills/loom-review/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-review/.loom-runtime/loom-spec-review/SKILL.md
@@ -39,6 +39,12 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - formal spec 路径不存在时，`flow spec-review` 必须 fail-closed
 - spec review 只写回单一 spec review record，不替代 implementation review record
 - `reviewed_head` 与 stale 语义必须显式暴露，供后续 gate 消费
+- full path 必须消费 suite path locator、必需工件 locator、provenance，以及
+  evidence-map / consistency-analysis / gate-chain 适用性结论；缺失或不可读时
+  fail-closed，回退到 spec shaping 或 suite path 修正
+- minimal path 只能消费带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable`；无理由缺口、`deferred` 或 source/generated sync 待办不得被当作
+  spec gate 通过
 
 ## 3. 固定编排
 
@@ -57,6 +63,9 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
 - 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不重新定义 full suite、minimal suite、evidence-map、consistency-analysis 或
+  gate-chain 语义；只消费这些合同已经定义的 locator、freshness、classification
+  与 fallback 边界
 
 ## 4. 输出要求
 
@@ -66,6 +75,8 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - spec review 的机械基线结果
 - spec review record 的定位与当前结论
 - reviewed head 绑定、当前 head、是否 stale
+- suite path decision，以及 full path readiness 或 minimal path `not_applicable`
+  rationale 是否可被 spec gate 消费
 - 审查结论（`allow` / `block` / `fallback`）
 - 若当前不能继续，应回退到哪里
 

--- a/skills/loom-review/.loom-runtime/loom-spec-review/references/input-signals.md
+++ b/skills/loom-review/.loom-runtime/loom-spec-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - formal spec 路径或明确的 spec review 意图
+- suite path decision：full path 的必需工件 locator，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-review/.loom-runtime/loom-spec-review/references/output-contract.md
+++ b/skills/loom-review/.loom-runtime/loom-spec-review/references/output-contract.md
@@ -22,6 +22,11 @@
   - `checkpoint build` 的结果、摘要、阻断项与回退去向
 - `gate_chain`
   - `spec_gate`、`build_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - `path: full|minimal`
+  - full path 的 suite locator、required artifact locators、provenance 与 freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - 无理由 missing、stale、conflict 或 deferred 输入必须进入 `missing_inputs`
 - `spec_review`
   - formal spec 路径、spec review record、head 绑定、stale 语义与当前 gate 结论
 - `spec_review_authority_migration`

--- a/skills/loom-review/.loom-runtime/loom-story/SKILL.md
+++ b/skills/loom-review/.loom-runtime/loom-story/SKILL.md
@@ -85,6 +85,21 @@ User Story 主体不得包含 delivery handoff、spec locator、plan locator、r
 - `Work Item` 仍是唯一执行入口
 - issue tree、Phase / FR / Work Item / PR 切分、blocked-by/blocks 与 host carrier mapping 由 `loom-init` 的 delivery planning 路由承接
 
+## 6. Full / Minimal Suite Path 边界
+
+`loom-story` 不选择或重定义 full/minimal suite path；它只产出可被
+`spec-suite` 消费的 story readiness 与 business confirmation 输入。
+
+- full path：若 formal spec path 消费 story，必须输出 Story Readiness 与 Story
+  Business Confirmation locator，且 decision 为 `confirmed` 或明确
+  `not_applicable`。`pending` / `revision-requested` 必须 fail closed，回到 story
+  shaping 或等待业务语义确认。
+- minimal path：纯治理、维护、格式、链接修复或载体整理可以输出
+  `not_applicable`，但必须包含 bypass rationale、consumer boundary 和 recheck
+  condition，供 `spec.md`、`plan.md`、evidence-map 与后续 gate 消费。
+- `loom-story` 不把 `not_applicable` 升级成产品确认，不生成 evidence-map、
+  consistency-analysis、review、merge-ready 或 GitHub closeout truth。
+
 输入信号与输出合同见：
 
 - [references/input-signals.md](./references/input-signals.md)

--- a/skills/loom-review/.loom-runtime/loom-story/references/output-contract.md
+++ b/skills/loom-review/.loom-runtime/loom-story/references/output-contract.md
@@ -28,6 +28,8 @@
   - story scenario 到 `plan.md` validation strategy 的映射
   - spec / plan 只消费已 `confirmed` 或明确 `not_applicable` 的 story 语义
   - 任何 `pending` 或 `revision-requested` 的 readiness / confirmation 都必须 fail closed，阻止 formal spec shaping
+  - full path 需要可消费的 readiness / confirmation locator；minimal path 需要
+    `not_applicable` rationale、consumer boundary 和 recheck condition
   - `Work Item` 仍是唯一执行入口
 - `missing_inputs`
   - 当前阻断 story shaping 的缺口；无阻断时为空数组

--- a/skills/loom-review/.loom-runtime/route-matrix.md
+++ b/skills/loom-review/.loom-runtime/route-matrix.md
@@ -45,7 +45,42 @@
 - `GitHub controlled merge`
   - merge 由宿主控制面执行；Loom 只消费 required checks、review、head 绑定与 merge gate 结果
 
-## 4. `governance_surface` 公共合同
+## 4. Formal Spec Suite Path 消费边界
+
+`loom-story`、`loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+必须消费 `docs/methodology/templates/spec-suite.md` 已定义的
+`full suite` / `minimal suite` path decision，不得在 skill 中重新定义 suite
+工件、evidence-map、consistency-analysis 或 gate-chain 语义。
+
+固定消费规则：
+
+- `full path` 表示当前事项选择完整 formal spec suite。后续 skill 必须能读取
+  suite path locator、必需工件 locator、条件工件的适用性判断、provenance，以及
+  #1018/#1019 合同声明适用时的 evidence-map、consistency-analysis 与 gate-chain
+  消费结论。
+- `full path` 缺少必需工件、locator、provenance 或当前 gate 所需 evidence 时，
+  `loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+  必须 fail-closed，返回 `block` 或带明确 `fallback_to` 的 `fallback`。
+- `minimal path` 是合法路径，但只能通过带 rationale、consumer boundary 和
+  recheck condition 的 `not_applicable` 消费 full path 附加工件；无理由缺口仍是
+  `missing`，不得被当成 `not_applicable`。
+- `deferred` 不等于 `not_applicable`。deferred source/generated sync、CLI surface
+  或后续 FR 工作只能作为后续事项输入，不得被当前 skill 当成 completed truth。
+- GitHub issue、sub-issue、Project item、PR、checklist 或 repo-local carrier 只按
+  GitHub task carrier profile 读取 locator、state、provenance 和冲突状态；不得替代
+  Work Item、spec suite、review record 或 merge-ready truth。
+
+场景到消费边界：
+
+| Skill | full path 消费 | minimal path 消费 |
+| --- | --- | --- |
+| `loom-story` | 输出 Story Readiness / Business Confirmation locator，供 `spec.md` / `plan.md` 和 suite path decision 消费 | 对纯治理、维护、格式、链接类事项输出 `not_applicable` rationale、consumer boundary、recheck condition |
+| `loom-spec-review` | 消费 suite path、formal spec、plan、必需工件、evidence-map / consistency-analysis 适用性；缺必需输入时 fail-closed | 只接受有效 `not_applicable` rationale；否则回退到 spec shaping / suite path 修正 |
+| `loom-build` | 在 build readiness 前消费 full suite readiness、scenario-to-validation mapping、task carrier profile locator | 合法跳过附加工件，但必须保留 rationale 和替代验证入口 |
+| `loom-pre-review` | 在 review 前消费 full suite locator、evidence-map freshness、consistency-analysis blocking/advisory 分类 | 缺口必须是有效 `not_applicable`，否则阻断 review admission |
+| `loom-merge-ready` | 在 merge gate 消费 reviewed full suite evidence、gate-chain、PR head / reviewed head / validation freshness | 只把有效 minimal path rationale 当作合法跳过，不把 missing 或 deferred 当作 ready |
+
+## 5. `governance_surface` 公共合同
 
 以下三类入口对外暴露的公共治理读面固定命名为 `governance_surface`：
 
@@ -73,7 +108,7 @@
 - 只回答 locator 与职责边界，不复制实时停点、下一步、阻断项、验证摘要
 - 若需要回答 gate 进度，统一通过 `review_merge_surface` 或 `status control plane` 读取，不在 `governance_surface` 并行维护 authored gate 状态
 
-## 5. Planning 边界
+## 6. Planning 边界
 
 `delivery planning` 是 `loom-init` 的路由结果，不是 build、review 或 merge-ready 的前置硬门禁。
 
@@ -102,7 +137,7 @@ planning 输出只能包含：
 
 planning 输出不能声明某个 Work Item 已完成，不能替代 `spec.md` / `plan.md`，不能替代 review、merge-ready、closeout，也不能直接改写 GitHub，除非用户明确要求执行创建或更新动作。
 
-## 6. fallback 语义
+## 7. fallback 语义
 
 出现以下任一情况时，root skill 不做猜测，直接回退到 `loom-init`：
 

--- a/skills/loom-review/.loom-runtime/shared/references/templates/spec-suite.md
+++ b/skills/loom-review/.loom-runtime/shared/references/templates/spec-suite.md
@@ -18,6 +18,21 @@ Loom 当前把正式规约套件的最小内核定义为：
 
 这两个工件分别承担不同职责，不得混写。
 
+Formal spec path 有两条合法 suite path：
+
+- `minimal suite`
+  - 必含 `spec.md` 与 `plan.md`
+  - 适用于低风险、局部、纯治理或文档类事项
+  - 可用 `not_applicable` rationale 合法跳过 full path 附加工件
+- `full suite`
+  - 在 minimal suite 之上消费 suite-index、条件附加工件、evidence-map、
+    consistency-analysis 与 gate-chain consumption
+  - 适用于 formal spec、高风险、跨模块、强 review 或需要完整证据链的事项
+
+路径选择必须有 locator 与 provenance。若从 full path 降到 minimal path，必须说明
+附加工件为什么 `not_applicable`；若从 minimal path 升到 full path，必须说明触发信号
+和需要补齐的工件。
+
 ## 2. `spec.md` 最小要求
 
 `spec.md` 至少应表达：
@@ -58,6 +73,17 @@ Loom 当前把正式规约套件的最小内核定义为：
 - 不能自动化的行为必须声明人工验证路径、证据 locator 与 fresh 条件
 - 纯文档或治理规则变更可以不强制 TDD，但必须说明行为证据如何由结构检查、审查记录或示例消费
 
+映射状态必须可被后续 gate 消费：
+
+- `scenario_id` / scenario locator 映射到 automated、manual、structural 或
+  `not_applicable` validation strategy
+- `acceptance_id` / acceptance locator 映射到 test evidence、structural check、
+  manual evidence 或 `not_applicable`
+- full path 下，缺少 scenario -> validation 或 acceptance -> test mapping 默认阻断
+  build / review
+- minimal path 下，缺映射必须以 `not_applicable` rationale、替代验证入口和
+  recheck condition 解释
+
 ## 4. 套件边界规则
 
 Loom 必须区分：
@@ -74,6 +100,11 @@ Loom 当前不固化：
 
 - 所有项目都必须有同一组附加工件
 - `TODO.md` 或同类文件是永恒必选项
+
+Full path 缺少必需工件、locator、provenance 或 gate 所需 evidence 时必须
+fail-closed。Minimal path 缺少 full path 附加工件时，只有同时具备 rationale、
+consumer boundary 与 recheck condition 的 `not_applicable` 才能消解；无理由缺口
+仍是 `missing`。`deferred` 不等于 `not_applicable`，不得作为 completed truth 消费。
 
 ## 5. 行为证据与测试证据
 

--- a/skills/loom-spec-review/.loom-runtime/loom-build/SKILL.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-build/SKILL.md
@@ -55,10 +55,21 @@ subagent-driven mode 必须先声明以下字段：
 - 多个委派声明重叠 `write_ownership`
 - 多轮或多个委派报告同一 blocker signature
 - 缺少 Work Item、spec、plan、recovery、validation baseline、workspace 或 ownership constraints
+- 选择 full path 但 suite-index、必需 suite 工件、scenario-to-validation mapping、
+  task carrier profile locator、provenance 或当前 build gate 所需 evidence 缺失
+- 选择 minimal path 但 full path 附加工件缺口没有 `not_applicable` rationale、
+  consumer boundary、recheck condition 或替代验证入口
+- 把 `deferred`、source/generated sync 待办或 CLI surface 待办当作 build readiness
+  的 completed truth
 
 ## 5. 完成标准
 
 只有当 `flow build` 返回 pass，且 build evidence 证明所有委派输出已集成、无 ownership overlap、无 repeated blocker 时，才允许继续进入 pre-review / review。
+
+Build readiness 只消费 full/minimal suite path 决策，不重新定义 suite 工件、
+evidence-map、consistency-analysis 或 gate-chain。full path 必须证明必需工件可读且
+fresh；minimal path 必须保留合法 `not_applicable` rationale，并把 recheck condition
+传递给后续 pre-review / review。
 
 输入信号与输出合同见：
 

--- a/skills/loom-spec-review/.loom-runtime/loom-build/references/input-signals.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-build/references/input-signals.md
@@ -14,4 +14,6 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - Work Item、spec、plan、recovery baseline、validation baseline、workspace 和 ownership constraints
+- suite path decision：full path 的 suite / evidence locators，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition 与替代验证入口
 - 若使用 subagent-driven mode，必须提供 delegation/build evidence locator

--- a/skills/loom-spec-review/.loom-runtime/loom-build/references/output-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-build/references/output-contract.md
@@ -26,6 +26,12 @@
   - `integration_evidence`
   - `ownership_conflicts`
   - `repeated_blocker_signal`
+- `suite_path_consumption`
+  - full path 的必需工件、scenario-to-validation mapping、task carrier locator 与
+    provenance 是否可读
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+    与替代验证入口
+  - 缺失、stale、conflict 或无理由跳过时必须阻断 build readiness
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> build-execution` 顺序列出
 

--- a/skills/loom-spec-review/.loom-runtime/loom-merge-ready/SKILL.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-merge-ready/SKILL.md
@@ -17,6 +17,14 @@ description: 负责 merge 前统一放行。Use when Codex needs to confirm whet
 - 只输出进入 `GitHub controlled merge` 前的统一放行摘要，不替代宿主平台 merge 动作
 - PR 合并前的宿主硬门禁由 `pr-gate check` 和 `controlled-merge check|merge` 承接；它们只能消费 authored Loom review record，不能把 raw review/shadow evidence 当作 approval
 - 不新建 authored 真相源，也不直接执行平台合并
+- 消费 full/minimal suite path、evidence-map freshness、consistency-analysis
+  classification 与 gate-chain 当前状态，但不重新定义这些合同
+- full path 下，review record 必须证明已消费 suite locators、evidence-map、
+  consistency-analysis、PR head / reviewed head / validation freshness；缺失、stale 或
+  conflict 必须 fail-closed
+- minimal path 下，只有带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable` 可以跳过 full path 附加工件；missing、deferred 或 source/generated
+  sync 待办不能被当作 merge-ready
 
 输入信号与输出合同见：
 

--- a/skills/loom-spec-review/.loom-runtime/loom-merge-ready/references/input-signals.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-merge-ready/references/input-signals.md
@@ -6,3 +6,11 @@
 - 最终放行前预检
 - 确认当前事项是否可合并
 - 确认 `GitHub controlled merge` 前置是否齐全
+
+最小输入：
+
+- 目标仓库
+- 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 reviewed suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+- PR locator、head SHA、reviewed head 与 validation freshness 证据

--- a/skills/loom-spec-review/.loom-runtime/loom-merge-ready/references/output-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-merge-ready/references/output-contract.md
@@ -28,6 +28,11 @@
   - `loom-governance-lint-status/v1` 派生证据；只消费 fact-chain 与 repo companion 的 blocking/advisory lint result，不替代 authored review record、merge checkpoint 或 host merge truth
 - `gate_chain`
   - `spec_gate`、`build_gate`、`review_gate`、`merge_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - full path 的 suite readiness、evidence-map、consistency-analysis、reviewed
+    locators、PR head / reviewed head / validation freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - missing、stale、conflict、deferred 或无理由跳过必须进入 `missing_inputs`
 - `github_controlled_merge`
   - required checks、branch protection、merge method 与 host merge 前置状态
 - `retained_host_signals`

--- a/skills/loom-spec-review/.loom-runtime/loom-pre-review/SKILL.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-pre-review/SKILL.md
@@ -43,6 +43,7 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 不替代 reviewer 的语义判断
 - 不直接执行 merge
 - 不回写事实链、恢复入口或状态面
+- 不重新定义 full/minimal suite、evidence-map、consistency-analysis 或 gate-chain
 
 ## 4. 输出要求
 
@@ -53,6 +54,10 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 哪一步阻断了继续进入 review
 - 若阻断，应回退到哪里
 - 当前 steps 的机械结果是什么
+- full path 的 suite locator、evidence-map freshness 与 consistency-analysis
+  blocking/advisory 分类是否已经可供 review 消费
+- minimal path 的 `not_applicable` rationale、consumer boundary 与 recheck condition
+  是否足够；不足时必须 fail-closed，不能进入 review
 
 ## 5. 完成标准
 
@@ -62,6 +67,9 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - `flow pre-review` 的步骤顺序稳定为 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate`
 - 输出 JSON 能直接支撑“是否进入 review 前语义审查”的判断
 - skill 自身不复制治理真相，也不冒充 reviewer 结论
+- full path 缺少必需 suite artifact、provenance、fresh evidence 或存在 blocking
+  consistency gap 时返回 `block` / `fallback`
+- minimal path 只有在缺口具备有效 `not_applicable` rationale 时才允许进入 review
 
 输入信号与输出合同见：
 

--- a/skills/loom-spec-review/.loom-runtime/loom-pre-review/references/input-signals.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-pre-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前 review 意图
 - 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-spec-review/.loom-runtime/loom-pre-review/references/output-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-pre-review/references/output-contract.md
@@ -16,6 +16,11 @@
   - 当前 Loom 入口自己的 scene / carrier 判定，以及 fail-closed 原因
 - `governance_lint`
   - `loom-governance-lint-status/v1` 派生证据；blocking lint 进入 `missing_inputs`，advisory lint 只进入风险摘要，不产生 reviewer 结论
+- `suite_path_consumption`
+  - full path 的 required artifacts、evidence-map freshness、consistency-analysis
+    blocking/advisory 分类
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - full path 缺必需输入或 minimal path 无有效 rationale 时必须 fail-closed
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> governance-lint` 顺序列出
 

--- a/skills/loom-spec-review/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-spec-review/SKILL.md
@@ -39,6 +39,12 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - formal spec 路径不存在时，`flow spec-review` 必须 fail-closed
 - spec review 只写回单一 spec review record，不替代 implementation review record
 - `reviewed_head` 与 stale 语义必须显式暴露，供后续 gate 消费
+- full path 必须消费 suite path locator、必需工件 locator、provenance，以及
+  evidence-map / consistency-analysis / gate-chain 适用性结论；缺失或不可读时
+  fail-closed，回退到 spec shaping 或 suite path 修正
+- minimal path 只能消费带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable`；无理由缺口、`deferred` 或 source/generated sync 待办不得被当作
+  spec gate 通过
 
 ## 3. 固定编排
 
@@ -57,6 +63,9 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
 - 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不重新定义 full suite、minimal suite、evidence-map、consistency-analysis 或
+  gate-chain 语义；只消费这些合同已经定义的 locator、freshness、classification
+  与 fallback 边界
 
 ## 4. 输出要求
 
@@ -66,6 +75,8 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - spec review 的机械基线结果
 - spec review record 的定位与当前结论
 - reviewed head 绑定、当前 head、是否 stale
+- suite path decision，以及 full path readiness 或 minimal path `not_applicable`
+  rationale 是否可被 spec gate 消费
 - 审查结论（`allow` / `block` / `fallback`）
 - 若当前不能继续，应回退到哪里
 

--- a/skills/loom-spec-review/.loom-runtime/loom-spec-review/references/input-signals.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-spec-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - formal spec 路径或明确的 spec review 意图
+- suite path decision：full path 的必需工件 locator，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-spec-review/.loom-runtime/loom-spec-review/references/output-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-spec-review/references/output-contract.md
@@ -22,6 +22,11 @@
   - `checkpoint build` 的结果、摘要、阻断项与回退去向
 - `gate_chain`
   - `spec_gate`、`build_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - `path: full|minimal`
+  - full path 的 suite locator、required artifact locators、provenance 与 freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - 无理由 missing、stale、conflict 或 deferred 输入必须进入 `missing_inputs`
 - `spec_review`
   - formal spec 路径、spec review record、head 绑定、stale 语义与当前 gate 结论
 - `spec_review_authority_migration`

--- a/skills/loom-spec-review/.loom-runtime/loom-story/SKILL.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-story/SKILL.md
@@ -85,6 +85,21 @@ User Story 主体不得包含 delivery handoff、spec locator、plan locator、r
 - `Work Item` 仍是唯一执行入口
 - issue tree、Phase / FR / Work Item / PR 切分、blocked-by/blocks 与 host carrier mapping 由 `loom-init` 的 delivery planning 路由承接
 
+## 6. Full / Minimal Suite Path 边界
+
+`loom-story` 不选择或重定义 full/minimal suite path；它只产出可被
+`spec-suite` 消费的 story readiness 与 business confirmation 输入。
+
+- full path：若 formal spec path 消费 story，必须输出 Story Readiness 与 Story
+  Business Confirmation locator，且 decision 为 `confirmed` 或明确
+  `not_applicable`。`pending` / `revision-requested` 必须 fail closed，回到 story
+  shaping 或等待业务语义确认。
+- minimal path：纯治理、维护、格式、链接修复或载体整理可以输出
+  `not_applicable`，但必须包含 bypass rationale、consumer boundary 和 recheck
+  condition，供 `spec.md`、`plan.md`、evidence-map 与后续 gate 消费。
+- `loom-story` 不把 `not_applicable` 升级成产品确认，不生成 evidence-map、
+  consistency-analysis、review、merge-ready 或 GitHub closeout truth。
+
 输入信号与输出合同见：
 
 - [references/input-signals.md](./references/input-signals.md)

--- a/skills/loom-spec-review/.loom-runtime/loom-story/references/output-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/loom-story/references/output-contract.md
@@ -28,6 +28,8 @@
   - story scenario 到 `plan.md` validation strategy 的映射
   - spec / plan 只消费已 `confirmed` 或明确 `not_applicable` 的 story 语义
   - 任何 `pending` 或 `revision-requested` 的 readiness / confirmation 都必须 fail closed，阻止 formal spec shaping
+  - full path 需要可消费的 readiness / confirmation locator；minimal path 需要
+    `not_applicable` rationale、consumer boundary 和 recheck condition
   - `Work Item` 仍是唯一执行入口
 - `missing_inputs`
   - 当前阻断 story shaping 的缺口；无阻断时为空数组

--- a/skills/loom-spec-review/.loom-runtime/route-matrix.md
+++ b/skills/loom-spec-review/.loom-runtime/route-matrix.md
@@ -45,7 +45,42 @@
 - `GitHub controlled merge`
   - merge 由宿主控制面执行；Loom 只消费 required checks、review、head 绑定与 merge gate 结果
 
-## 4. `governance_surface` 公共合同
+## 4. Formal Spec Suite Path 消费边界
+
+`loom-story`、`loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+必须消费 `docs/methodology/templates/spec-suite.md` 已定义的
+`full suite` / `minimal suite` path decision，不得在 skill 中重新定义 suite
+工件、evidence-map、consistency-analysis 或 gate-chain 语义。
+
+固定消费规则：
+
+- `full path` 表示当前事项选择完整 formal spec suite。后续 skill 必须能读取
+  suite path locator、必需工件 locator、条件工件的适用性判断、provenance，以及
+  #1018/#1019 合同声明适用时的 evidence-map、consistency-analysis 与 gate-chain
+  消费结论。
+- `full path` 缺少必需工件、locator、provenance 或当前 gate 所需 evidence 时，
+  `loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+  必须 fail-closed，返回 `block` 或带明确 `fallback_to` 的 `fallback`。
+- `minimal path` 是合法路径，但只能通过带 rationale、consumer boundary 和
+  recheck condition 的 `not_applicable` 消费 full path 附加工件；无理由缺口仍是
+  `missing`，不得被当成 `not_applicable`。
+- `deferred` 不等于 `not_applicable`。deferred source/generated sync、CLI surface
+  或后续 FR 工作只能作为后续事项输入，不得被当前 skill 当成 completed truth。
+- GitHub issue、sub-issue、Project item、PR、checklist 或 repo-local carrier 只按
+  GitHub task carrier profile 读取 locator、state、provenance 和冲突状态；不得替代
+  Work Item、spec suite、review record 或 merge-ready truth。
+
+场景到消费边界：
+
+| Skill | full path 消费 | minimal path 消费 |
+| --- | --- | --- |
+| `loom-story` | 输出 Story Readiness / Business Confirmation locator，供 `spec.md` / `plan.md` 和 suite path decision 消费 | 对纯治理、维护、格式、链接类事项输出 `not_applicable` rationale、consumer boundary、recheck condition |
+| `loom-spec-review` | 消费 suite path、formal spec、plan、必需工件、evidence-map / consistency-analysis 适用性；缺必需输入时 fail-closed | 只接受有效 `not_applicable` rationale；否则回退到 spec shaping / suite path 修正 |
+| `loom-build` | 在 build readiness 前消费 full suite readiness、scenario-to-validation mapping、task carrier profile locator | 合法跳过附加工件，但必须保留 rationale 和替代验证入口 |
+| `loom-pre-review` | 在 review 前消费 full suite locator、evidence-map freshness、consistency-analysis blocking/advisory 分类 | 缺口必须是有效 `not_applicable`，否则阻断 review admission |
+| `loom-merge-ready` | 在 merge gate 消费 reviewed full suite evidence、gate-chain、PR head / reviewed head / validation freshness | 只把有效 minimal path rationale 当作合法跳过，不把 missing 或 deferred 当作 ready |
+
+## 5. `governance_surface` 公共合同
 
 以下三类入口对外暴露的公共治理读面固定命名为 `governance_surface`：
 
@@ -73,7 +108,7 @@
 - 只回答 locator 与职责边界，不复制实时停点、下一步、阻断项、验证摘要
 - 若需要回答 gate 进度，统一通过 `review_merge_surface` 或 `status control plane` 读取，不在 `governance_surface` 并行维护 authored gate 状态
 
-## 5. Planning 边界
+## 6. Planning 边界
 
 `delivery planning` 是 `loom-init` 的路由结果，不是 build、review 或 merge-ready 的前置硬门禁。
 
@@ -102,7 +137,7 @@ planning 输出只能包含：
 
 planning 输出不能声明某个 Work Item 已完成，不能替代 `spec.md` / `plan.md`，不能替代 review、merge-ready、closeout，也不能直接改写 GitHub，除非用户明确要求执行创建或更新动作。
 
-## 6. fallback 语义
+## 7. fallback 语义
 
 出现以下任一情况时，root skill 不做猜测，直接回退到 `loom-init`：
 

--- a/skills/loom-spec-review/.loom-runtime/shared/references/templates/spec-suite.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/templates/spec-suite.md
@@ -18,6 +18,21 @@ Loom 当前把正式规约套件的最小内核定义为：
 
 这两个工件分别承担不同职责，不得混写。
 
+Formal spec path 有两条合法 suite path：
+
+- `minimal suite`
+  - 必含 `spec.md` 与 `plan.md`
+  - 适用于低风险、局部、纯治理或文档类事项
+  - 可用 `not_applicable` rationale 合法跳过 full path 附加工件
+- `full suite`
+  - 在 minimal suite 之上消费 suite-index、条件附加工件、evidence-map、
+    consistency-analysis 与 gate-chain consumption
+  - 适用于 formal spec、高风险、跨模块、强 review 或需要完整证据链的事项
+
+路径选择必须有 locator 与 provenance。若从 full path 降到 minimal path，必须说明
+附加工件为什么 `not_applicable`；若从 minimal path 升到 full path，必须说明触发信号
+和需要补齐的工件。
+
 ## 2. `spec.md` 最小要求
 
 `spec.md` 至少应表达：
@@ -58,6 +73,17 @@ Loom 当前把正式规约套件的最小内核定义为：
 - 不能自动化的行为必须声明人工验证路径、证据 locator 与 fresh 条件
 - 纯文档或治理规则变更可以不强制 TDD，但必须说明行为证据如何由结构检查、审查记录或示例消费
 
+映射状态必须可被后续 gate 消费：
+
+- `scenario_id` / scenario locator 映射到 automated、manual、structural 或
+  `not_applicable` validation strategy
+- `acceptance_id` / acceptance locator 映射到 test evidence、structural check、
+  manual evidence 或 `not_applicable`
+- full path 下，缺少 scenario -> validation 或 acceptance -> test mapping 默认阻断
+  build / review
+- minimal path 下，缺映射必须以 `not_applicable` rationale、替代验证入口和
+  recheck condition 解释
+
 ## 4. 套件边界规则
 
 Loom 必须区分：
@@ -74,6 +100,11 @@ Loom 当前不固化：
 
 - 所有项目都必须有同一组附加工件
 - `TODO.md` 或同类文件是永恒必选项
+
+Full path 缺少必需工件、locator、provenance 或 gate 所需 evidence 时必须
+fail-closed。Minimal path 缺少 full path 附加工件时，只有同时具备 rationale、
+consumer boundary 与 recheck condition 的 `not_applicable` 才能消解；无理由缺口
+仍是 `missing`。`deferred` 不等于 `not_applicable`，不得作为 completed truth 消费。
 
 ## 5. 行为证据与测试证据
 

--- a/skills/loom-spec-review/SKILL.md
+++ b/skills/loom-spec-review/SKILL.md
@@ -39,6 +39,12 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - formal spec 路径不存在时，`flow spec-review` 必须 fail-closed
 - spec review 只写回单一 spec review record，不替代 implementation review record
 - `reviewed_head` 与 stale 语义必须显式暴露，供后续 gate 消费
+- full path 必须消费 suite path locator、必需工件 locator、provenance，以及
+  evidence-map / consistency-analysis / gate-chain 适用性结论；缺失或不可读时
+  fail-closed，回退到 spec shaping 或 suite path 修正
+- minimal path 只能消费带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable`；无理由缺口、`deferred` 或 source/generated sync 待办不得被当作
+  spec gate 通过
 
 ## 3. 固定编排
 
@@ -57,6 +63,9 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
 - 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不重新定义 full suite、minimal suite、evidence-map、consistency-analysis 或
+  gate-chain 语义；只消费这些合同已经定义的 locator、freshness、classification
+  与 fallback 边界
 
 ## 4. 输出要求
 
@@ -66,6 +75,8 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - spec review 的机械基线结果
 - spec review record 的定位与当前结论
 - reviewed head 绑定、当前 head、是否 stale
+- suite path decision，以及 full path readiness 或 minimal path `not_applicable`
+  rationale 是否可被 spec gate 消费
 - 审查结论（`allow` / `block` / `fallback`）
 - 若当前不能继续，应回退到哪里
 

--- a/skills/loom-spec-review/references/input-signals.md
+++ b/skills/loom-spec-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - formal spec 路径或明确的 spec review 意图
+- suite path decision：full path 的必需工件 locator，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-spec-review/references/output-contract.md
+++ b/skills/loom-spec-review/references/output-contract.md
@@ -22,6 +22,11 @@
   - `checkpoint build` 的结果、摘要、阻断项与回退去向
 - `gate_chain`
   - `spec_gate`、`build_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - `path: full|minimal`
+  - full path 的 suite locator、required artifact locators、provenance 与 freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - 无理由 missing、stale、conflict 或 deferred 输入必须进入 `missing_inputs`
 - `spec_review`
   - formal spec 路径、spec review record、head 绑定、stale 语义与当前 gate 结论
 - `spec_review_authority_migration`

--- a/skills/loom-story/.loom-runtime/loom-build/SKILL.md
+++ b/skills/loom-story/.loom-runtime/loom-build/SKILL.md
@@ -55,10 +55,21 @@ subagent-driven mode 必须先声明以下字段：
 - 多个委派声明重叠 `write_ownership`
 - 多轮或多个委派报告同一 blocker signature
 - 缺少 Work Item、spec、plan、recovery、validation baseline、workspace 或 ownership constraints
+- 选择 full path 但 suite-index、必需 suite 工件、scenario-to-validation mapping、
+  task carrier profile locator、provenance 或当前 build gate 所需 evidence 缺失
+- 选择 minimal path 但 full path 附加工件缺口没有 `not_applicable` rationale、
+  consumer boundary、recheck condition 或替代验证入口
+- 把 `deferred`、source/generated sync 待办或 CLI surface 待办当作 build readiness
+  的 completed truth
 
 ## 5. 完成标准
 
 只有当 `flow build` 返回 pass，且 build evidence 证明所有委派输出已集成、无 ownership overlap、无 repeated blocker 时，才允许继续进入 pre-review / review。
+
+Build readiness 只消费 full/minimal suite path 决策，不重新定义 suite 工件、
+evidence-map、consistency-analysis 或 gate-chain。full path 必须证明必需工件可读且
+fresh；minimal path 必须保留合法 `not_applicable` rationale，并把 recheck condition
+传递给后续 pre-review / review。
 
 输入信号与输出合同见：
 

--- a/skills/loom-story/.loom-runtime/loom-build/references/input-signals.md
+++ b/skills/loom-story/.loom-runtime/loom-build/references/input-signals.md
@@ -14,4 +14,6 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - Work Item、spec、plan、recovery baseline、validation baseline、workspace 和 ownership constraints
+- suite path decision：full path 的 suite / evidence locators，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition 与替代验证入口
 - 若使用 subagent-driven mode，必须提供 delegation/build evidence locator

--- a/skills/loom-story/.loom-runtime/loom-build/references/output-contract.md
+++ b/skills/loom-story/.loom-runtime/loom-build/references/output-contract.md
@@ -26,6 +26,12 @@
   - `integration_evidence`
   - `ownership_conflicts`
   - `repeated_blocker_signal`
+- `suite_path_consumption`
+  - full path 的必需工件、scenario-to-validation mapping、task carrier locator 与
+    provenance 是否可读
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+    与替代验证入口
+  - 缺失、stale、conflict 或无理由跳过时必须阻断 build readiness
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> build-execution` 顺序列出
 

--- a/skills/loom-story/.loom-runtime/loom-merge-ready/SKILL.md
+++ b/skills/loom-story/.loom-runtime/loom-merge-ready/SKILL.md
@@ -17,6 +17,14 @@ description: 负责 merge 前统一放行。Use when Codex needs to confirm whet
 - 只输出进入 `GitHub controlled merge` 前的统一放行摘要，不替代宿主平台 merge 动作
 - PR 合并前的宿主硬门禁由 `pr-gate check` 和 `controlled-merge check|merge` 承接；它们只能消费 authored Loom review record，不能把 raw review/shadow evidence 当作 approval
 - 不新建 authored 真相源，也不直接执行平台合并
+- 消费 full/minimal suite path、evidence-map freshness、consistency-analysis
+  classification 与 gate-chain 当前状态，但不重新定义这些合同
+- full path 下，review record 必须证明已消费 suite locators、evidence-map、
+  consistency-analysis、PR head / reviewed head / validation freshness；缺失、stale 或
+  conflict 必须 fail-closed
+- minimal path 下，只有带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable` 可以跳过 full path 附加工件；missing、deferred 或 source/generated
+  sync 待办不能被当作 merge-ready
 
 输入信号与输出合同见：
 

--- a/skills/loom-story/.loom-runtime/loom-merge-ready/references/input-signals.md
+++ b/skills/loom-story/.loom-runtime/loom-merge-ready/references/input-signals.md
@@ -6,3 +6,11 @@
 - 最终放行前预检
 - 确认当前事项是否可合并
 - 确认 `GitHub controlled merge` 前置是否齐全
+
+最小输入：
+
+- 目标仓库
+- 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 reviewed suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+- PR locator、head SHA、reviewed head 与 validation freshness 证据

--- a/skills/loom-story/.loom-runtime/loom-merge-ready/references/output-contract.md
+++ b/skills/loom-story/.loom-runtime/loom-merge-ready/references/output-contract.md
@@ -28,6 +28,11 @@
   - `loom-governance-lint-status/v1` 派生证据；只消费 fact-chain 与 repo companion 的 blocking/advisory lint result，不替代 authored review record、merge checkpoint 或 host merge truth
 - `gate_chain`
   - `spec_gate`、`build_gate`、`review_gate`、`merge_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - full path 的 suite readiness、evidence-map、consistency-analysis、reviewed
+    locators、PR head / reviewed head / validation freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - missing、stale、conflict、deferred 或无理由跳过必须进入 `missing_inputs`
 - `github_controlled_merge`
   - required checks、branch protection、merge method 与 host merge 前置状态
 - `retained_host_signals`

--- a/skills/loom-story/.loom-runtime/loom-pre-review/SKILL.md
+++ b/skills/loom-story/.loom-runtime/loom-pre-review/SKILL.md
@@ -43,6 +43,7 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 不替代 reviewer 的语义判断
 - 不直接执行 merge
 - 不回写事实链、恢复入口或状态面
+- 不重新定义 full/minimal suite、evidence-map、consistency-analysis 或 gate-chain
 
 ## 4. 输出要求
 
@@ -53,6 +54,10 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 哪一步阻断了继续进入 review
 - 若阻断，应回退到哪里
 - 当前 steps 的机械结果是什么
+- full path 的 suite locator、evidence-map freshness 与 consistency-analysis
+  blocking/advisory 分类是否已经可供 review 消费
+- minimal path 的 `not_applicable` rationale、consumer boundary 与 recheck condition
+  是否足够；不足时必须 fail-closed，不能进入 review
 
 ## 5. 完成标准
 
@@ -62,6 +67,9 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - `flow pre-review` 的步骤顺序稳定为 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate`
 - 输出 JSON 能直接支撑“是否进入 review 前语义审查”的判断
 - skill 自身不复制治理真相，也不冒充 reviewer 结论
+- full path 缺少必需 suite artifact、provenance、fresh evidence 或存在 blocking
+  consistency gap 时返回 `block` / `fallback`
+- minimal path 只有在缺口具备有效 `not_applicable` rationale 时才允许进入 review
 
 输入信号与输出合同见：
 

--- a/skills/loom-story/.loom-runtime/loom-pre-review/references/input-signals.md
+++ b/skills/loom-story/.loom-runtime/loom-pre-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前 review 意图
 - 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-story/.loom-runtime/loom-pre-review/references/output-contract.md
+++ b/skills/loom-story/.loom-runtime/loom-pre-review/references/output-contract.md
@@ -16,6 +16,11 @@
   - 当前 Loom 入口自己的 scene / carrier 判定，以及 fail-closed 原因
 - `governance_lint`
   - `loom-governance-lint-status/v1` 派生证据；blocking lint 进入 `missing_inputs`，advisory lint 只进入风险摘要，不产生 reviewer 结论
+- `suite_path_consumption`
+  - full path 的 required artifacts、evidence-map freshness、consistency-analysis
+    blocking/advisory 分类
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - full path 缺必需输入或 minimal path 无有效 rationale 时必须 fail-closed
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> governance-lint` 顺序列出
 

--- a/skills/loom-story/.loom-runtime/loom-spec-review/SKILL.md
+++ b/skills/loom-story/.loom-runtime/loom-spec-review/SKILL.md
@@ -39,6 +39,12 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - formal spec 路径不存在时，`flow spec-review` 必须 fail-closed
 - spec review 只写回单一 spec review record，不替代 implementation review record
 - `reviewed_head` 与 stale 语义必须显式暴露，供后续 gate 消费
+- full path 必须消费 suite path locator、必需工件 locator、provenance，以及
+  evidence-map / consistency-analysis / gate-chain 适用性结论；缺失或不可读时
+  fail-closed，回退到 spec shaping 或 suite path 修正
+- minimal path 只能消费带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable`；无理由缺口、`deferred` 或 source/generated sync 待办不得被当作
+  spec gate 通过
 
 ## 3. 固定编排
 
@@ -57,6 +63,9 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
 - 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不重新定义 full suite、minimal suite、evidence-map、consistency-analysis 或
+  gate-chain 语义；只消费这些合同已经定义的 locator、freshness、classification
+  与 fallback 边界
 
 ## 4. 输出要求
 
@@ -66,6 +75,8 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - spec review 的机械基线结果
 - spec review record 的定位与当前结论
 - reviewed head 绑定、当前 head、是否 stale
+- suite path decision，以及 full path readiness 或 minimal path `not_applicable`
+  rationale 是否可被 spec gate 消费
 - 审查结论（`allow` / `block` / `fallback`）
 - 若当前不能继续，应回退到哪里
 

--- a/skills/loom-story/.loom-runtime/loom-spec-review/references/input-signals.md
+++ b/skills/loom-story/.loom-runtime/loom-spec-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - formal spec 路径或明确的 spec review 意图
+- suite path decision：full path 的必需工件 locator，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition

--- a/skills/loom-story/.loom-runtime/loom-spec-review/references/output-contract.md
+++ b/skills/loom-story/.loom-runtime/loom-spec-review/references/output-contract.md
@@ -22,6 +22,11 @@
   - `checkpoint build` 的结果、摘要、阻断项与回退去向
 - `gate_chain`
   - `spec_gate`、`build_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - `path: full|minimal`
+  - full path 的 suite locator、required artifact locators、provenance 与 freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - 无理由 missing、stale、conflict 或 deferred 输入必须进入 `missing_inputs`
 - `spec_review`
   - formal spec 路径、spec review record、head 绑定、stale 语义与当前 gate 结论
 - `spec_review_authority_migration`

--- a/skills/loom-story/.loom-runtime/loom-story/SKILL.md
+++ b/skills/loom-story/.loom-runtime/loom-story/SKILL.md
@@ -85,6 +85,21 @@ User Story 主体不得包含 delivery handoff、spec locator、plan locator、r
 - `Work Item` 仍是唯一执行入口
 - issue tree、Phase / FR / Work Item / PR 切分、blocked-by/blocks 与 host carrier mapping 由 `loom-init` 的 delivery planning 路由承接
 
+## 6. Full / Minimal Suite Path 边界
+
+`loom-story` 不选择或重定义 full/minimal suite path；它只产出可被
+`spec-suite` 消费的 story readiness 与 business confirmation 输入。
+
+- full path：若 formal spec path 消费 story，必须输出 Story Readiness 与 Story
+  Business Confirmation locator，且 decision 为 `confirmed` 或明确
+  `not_applicable`。`pending` / `revision-requested` 必须 fail closed，回到 story
+  shaping 或等待业务语义确认。
+- minimal path：纯治理、维护、格式、链接修复或载体整理可以输出
+  `not_applicable`，但必须包含 bypass rationale、consumer boundary 和 recheck
+  condition，供 `spec.md`、`plan.md`、evidence-map 与后续 gate 消费。
+- `loom-story` 不把 `not_applicable` 升级成产品确认，不生成 evidence-map、
+  consistency-analysis、review、merge-ready 或 GitHub closeout truth。
+
 输入信号与输出合同见：
 
 - [references/input-signals.md](./references/input-signals.md)

--- a/skills/loom-story/.loom-runtime/loom-story/references/output-contract.md
+++ b/skills/loom-story/.loom-runtime/loom-story/references/output-contract.md
@@ -28,6 +28,8 @@
   - story scenario 到 `plan.md` validation strategy 的映射
   - spec / plan 只消费已 `confirmed` 或明确 `not_applicable` 的 story 语义
   - 任何 `pending` 或 `revision-requested` 的 readiness / confirmation 都必须 fail closed，阻止 formal spec shaping
+  - full path 需要可消费的 readiness / confirmation locator；minimal path 需要
+    `not_applicable` rationale、consumer boundary 和 recheck condition
   - `Work Item` 仍是唯一执行入口
 - `missing_inputs`
   - 当前阻断 story shaping 的缺口；无阻断时为空数组

--- a/skills/loom-story/.loom-runtime/route-matrix.md
+++ b/skills/loom-story/.loom-runtime/route-matrix.md
@@ -45,7 +45,42 @@
 - `GitHub controlled merge`
   - merge 由宿主控制面执行；Loom 只消费 required checks、review、head 绑定与 merge gate 结果
 
-## 4. `governance_surface` 公共合同
+## 4. Formal Spec Suite Path 消费边界
+
+`loom-story`、`loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+必须消费 `docs/methodology/templates/spec-suite.md` 已定义的
+`full suite` / `minimal suite` path decision，不得在 skill 中重新定义 suite
+工件、evidence-map、consistency-analysis 或 gate-chain 语义。
+
+固定消费规则：
+
+- `full path` 表示当前事项选择完整 formal spec suite。后续 skill 必须能读取
+  suite path locator、必需工件 locator、条件工件的适用性判断、provenance，以及
+  #1018/#1019 合同声明适用时的 evidence-map、consistency-analysis 与 gate-chain
+  消费结论。
+- `full path` 缺少必需工件、locator、provenance 或当前 gate 所需 evidence 时，
+  `loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+  必须 fail-closed，返回 `block` 或带明确 `fallback_to` 的 `fallback`。
+- `minimal path` 是合法路径，但只能通过带 rationale、consumer boundary 和
+  recheck condition 的 `not_applicable` 消费 full path 附加工件；无理由缺口仍是
+  `missing`，不得被当成 `not_applicable`。
+- `deferred` 不等于 `not_applicable`。deferred source/generated sync、CLI surface
+  或后续 FR 工作只能作为后续事项输入，不得被当前 skill 当成 completed truth。
+- GitHub issue、sub-issue、Project item、PR、checklist 或 repo-local carrier 只按
+  GitHub task carrier profile 读取 locator、state、provenance 和冲突状态；不得替代
+  Work Item、spec suite、review record 或 merge-ready truth。
+
+场景到消费边界：
+
+| Skill | full path 消费 | minimal path 消费 |
+| --- | --- | --- |
+| `loom-story` | 输出 Story Readiness / Business Confirmation locator，供 `spec.md` / `plan.md` 和 suite path decision 消费 | 对纯治理、维护、格式、链接类事项输出 `not_applicable` rationale、consumer boundary、recheck condition |
+| `loom-spec-review` | 消费 suite path、formal spec、plan、必需工件、evidence-map / consistency-analysis 适用性；缺必需输入时 fail-closed | 只接受有效 `not_applicable` rationale；否则回退到 spec shaping / suite path 修正 |
+| `loom-build` | 在 build readiness 前消费 full suite readiness、scenario-to-validation mapping、task carrier profile locator | 合法跳过附加工件，但必须保留 rationale 和替代验证入口 |
+| `loom-pre-review` | 在 review 前消费 full suite locator、evidence-map freshness、consistency-analysis blocking/advisory 分类 | 缺口必须是有效 `not_applicable`，否则阻断 review admission |
+| `loom-merge-ready` | 在 merge gate 消费 reviewed full suite evidence、gate-chain、PR head / reviewed head / validation freshness | 只把有效 minimal path rationale 当作合法跳过，不把 missing 或 deferred 当作 ready |
+
+## 5. `governance_surface` 公共合同
 
 以下三类入口对外暴露的公共治理读面固定命名为 `governance_surface`：
 
@@ -73,7 +108,7 @@
 - 只回答 locator 与职责边界，不复制实时停点、下一步、阻断项、验证摘要
 - 若需要回答 gate 进度，统一通过 `review_merge_surface` 或 `status control plane` 读取，不在 `governance_surface` 并行维护 authored gate 状态
 
-## 5. Planning 边界
+## 6. Planning 边界
 
 `delivery planning` 是 `loom-init` 的路由结果，不是 build、review 或 merge-ready 的前置硬门禁。
 
@@ -102,7 +137,7 @@ planning 输出只能包含：
 
 planning 输出不能声明某个 Work Item 已完成，不能替代 `spec.md` / `plan.md`，不能替代 review、merge-ready、closeout，也不能直接改写 GitHub，除非用户明确要求执行创建或更新动作。
 
-## 6. fallback 语义
+## 7. fallback 语义
 
 出现以下任一情况时，root skill 不做猜测，直接回退到 `loom-init`：
 

--- a/skills/loom-story/.loom-runtime/shared/references/templates/spec-suite.md
+++ b/skills/loom-story/.loom-runtime/shared/references/templates/spec-suite.md
@@ -18,6 +18,21 @@ Loom 当前把正式规约套件的最小内核定义为：
 
 这两个工件分别承担不同职责，不得混写。
 
+Formal spec path 有两条合法 suite path：
+
+- `minimal suite`
+  - 必含 `spec.md` 与 `plan.md`
+  - 适用于低风险、局部、纯治理或文档类事项
+  - 可用 `not_applicable` rationale 合法跳过 full path 附加工件
+- `full suite`
+  - 在 minimal suite 之上消费 suite-index、条件附加工件、evidence-map、
+    consistency-analysis 与 gate-chain consumption
+  - 适用于 formal spec、高风险、跨模块、强 review 或需要完整证据链的事项
+
+路径选择必须有 locator 与 provenance。若从 full path 降到 minimal path，必须说明
+附加工件为什么 `not_applicable`；若从 minimal path 升到 full path，必须说明触发信号
+和需要补齐的工件。
+
 ## 2. `spec.md` 最小要求
 
 `spec.md` 至少应表达：
@@ -58,6 +73,17 @@ Loom 当前把正式规约套件的最小内核定义为：
 - 不能自动化的行为必须声明人工验证路径、证据 locator 与 fresh 条件
 - 纯文档或治理规则变更可以不强制 TDD，但必须说明行为证据如何由结构检查、审查记录或示例消费
 
+映射状态必须可被后续 gate 消费：
+
+- `scenario_id` / scenario locator 映射到 automated、manual、structural 或
+  `not_applicable` validation strategy
+- `acceptance_id` / acceptance locator 映射到 test evidence、structural check、
+  manual evidence 或 `not_applicable`
+- full path 下，缺少 scenario -> validation 或 acceptance -> test mapping 默认阻断
+  build / review
+- minimal path 下，缺映射必须以 `not_applicable` rationale、替代验证入口和
+  recheck condition 解释
+
 ## 4. 套件边界规则
 
 Loom 必须区分：
@@ -74,6 +100,11 @@ Loom 当前不固化：
 
 - 所有项目都必须有同一组附加工件
 - `TODO.md` 或同类文件是永恒必选项
+
+Full path 缺少必需工件、locator、provenance 或 gate 所需 evidence 时必须
+fail-closed。Minimal path 缺少 full path 附加工件时，只有同时具备 rationale、
+consumer boundary 与 recheck condition 的 `not_applicable` 才能消解；无理由缺口
+仍是 `missing`。`deferred` 不等于 `not_applicable`，不得作为 completed truth 消费。
 
 ## 5. 行为证据与测试证据
 

--- a/skills/loom-story/SKILL.md
+++ b/skills/loom-story/SKILL.md
@@ -85,6 +85,21 @@ User Story 主体不得包含 delivery handoff、spec locator、plan locator、r
 - `Work Item` 仍是唯一执行入口
 - issue tree、Phase / FR / Work Item / PR 切分、blocked-by/blocks 与 host carrier mapping 由 `loom-init` 的 delivery planning 路由承接
 
+## 6. Full / Minimal Suite Path 边界
+
+`loom-story` 不选择或重定义 full/minimal suite path；它只产出可被
+`spec-suite` 消费的 story readiness 与 business confirmation 输入。
+
+- full path：若 formal spec path 消费 story，必须输出 Story Readiness 与 Story
+  Business Confirmation locator，且 decision 为 `confirmed` 或明确
+  `not_applicable`。`pending` / `revision-requested` 必须 fail closed，回到 story
+  shaping 或等待业务语义确认。
+- minimal path：纯治理、维护、格式、链接修复或载体整理可以输出
+  `not_applicable`，但必须包含 bypass rationale、consumer boundary 和 recheck
+  condition，供 `spec.md`、`plan.md`、evidence-map 与后续 gate 消费。
+- `loom-story` 不把 `not_applicable` 升级成产品确认，不生成 evidence-map、
+  consistency-analysis、review、merge-ready 或 GitHub closeout truth。
+
 输入信号与输出合同见：
 
 - [references/input-signals.md](./references/input-signals.md)

--- a/skills/loom-story/references/output-contract.md
+++ b/skills/loom-story/references/output-contract.md
@@ -28,6 +28,8 @@
   - story scenario 到 `plan.md` validation strategy 的映射
   - spec / plan 只消费已 `confirmed` 或明确 `not_applicable` 的 story 语义
   - 任何 `pending` 或 `revision-requested` 的 readiness / confirmation 都必须 fail closed，阻止 formal spec shaping
+  - full path 需要可消费的 readiness / confirmation locator；minimal path 需要
+    `not_applicable` rationale、consumer boundary 和 recheck condition
   - `Work Item` 仍是唯一执行入口
 - `missing_inputs`
   - 当前阻断 story shaping 的缺口；无阻断时为空数组

--- a/skills/route-matrix.md
+++ b/skills/route-matrix.md
@@ -45,7 +45,42 @@
 - `GitHub controlled merge`
   - merge 由宿主控制面执行；Loom 只消费 required checks、review、head 绑定与 merge gate 结果
 
-## 4. `governance_surface` 公共合同
+## 4. Formal Spec Suite Path 消费边界
+
+`loom-story`、`loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+必须消费 `docs/methodology/templates/spec-suite.md` 已定义的
+`full suite` / `minimal suite` path decision，不得在 skill 中重新定义 suite
+工件、evidence-map、consistency-analysis 或 gate-chain 语义。
+
+固定消费规则：
+
+- `full path` 表示当前事项选择完整 formal spec suite。后续 skill 必须能读取
+  suite path locator、必需工件 locator、条件工件的适用性判断、provenance，以及
+  #1018/#1019 合同声明适用时的 evidence-map、consistency-analysis 与 gate-chain
+  消费结论。
+- `full path` 缺少必需工件、locator、provenance 或当前 gate 所需 evidence 时，
+  `loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+  必须 fail-closed，返回 `block` 或带明确 `fallback_to` 的 `fallback`。
+- `minimal path` 是合法路径，但只能通过带 rationale、consumer boundary 和
+  recheck condition 的 `not_applicable` 消费 full path 附加工件；无理由缺口仍是
+  `missing`，不得被当成 `not_applicable`。
+- `deferred` 不等于 `not_applicable`。deferred source/generated sync、CLI surface
+  或后续 FR 工作只能作为后续事项输入，不得被当前 skill 当成 completed truth。
+- GitHub issue、sub-issue、Project item、PR、checklist 或 repo-local carrier 只按
+  GitHub task carrier profile 读取 locator、state、provenance 和冲突状态；不得替代
+  Work Item、spec suite、review record 或 merge-ready truth。
+
+场景到消费边界：
+
+| Skill | full path 消费 | minimal path 消费 |
+| --- | --- | --- |
+| `loom-story` | 输出 Story Readiness / Business Confirmation locator，供 `spec.md` / `plan.md` 和 suite path decision 消费 | 对纯治理、维护、格式、链接类事项输出 `not_applicable` rationale、consumer boundary、recheck condition |
+| `loom-spec-review` | 消费 suite path、formal spec、plan、必需工件、evidence-map / consistency-analysis 适用性；缺必需输入时 fail-closed | 只接受有效 `not_applicable` rationale；否则回退到 spec shaping / suite path 修正 |
+| `loom-build` | 在 build readiness 前消费 full suite readiness、scenario-to-validation mapping、task carrier profile locator | 合法跳过附加工件，但必须保留 rationale 和替代验证入口 |
+| `loom-pre-review` | 在 review 前消费 full suite locator、evidence-map freshness、consistency-analysis blocking/advisory 分类 | 缺口必须是有效 `not_applicable`，否则阻断 review admission |
+| `loom-merge-ready` | 在 merge gate 消费 reviewed full suite evidence、gate-chain、PR head / reviewed head / validation freshness | 只把有效 minimal path rationale 当作合法跳过，不把 missing 或 deferred 当作 ready |
+
+## 5. `governance_surface` 公共合同
 
 以下三类入口对外暴露的公共治理读面固定命名为 `governance_surface`：
 
@@ -73,7 +108,7 @@
 - 只回答 locator 与职责边界，不复制实时停点、下一步、阻断项、验证摘要
 - 若需要回答 gate 进度，统一通过 `review_merge_surface` 或 `status control plane` 读取，不在 `governance_surface` 并行维护 authored gate 状态
 
-## 5. Planning 边界
+## 6. Planning 边界
 
 `delivery planning` 是 `loom-init` 的路由结果，不是 build、review 或 merge-ready 的前置硬门禁。
 
@@ -102,7 +137,7 @@ planning 输出只能包含：
 
 planning 输出不能声明某个 Work Item 已完成，不能替代 `spec.md` / `plan.md`，不能替代 review、merge-ready、closeout，也不能直接改写 GitHub，除非用户明确要求执行创建或更新动作。
 
-## 6. fallback 语义
+## 7. fallback 语义
 
 出现以下任一情况时，root skill 不做猜测，直接回退到 `loom-init`：
 

--- a/skills/shared/references/templates/spec-suite.md
+++ b/skills/shared/references/templates/spec-suite.md
@@ -18,6 +18,21 @@ Loom 当前把正式规约套件的最小内核定义为：
 
 这两个工件分别承担不同职责，不得混写。
 
+Formal spec path 有两条合法 suite path：
+
+- `minimal suite`
+  - 必含 `spec.md` 与 `plan.md`
+  - 适用于低风险、局部、纯治理或文档类事项
+  - 可用 `not_applicable` rationale 合法跳过 full path 附加工件
+- `full suite`
+  - 在 minimal suite 之上消费 suite-index、条件附加工件、evidence-map、
+    consistency-analysis 与 gate-chain consumption
+  - 适用于 formal spec、高风险、跨模块、强 review 或需要完整证据链的事项
+
+路径选择必须有 locator 与 provenance。若从 full path 降到 minimal path，必须说明
+附加工件为什么 `not_applicable`；若从 minimal path 升到 full path，必须说明触发信号
+和需要补齐的工件。
+
 ## 2. `spec.md` 最小要求
 
 `spec.md` 至少应表达：
@@ -58,6 +73,17 @@ Loom 当前把正式规约套件的最小内核定义为：
 - 不能自动化的行为必须声明人工验证路径、证据 locator 与 fresh 条件
 - 纯文档或治理规则变更可以不强制 TDD，但必须说明行为证据如何由结构检查、审查记录或示例消费
 
+映射状态必须可被后续 gate 消费：
+
+- `scenario_id` / scenario locator 映射到 automated、manual、structural 或
+  `not_applicable` validation strategy
+- `acceptance_id` / acceptance locator 映射到 test evidence、structural check、
+  manual evidence 或 `not_applicable`
+- full path 下，缺少 scenario -> validation 或 acceptance -> test mapping 默认阻断
+  build / review
+- minimal path 下，缺映射必须以 `not_applicable` rationale、替代验证入口和
+  recheck condition 解释
+
 ## 4. 套件边界规则
 
 Loom 必须区分：
@@ -74,6 +100,11 @@ Loom 当前不固化：
 
 - 所有项目都必须有同一组附加工件
 - `TODO.md` 或同类文件是永恒必选项
+
+Full path 缺少必需工件、locator、provenance 或 gate 所需 evidence 时必须
+fail-closed。Minimal path 缺少 full path 附加工件时，只有同时具备 rationale、
+consumer boundary 与 recheck condition 的 `not_applicable` 才能消解；无理由缺口
+仍是 `missing`。`deferred` 不等于 `not_applicable`，不得作为 completed truth 消费。
 
 ## 5. 行为证据与测试证据
 

--- a/src/skills/loom-build/SKILL.md
+++ b/src/skills/loom-build/SKILL.md
@@ -55,10 +55,21 @@ subagent-driven mode 必须先声明以下字段：
 - 多个委派声明重叠 `write_ownership`
 - 多轮或多个委派报告同一 blocker signature
 - 缺少 Work Item、spec、plan、recovery、validation baseline、workspace 或 ownership constraints
+- 选择 full path 但 suite-index、必需 suite 工件、scenario-to-validation mapping、
+  task carrier profile locator、provenance 或当前 build gate 所需 evidence 缺失
+- 选择 minimal path 但 full path 附加工件缺口没有 `not_applicable` rationale、
+  consumer boundary、recheck condition 或替代验证入口
+- 把 `deferred`、source/generated sync 待办或 CLI surface 待办当作 build readiness
+  的 completed truth
 
 ## 5. 完成标准
 
 只有当 `flow build` 返回 pass，且 build evidence 证明所有委派输出已集成、无 ownership overlap、无 repeated blocker 时，才允许继续进入 pre-review / review。
+
+Build readiness 只消费 full/minimal suite path 决策，不重新定义 suite 工件、
+evidence-map、consistency-analysis 或 gate-chain。full path 必须证明必需工件可读且
+fresh；minimal path 必须保留合法 `not_applicable` rationale，并把 recheck condition
+传递给后续 pre-review / review。
 
 输入信号与输出合同见：
 

--- a/src/skills/loom-build/references/input-signals.md
+++ b/src/skills/loom-build/references/input-signals.md
@@ -14,4 +14,6 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - Work Item、spec、plan、recovery baseline、validation baseline、workspace 和 ownership constraints
+- suite path decision：full path 的 suite / evidence locators，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition 与替代验证入口
 - 若使用 subagent-driven mode，必须提供 delegation/build evidence locator

--- a/src/skills/loom-build/references/output-contract.md
+++ b/src/skills/loom-build/references/output-contract.md
@@ -26,6 +26,12 @@
   - `integration_evidence`
   - `ownership_conflicts`
   - `repeated_blocker_signal`
+- `suite_path_consumption`
+  - full path 的必需工件、scenario-to-validation mapping、task carrier locator 与
+    provenance 是否可读
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+    与替代验证入口
+  - 缺失、stale、conflict 或无理由跳过时必须阻断 build readiness
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> build-execution` 顺序列出
 

--- a/src/skills/loom-merge-ready/SKILL.md
+++ b/src/skills/loom-merge-ready/SKILL.md
@@ -17,6 +17,14 @@ description: 负责 merge 前统一放行。Use when Codex needs to confirm whet
 - 只输出进入 `GitHub controlled merge` 前的统一放行摘要，不替代宿主平台 merge 动作
 - PR 合并前的宿主硬门禁由 `pr-gate check` 和 `controlled-merge check|merge` 承接；它们只能消费 authored Loom review record，不能把 raw review/shadow evidence 当作 approval
 - 不新建 authored 真相源，也不直接执行平台合并
+- 消费 full/minimal suite path、evidence-map freshness、consistency-analysis
+  classification 与 gate-chain 当前状态，但不重新定义这些合同
+- full path 下，review record 必须证明已消费 suite locators、evidence-map、
+  consistency-analysis、PR head / reviewed head / validation freshness；缺失、stale 或
+  conflict 必须 fail-closed
+- minimal path 下，只有带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable` 可以跳过 full path 附加工件；missing、deferred 或 source/generated
+  sync 待办不能被当作 merge-ready
 
 输入信号与输出合同见：
 

--- a/src/skills/loom-merge-ready/references/input-signals.md
+++ b/src/skills/loom-merge-ready/references/input-signals.md
@@ -6,3 +6,11 @@
 - 最终放行前预检
 - 确认当前事项是否可合并
 - 确认 `GitHub controlled merge` 前置是否齐全
+
+最小输入：
+
+- 目标仓库
+- 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 reviewed suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+- PR locator、head SHA、reviewed head 与 validation freshness 证据

--- a/src/skills/loom-merge-ready/references/output-contract.md
+++ b/src/skills/loom-merge-ready/references/output-contract.md
@@ -28,6 +28,11 @@
   - `loom-governance-lint-status/v1` 派生证据；只消费 fact-chain 与 repo companion 的 blocking/advisory lint result，不替代 authored review record、merge checkpoint 或 host merge truth
 - `gate_chain`
   - `spec_gate`、`build_gate`、`review_gate`、`merge_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - full path 的 suite readiness、evidence-map、consistency-analysis、reviewed
+    locators、PR head / reviewed head / validation freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - missing、stale、conflict、deferred 或无理由跳过必须进入 `missing_inputs`
 - `github_controlled_merge`
   - required checks、branch protection、merge method 与 host merge 前置状态
 - `retained_host_signals`

--- a/src/skills/loom-pre-review/SKILL.md
+++ b/src/skills/loom-pre-review/SKILL.md
@@ -43,6 +43,7 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 不替代 reviewer 的语义判断
 - 不直接执行 merge
 - 不回写事实链、恢复入口或状态面
+- 不重新定义 full/minimal suite、evidence-map、consistency-analysis 或 gate-chain
 
 ## 4. 输出要求
 
@@ -53,6 +54,10 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - 哪一步阻断了继续进入 review
 - 若阻断，应回退到哪里
 - 当前 steps 的机械结果是什么
+- full path 的 suite locator、evidence-map freshness 与 consistency-analysis
+  blocking/advisory 分类是否已经可供 review 消费
+- minimal path 的 `not_applicable` rationale、consumer boundary 与 recheck condition
+  是否足够；不足时必须 fail-closed，不能进入 review
 
 ## 5. 完成标准
 
@@ -62,6 +67,9 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 - `flow pre-review` 的步骤顺序稳定为 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate`
 - 输出 JSON 能直接支撑“是否进入 review 前语义审查”的判断
 - skill 自身不复制治理真相，也不冒充 reviewer 结论
+- full path 缺少必需 suite artifact、provenance、fresh evidence 或存在 blocking
+  consistency gap 时返回 `block` / `fallback`
+- minimal path 只有在缺口具备有效 `not_applicable` rationale 时才允许进入 review
 
 输入信号与输出合同见：
 

--- a/src/skills/loom-pre-review/references/input-signals.md
+++ b/src/skills/loom-pre-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前 review 意图
 - 当前事项编号，或允许从事实链定位活跃事项
+- suite path decision：full path 的 suite/evidence/consistency locators，或
+  minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition

--- a/src/skills/loom-pre-review/references/output-contract.md
+++ b/src/skills/loom-pre-review/references/output-contract.md
@@ -16,6 +16,11 @@
   - 当前 Loom 入口自己的 scene / carrier 判定，以及 fail-closed 原因
 - `governance_lint`
   - `loom-governance-lint-status/v1` 派生证据；blocking lint 进入 `missing_inputs`，advisory lint 只进入风险摘要，不产生 reviewer 结论
+- `suite_path_consumption`
+  - full path 的 required artifacts、evidence-map freshness、consistency-analysis
+    blocking/advisory 分类
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - full path 缺必需输入或 minimal path 无有效 rationale 时必须 fail-closed
 - `steps`
   - 固定按 `runtime-state -> fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate -> governance-lint` 顺序列出
 

--- a/src/skills/loom-spec-review/SKILL.md
+++ b/src/skills/loom-spec-review/SKILL.md
@@ -39,6 +39,12 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - formal spec 路径不存在时，`flow spec-review` 必须 fail-closed
 - spec review 只写回单一 spec review record，不替代 implementation review record
 - `reviewed_head` 与 stale 语义必须显式暴露，供后续 gate 消费
+- full path 必须消费 suite path locator、必需工件 locator、provenance，以及
+  evidence-map / consistency-analysis / gate-chain 适用性结论；缺失或不可读时
+  fail-closed，回退到 spec shaping 或 suite path 修正
+- minimal path 只能消费带 rationale、consumer boundary 和 recheck condition 的
+  `not_applicable`；无理由缺口、`deferred` 或 source/generated sync 待办不得被当作
+  spec gate 通过
 
 ## 3. 固定编排
 
@@ -57,6 +63,9 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - 不直接执行 merge 或平台动作
 - 不回写 recovery entry、status control plane 或其他 authored 真相载体
 - 不把 Codex App raw review output 直接升级成 spec review authored truth；verified host default 与显式 Codex App path 都必须经同一 normalized `review_record_input` 与 spec review record 边界
+- 不重新定义 full suite、minimal suite、evidence-map、consistency-analysis 或
+  gate-chain 语义；只消费这些合同已经定义的 locator、freshness、classification
+  与 fallback 边界
 
 ## 4. 输出要求
 
@@ -66,6 +75,8 @@ description: 负责 formal spec review 执行层。Use when Codex needs to revie
 - spec review 的机械基线结果
 - spec review record 的定位与当前结论
 - reviewed head 绑定、当前 head、是否 stale
+- suite path decision，以及 full path readiness 或 minimal path `not_applicable`
+  rationale 是否可被 spec gate 消费
 - 审查结论（`allow` / `block` / `fallback`）
 - 若当前不能继续，应回退到哪里
 

--- a/src/skills/loom-spec-review/references/input-signals.md
+++ b/src/skills/loom-spec-review/references/input-signals.md
@@ -12,3 +12,5 @@
 - 目标仓库
 - 当前事项编号，或允许从事实链定位活跃事项
 - formal spec 路径或明确的 spec review 意图
+- suite path decision：full path 的必需工件 locator，或 minimal path 的
+  `not_applicable` rationale、consumer boundary、recheck condition

--- a/src/skills/loom-spec-review/references/output-contract.md
+++ b/src/skills/loom-spec-review/references/output-contract.md
@@ -22,6 +22,11 @@
   - `checkpoint build` 的结果、摘要、阻断项与回退去向
 - `gate_chain`
   - `spec_gate`、`build_gate` 的当前可消费状态
+- `suite_path_consumption`
+  - `path: full|minimal`
+  - full path 的 suite locator、required artifact locators、provenance 与 freshness
+  - minimal path 的 `not_applicable` rationale、consumer boundary、recheck condition
+  - 无理由 missing、stale、conflict 或 deferred 输入必须进入 `missing_inputs`
 - `spec_review`
   - formal spec 路径、spec review record、head 绑定、stale 语义与当前 gate 结论
 - `spec_review_authority_migration`

--- a/src/skills/loom-story/SKILL.md
+++ b/src/skills/loom-story/SKILL.md
@@ -85,6 +85,21 @@ User Story 主体不得包含 delivery handoff、spec locator、plan locator、r
 - `Work Item` 仍是唯一执行入口
 - issue tree、Phase / FR / Work Item / PR 切分、blocked-by/blocks 与 host carrier mapping 由 `loom-init` 的 delivery planning 路由承接
 
+## 6. Full / Minimal Suite Path 边界
+
+`loom-story` 不选择或重定义 full/minimal suite path；它只产出可被
+`spec-suite` 消费的 story readiness 与 business confirmation 输入。
+
+- full path：若 formal spec path 消费 story，必须输出 Story Readiness 与 Story
+  Business Confirmation locator，且 decision 为 `confirmed` 或明确
+  `not_applicable`。`pending` / `revision-requested` 必须 fail closed，回到 story
+  shaping 或等待业务语义确认。
+- minimal path：纯治理、维护、格式、链接修复或载体整理可以输出
+  `not_applicable`，但必须包含 bypass rationale、consumer boundary 和 recheck
+  condition，供 `spec.md`、`plan.md`、evidence-map 与后续 gate 消费。
+- `loom-story` 不把 `not_applicable` 升级成产品确认，不生成 evidence-map、
+  consistency-analysis、review、merge-ready 或 GitHub closeout truth。
+
 输入信号与输出合同见：
 
 - [references/input-signals.md](./references/input-signals.md)

--- a/src/skills/loom-story/references/output-contract.md
+++ b/src/skills/loom-story/references/output-contract.md
@@ -28,6 +28,8 @@
   - story scenario 到 `plan.md` validation strategy 的映射
   - spec / plan 只消费已 `confirmed` 或明确 `not_applicable` 的 story 语义
   - 任何 `pending` 或 `revision-requested` 的 readiness / confirmation 都必须 fail closed，阻止 formal spec shaping
+  - full path 需要可消费的 readiness / confirmation locator；minimal path 需要
+    `not_applicable` rationale、consumer boundary 和 recheck condition
   - `Work Item` 仍是唯一执行入口
 - `missing_inputs`
   - 当前阻断 story shaping 的缺口；无阻断时为空数组

--- a/src/skills/route-matrix.md
+++ b/src/skills/route-matrix.md
@@ -45,7 +45,42 @@
 - `GitHub controlled merge`
   - merge 由宿主控制面执行；Loom 只消费 required checks、review、head 绑定与 merge gate 结果
 
-## 4. `governance_surface` 公共合同
+## 4. Formal Spec Suite Path 消费边界
+
+`loom-story`、`loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+必须消费 `docs/methodology/templates/spec-suite.md` 已定义的
+`full suite` / `minimal suite` path decision，不得在 skill 中重新定义 suite
+工件、evidence-map、consistency-analysis 或 gate-chain 语义。
+
+固定消费规则：
+
+- `full path` 表示当前事项选择完整 formal spec suite。后续 skill 必须能读取
+  suite path locator、必需工件 locator、条件工件的适用性判断、provenance，以及
+  #1018/#1019 合同声明适用时的 evidence-map、consistency-analysis 与 gate-chain
+  消费结论。
+- `full path` 缺少必需工件、locator、provenance 或当前 gate 所需 evidence 时，
+  `loom-spec-review`、`loom-build`、`loom-pre-review` 与 `loom-merge-ready`
+  必须 fail-closed，返回 `block` 或带明确 `fallback_to` 的 `fallback`。
+- `minimal path` 是合法路径，但只能通过带 rationale、consumer boundary 和
+  recheck condition 的 `not_applicable` 消费 full path 附加工件；无理由缺口仍是
+  `missing`，不得被当成 `not_applicable`。
+- `deferred` 不等于 `not_applicable`。deferred source/generated sync、CLI surface
+  或后续 FR 工作只能作为后续事项输入，不得被当前 skill 当成 completed truth。
+- GitHub issue、sub-issue、Project item、PR、checklist 或 repo-local carrier 只按
+  GitHub task carrier profile 读取 locator、state、provenance 和冲突状态；不得替代
+  Work Item、spec suite、review record 或 merge-ready truth。
+
+场景到消费边界：
+
+| Skill | full path 消费 | minimal path 消费 |
+| --- | --- | --- |
+| `loom-story` | 输出 Story Readiness / Business Confirmation locator，供 `spec.md` / `plan.md` 和 suite path decision 消费 | 对纯治理、维护、格式、链接类事项输出 `not_applicable` rationale、consumer boundary、recheck condition |
+| `loom-spec-review` | 消费 suite path、formal spec、plan、必需工件、evidence-map / consistency-analysis 适用性；缺必需输入时 fail-closed | 只接受有效 `not_applicable` rationale；否则回退到 spec shaping / suite path 修正 |
+| `loom-build` | 在 build readiness 前消费 full suite readiness、scenario-to-validation mapping、task carrier profile locator | 合法跳过附加工件，但必须保留 rationale 和替代验证入口 |
+| `loom-pre-review` | 在 review 前消费 full suite locator、evidence-map freshness、consistency-analysis blocking/advisory 分类 | 缺口必须是有效 `not_applicable`，否则阻断 review admission |
+| `loom-merge-ready` | 在 merge gate 消费 reviewed full suite evidence、gate-chain、PR head / reviewed head / validation freshness | 只把有效 minimal path rationale 当作合法跳过，不把 missing 或 deferred 当作 ready |
+
+## 5. `governance_surface` 公共合同
 
 以下三类入口对外暴露的公共治理读面固定命名为 `governance_surface`：
 
@@ -73,7 +108,7 @@
 - 只回答 locator 与职责边界，不复制实时停点、下一步、阻断项、验证摘要
 - 若需要回答 gate 进度，统一通过 `review_merge_surface` 或 `status control plane` 读取，不在 `governance_surface` 并行维护 authored gate 状态
 
-## 5. Planning 边界
+## 6. Planning 边界
 
 `delivery planning` 是 `loom-init` 的路由结果，不是 build、review 或 merge-ready 的前置硬门禁。
 
@@ -102,7 +137,7 @@ planning 输出只能包含：
 
 planning 输出不能声明某个 Work Item 已完成，不能替代 `spec.md` / `plan.md`，不能替代 review、merge-ready、closeout，也不能直接改写 GitHub，除非用户明确要求执行创建或更新动作。
 
-## 6. fallback 语义
+## 7. fallback 语义
 
 出现以下任一情况时，root skill 不做猜测，直接回退到 `loom-init`：
 

--- a/src/skills/shared/references/templates/spec-suite.md
+++ b/src/skills/shared/references/templates/spec-suite.md
@@ -18,6 +18,21 @@ Loom 当前把正式规约套件的最小内核定义为：
 
 这两个工件分别承担不同职责，不得混写。
 
+Formal spec path 有两条合法 suite path：
+
+- `minimal suite`
+  - 必含 `spec.md` 与 `plan.md`
+  - 适用于低风险、局部、纯治理或文档类事项
+  - 可用 `not_applicable` rationale 合法跳过 full path 附加工件
+- `full suite`
+  - 在 minimal suite 之上消费 suite-index、条件附加工件、evidence-map、
+    consistency-analysis 与 gate-chain consumption
+  - 适用于 formal spec、高风险、跨模块、强 review 或需要完整证据链的事项
+
+路径选择必须有 locator 与 provenance。若从 full path 降到 minimal path，必须说明
+附加工件为什么 `not_applicable`；若从 minimal path 升到 full path，必须说明触发信号
+和需要补齐的工件。
+
 ## 2. `spec.md` 最小要求
 
 `spec.md` 至少应表达：
@@ -58,6 +73,17 @@ Loom 当前把正式规约套件的最小内核定义为：
 - 不能自动化的行为必须声明人工验证路径、证据 locator 与 fresh 条件
 - 纯文档或治理规则变更可以不强制 TDD，但必须说明行为证据如何由结构检查、审查记录或示例消费
 
+映射状态必须可被后续 gate 消费：
+
+- `scenario_id` / scenario locator 映射到 automated、manual、structural 或
+  `not_applicable` validation strategy
+- `acceptance_id` / acceptance locator 映射到 test evidence、structural check、
+  manual evidence 或 `not_applicable`
+- full path 下，缺少 scenario -> validation 或 acceptance -> test mapping 默认阻断
+  build / review
+- minimal path 下，缺映射必须以 `not_applicable` rationale、替代验证入口和
+  recheck condition 解释
+
 ## 4. 套件边界规则
 
 Loom 必须区分：
@@ -74,6 +100,11 @@ Loom 当前不固化：
 
 - 所有项目都必须有同一组附加工件
 - `TODO.md` 或同类文件是永恒必选项
+
+Full path 缺少必需工件、locator、provenance 或 gate 所需 evidence 时必须
+fail-closed。Minimal path 缺少 full path 附加工件时，只有同时具备 rationale、
+consumer boundary 与 recheck condition 的 `not_applicable` 才能消解；无理由缺口
+仍是 `missing`。`deferred` 不等于 `not_applicable`，不得作为 completed truth 消费。
 
 ## 5. 行为证据与测试证据
 


### PR DESCRIPTION
## Summary
- Update scenario skill contracts so loom-story, loom-spec-review, loom-build, loom-pre-review, and loom-merge-ready consume full/minimal suite path boundaries.
- Refresh generated skills surface from src/skills to keep checked-in source/generated surface consistent.
- Bind WI-1050 work item, progress, spec review, and implementation review carriers; mark WI-1049 as terminal in this workspace.

## Validation
- git diff --check
- focused rg checks for full/minimal suite path, scenario/acceptance mapping, not_applicable rationale, consumer boundary, recheck condition, and fail-closed boundaries
- python3 tools/skills_surface.py check
- python3 tools/loom_check.py --profile source --source-surface contract-only .
- python3 tools/check_release_surface.py
- python3 tools/host_adapter_check.py
- python3 tools/version_surface_check.py
- python3 tools/check_npm_package.py
- PYTHONDONTWRITEBYTECODE=1 python3 tools/loom_flow.py checkpoint merge --target . --item WI-1050
- PYTHONDONTWRITEBYTECODE=1 python3 .loom/bin/loom_init.py verify --target .

## Risks And Follow-ups
- #1051 remains responsible for broader source/generated skills surface synchronization, drift checks, and #1036 deferred sync consumption.
- #1052 remains responsible for CLI command surface planning and is intentionally out of this PR.

## Related Work
- Loom Work Item: WI-1050
- Closes #1050
- Consumes #1016, #1018, #1019, and #1049 for scenario skill suite-path boundaries.