### PR TITLE
Add scaffold truth-surface safeguards

### DIFF
--- a/.loom/bootstrap/init-result.json
+++ b/.loom/bootstrap/init-result.json
@@ -76,9 +76,9 @@
     "mode": "work-item + recovery-entry + derived status-surface",
     "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
     "entry_points": {
-      "current_item_id": "WI-1117",
-      "work_item": ".loom/work-items/WI-1117.md",
-      "recovery_entry": ".loom/progress/WI-1117.md",
+      "current_item_id": "WI-1118",
+      "work_item": ".loom/work-items/WI-1118.md",
+      "recovery_entry": ".loom/progress/WI-1118.md",
       "status_surface": ".loom/status/current.md"
     }
   },

--- a/.loom/progress/WI-1117.md
+++ b/.loom/progress/WI-1117.md
@@ -3,11 +3,11 @@
 ## Dynamic Facts
 
 - Item ID: WI-1117
-- Current Checkpoint: PR checkpoint
-- Current Stop: Branch work/1117-scaffold-json has validated scaffold JSON audit contract coverage and formal reviews recorded; PR creation is next.
-- Next Step: Push branch, open PR for #1117, run PR gate and GitHub checks, then merge and close out #1117.
+- Current Checkpoint: closed
+- Current Stop: #1117 closed as completed after PR #1163 merged to main at d1c106844f4ecde11345f3f75fa0bed73f5d52ab; Project `Loom` readback is Done and closeout check passed.
+- Next Step: Terminal for WI-1117; #1113 consumed the closeout evidence and execution continues in WI-1118.
 - Blockers: None
-- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; git diff --check; focused rg for rollback_note, ambiguous_overwrite, created_locators, planned_writes, source_templates, apply_required, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1117; formal spec and general reviews recorded.
+- Latest Validation Summary: PR #1163 merged with head 1a76121fccc0893c63a78500e8ffccdb30a874b5 and merge commit d1c106844f4ecde11345f3f75fa0bed73f5d52ab; closeout check passed and Project `Loom` status is Done.
 - Recovery Boundary: #1117 owns scaffold JSON contract coverage for overwrite, rollback, planned write, source template, apply-required, and created locator fields only. It must not add rollback execution, new scaffold artifacts, host writes, review writes, merge-ready writes, closeout writes, generated skills, /speckit.*, or .specify surfaces.
 - Current Lane: full-spec-suite-cli/scaffold-json-audit
 
@@ -17,5 +17,5 @@
 - Plan Locator: .loom/specs/WI-1117/plan.md
 - Acceptance Locator: .loom/specs/WI-1117/spec.md
 - Validation Evidence Locator: .loom/progress/WI-1117.md
-- Handoff Notes Locator: not_applicable
+- Handoff Notes Locator: https://github.com/MC-and-his-Agents/Loom/issues/1117#issuecomment-4559493032
 - Evidence Freshness: current

--- a/.loom/progress/WI-1118.md
+++ b/.loom/progress/WI-1118.md
@@ -1,0 +1,21 @@
+# WI-1118 Progress
+
+## Dynamic Facts
+
+- Item ID: WI-1118
+- Current Checkpoint: build checkpoint
+- Current Stop: Branch work/1118-scaffold-truth-safeguards has #1118 negative scaffold truth-surface fixtures implemented and local validation/build checkpoint passed.
+- Next Step: Push branch, open PR for #1118, run PR gate and GitHub checks, then merge and close out #1118.
+- Blockers: None
+- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; git diff --check; focused rg for forbidden truth fixtures, scaffold write boundaries, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118.
+- Recovery Boundary: #1118 owns negative scaffold regression coverage only. It must not implement host integration, new scaffold artifacts, rollback execution, generated skills sync, review writes, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.
+- Current Lane: full-spec-suite-cli/scaffold-truth-safeguards
+
+## Execution Ledger
+
+- Ledger Binding: recovery_entry
+- Plan Locator: .loom/specs/WI-1118/plan.md
+- Acceptance Locator: .loom/specs/WI-1118/spec.md
+- Validation Evidence Locator: .loom/progress/WI-1118.md
+- Handoff Notes Locator: https://github.com/MC-and-his-Agents/Loom/issues/1118#issuecomment-4559515396
+- Evidence Freshness: current

--- a/.loom/progress/WI-1118.md
+++ b/.loom/progress/WI-1118.md
@@ -3,9 +3,9 @@
 ## Dynamic Facts
 
 - Item ID: WI-1118
-- Current Checkpoint: build checkpoint
-- Current Stop: Branch work/1118-scaffold-truth-safeguards has #1118 negative scaffold truth-surface fixtures implemented and local validation/build checkpoint passed.
-- Next Step: Push branch, open PR for #1118, run PR gate and GitHub checks, then merge and close out #1118.
+- Current Checkpoint: PR checkpoint
+- Current Stop: Branch work/1118-scaffold-truth-safeguards is pushed and PR #1164 is open for #1118 after local validation/build checkpoint passed.
+- Next Step: Run PR gate and GitHub checks for PR #1164, then merge and close out #1118.
 - Blockers: None
 - Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; git diff --check; focused rg for forbidden truth fixtures, scaffold write boundaries, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118.
 - Recovery Boundary: #1118 owns negative scaffold regression coverage only. It must not implement host integration, new scaffold artifacts, rollback execution, generated skills sync, review writes, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.

--- a/.loom/reviews/WI-1118.json
+++ b/.loom/reviews/WI-1118.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-1118",
+  "decision": "allow",
+  "kind": "general_review",
+  "summary": "General review allows WI-1118 at build checkpoint: implementation is limited to contract-test fixtures and Loom carriers. The added checks prove suite scaffold planned and created locators stay in the allowed spec scaffold set, forbidden truth surfaces are unchanged, and no host/review/merge-ready/closeout/generated-skill action keys are emitted. Local validation and build checkpoint passed.",
+  "reviewer": "Codex",
+  "reviewed_head": "d1c106844f4ecde11345f3f75fa0bed73f5d52ab",
+  "reviewed_validation_summary": "Passed: python3 tools/check_cli_contract.py; git diff --check; focused rg for forbidden truth fixtures, scaffold write boundaries, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-1118.md",
+    "recovery_entry": ".loom/progress/WI-1118.md",
+    "status_surface": ".loom/status/current.md",
+    "build_checkpoint": "pass",
+    "budget_risk": {
+      "schema_version": "loom-execution-budget-risk/v1",
+      "status": "not_applicable",
+      "enforcement": "advisory",
+      "highest_risk": "none",
+      "risk_dimensions": [],
+      "summary": "execution budget is not_applicable; budget risk remains advisory and non-blocking",
+      "budget_summary": "execution budget is not collected for this invocation.",
+      "adapter_evidence_locator": "",
+      "provenance": {
+        "source": "github_host"
+      }
+    },
+    "engine_adapter": null,
+    "engine_evidence": null,
+    "normalized_findings": null
+  }
+}

--- a/.loom/reviews/WI-1118.json
+++ b/.loom/reviews/WI-1118.json
@@ -5,7 +5,7 @@
   "kind": "general_review",
   "summary": "General review allows WI-1118 at build checkpoint: implementation is limited to contract-test fixtures and Loom carriers. The added checks prove suite scaffold planned and created locators stay in the allowed spec scaffold set, forbidden truth surfaces are unchanged, and no host/review/merge-ready/closeout/generated-skill action keys are emitted. Local validation and build checkpoint passed.",
   "reviewer": "Codex",
-  "reviewed_head": "32917cbe6a1eb724d9cb781efe5623a1fd88d056",
+  "reviewed_head": "81a7c4b3b0e3ef0ae2874d357a03053fc89157ae",
   "reviewed_validation_summary": "Passed: python3 tools/check_cli_contract.py; git diff --check; focused rg for forbidden truth fixtures, scaffold write boundaries, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-1118.json
+++ b/.loom/reviews/WI-1118.json
@@ -5,7 +5,7 @@
   "kind": "general_review",
   "summary": "General review allows WI-1118 at build checkpoint: implementation is limited to contract-test fixtures and Loom carriers. The added checks prove suite scaffold planned and created locators stay in the allowed spec scaffold set, forbidden truth surfaces are unchanged, and no host/review/merge-ready/closeout/generated-skill action keys are emitted. Local validation and build checkpoint passed.",
   "reviewer": "Codex",
-  "reviewed_head": "7fdb2fdac9ebcffc4ed5b62ad043c7db104a0f20",
+  "reviewed_head": "32917cbe8ec15f883aa91e8e98e885a7d81dc0f6",
   "reviewed_validation_summary": "Passed: python3 tools/check_cli_contract.py; git diff --check; focused rg for forbidden truth fixtures, scaffold write boundaries, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-1118.json
+++ b/.loom/reviews/WI-1118.json
@@ -5,7 +5,7 @@
   "kind": "general_review",
   "summary": "General review allows WI-1118 at build checkpoint: implementation is limited to contract-test fixtures and Loom carriers. The added checks prove suite scaffold planned and created locators stay in the allowed spec scaffold set, forbidden truth surfaces are unchanged, and no host/review/merge-ready/closeout/generated-skill action keys are emitted. Local validation and build checkpoint passed.",
   "reviewer": "Codex",
-  "reviewed_head": "32917cbe8ec15f883aa91e8e98e885a7d81dc0f6",
+  "reviewed_head": "32917cbe6a1eb724d9cb781efe5623a1fd88d056",
   "reviewed_validation_summary": "Passed: python3 tools/check_cli_contract.py; git diff --check; focused rg for forbidden truth fixtures, scaffold write boundaries, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-1118.json
+++ b/.loom/reviews/WI-1118.json
@@ -5,7 +5,7 @@
   "kind": "general_review",
   "summary": "General review allows WI-1118 at build checkpoint: implementation is limited to contract-test fixtures and Loom carriers. The added checks prove suite scaffold planned and created locators stay in the allowed spec scaffold set, forbidden truth surfaces are unchanged, and no host/review/merge-ready/closeout/generated-skill action keys are emitted. Local validation and build checkpoint passed.",
   "reviewer": "Codex",
-  "reviewed_head": "3221696356fad8b907dc9e1ab7f9ef718dc47d8f",
+  "reviewed_head": "7fdb2fdac9ebcffc4ed5b62ad043c7db104a0f20",
   "reviewed_validation_summary": "Passed: python3 tools/check_cli_contract.py; git diff --check; focused rg for forbidden truth fixtures, scaffold write boundaries, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-1118.json
+++ b/.loom/reviews/WI-1118.json
@@ -5,7 +5,7 @@
   "kind": "general_review",
   "summary": "General review allows WI-1118 at build checkpoint: implementation is limited to contract-test fixtures and Loom carriers. The added checks prove suite scaffold planned and created locators stay in the allowed spec scaffold set, forbidden truth surfaces are unchanged, and no host/review/merge-ready/closeout/generated-skill action keys are emitted. Local validation and build checkpoint passed.",
   "reviewer": "Codex",
-  "reviewed_head": "d1c106844f4ecde11345f3f75fa0bed73f5d52ab",
+  "reviewed_head": "3221696356fad8b907dc9e1ab7f9ef718dc47d8f",
   "reviewed_validation_summary": "Passed: python3 tools/check_cli_contract.py; git diff --check; focused rg for forbidden truth fixtures, scaffold write boundaries, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-1118.spec.json
+++ b/.loom/reviews/WI-1118.spec.json
@@ -5,7 +5,7 @@
   "kind": "spec_review",
   "summary": "Spec review allows WI-1118: scope is limited to negative contract fixtures proving suite scaffold dry-run/apply stays repo-local and does not modify host, review, merge-ready, closeout, task-carrier, generated skills, runtime, shadow, PR template, or workflow truth surfaces. No host integration, new scaffold artifacts, rollback execution, /speckit.*, or .specify layout is introduced.",
   "reviewer": "Codex",
-  "reviewed_head": "3221696356fad8b907dc9e1ab7f9ef718dc47d8f",
+  "reviewed_head": "32216963095dd657c416263602f17cb61224a2ee",
   "reviewed_validation_summary": "Passed: python3 tools/check_cli_contract.py; git diff --check; focused rg for forbidden truth fixtures, scaffold write boundaries, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-1118.spec.json
+++ b/.loom/reviews/WI-1118.spec.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-1118",
+  "decision": "allow",
+  "kind": "spec_review",
+  "summary": "Spec review allows WI-1118: scope is limited to negative contract fixtures proving suite scaffold dry-run/apply stays repo-local and does not modify host, review, merge-ready, closeout, task-carrier, generated skills, runtime, shadow, PR template, or workflow truth surfaces. No host integration, new scaffold artifacts, rollback execution, /speckit.*, or .specify layout is introduced.",
+  "reviewer": "Codex",
+  "reviewed_head": "d1c106844f4ecde11345f3f75fa0bed73f5d52ab",
+  "reviewed_validation_summary": "Passed: python3 tools/check_cli_contract.py; git diff --check; focused rg for forbidden truth fixtures, scaffold write boundaries, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-1118.md",
+    "recovery_entry": ".loom/progress/WI-1118.md",
+    "status_surface": ".loom/status/current.md",
+    "build_checkpoint": "pass",
+    "budget_risk": {
+      "schema_version": "loom-execution-budget-risk/v1",
+      "status": "not_applicable",
+      "enforcement": "advisory",
+      "highest_risk": "none",
+      "risk_dimensions": [],
+      "summary": "execution budget is not_applicable; budget risk remains advisory and non-blocking",
+      "budget_summary": "execution budget is not collected for this invocation.",
+      "adapter_evidence_locator": "",
+      "provenance": {
+        "source": "github_host"
+      }
+    },
+    "engine_adapter": null,
+    "engine_evidence": null,
+    "normalized_findings": null
+  }
+}

--- a/.loom/reviews/WI-1118.spec.json
+++ b/.loom/reviews/WI-1118.spec.json
@@ -5,7 +5,7 @@
   "kind": "spec_review",
   "summary": "Spec review allows WI-1118: scope is limited to negative contract fixtures proving suite scaffold dry-run/apply stays repo-local and does not modify host, review, merge-ready, closeout, task-carrier, generated skills, runtime, shadow, PR template, or workflow truth surfaces. No host integration, new scaffold artifacts, rollback execution, /speckit.*, or .specify layout is introduced.",
   "reviewer": "Codex",
-  "reviewed_head": "d1c106844f4ecde11345f3f75fa0bed73f5d52ab",
+  "reviewed_head": "3221696356fad8b907dc9e1ab7f9ef718dc47d8f",
   "reviewed_validation_summary": "Passed: python3 tools/check_cli_contract.py; git diff --check; focused rg for forbidden truth fixtures, scaffold write boundaries, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "90482d901be18f6391f54aac6328dad666661ac04d796787568f4255431fd1a5"
+    ".loom/status/current.md": "ed8b7bbf17dd699070410887985aeba85c4e27901e63835fe00e1e9c72908df7"
   }
 }

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "02580fab0fadf5bb8b33d91088deb3af8cf424690f6d49aeac15cdcecac9096c"
+    ".loom/status/current.md": "90482d901be18f6391f54aac6328dad666661ac04d796787568f4255431fd1a5"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "90482d901be18f6391f54aac6328dad666661ac04d796787568f4255431fd1a5"
+    ".loom/status/current.md": "ed8b7bbf17dd699070410887985aeba85c4e27901e63835fe00e1e9c72908df7"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "02580fab0fadf5bb8b33d91088deb3af8cf424690f6d49aeac15cdcecac9096c"
+    ".loom/status/current.md": "90482d901be18f6391f54aac6328dad666661ac04d796787568f4255431fd1a5"
   }
 }

--- a/.loom/specs/WI-1118/implementation-contract.md
+++ b/.loom/specs/WI-1118/implementation-contract.md
@@ -1,0 +1,20 @@
+# WI-1118 Implementation Contract
+
+## Owned Surface
+
+- Contract-test coverage proving `loom suite scaffold` only writes the suite scaffold artifacts it owns.
+
+## Required Behavior
+
+- Dry-run remains read-only.
+- Minimal apply creates only missing `spec.md` and `plan.md`.
+- Full apply creates only missing `suite-index.md`, `spec.md`, `plan.md`, `research.md`, `contracts.md`, and `readiness-checklist.md`.
+- Existing forbidden truth surfaces are not modified.
+- Scaffold JSON does not expose host/review/merge-ready/closeout/generated-skill action keys.
+
+## Forbidden Surface
+
+- No GitHub issue, Project, PR, branch, worktree, or host-control mutation.
+- No review record, merge-ready result, closeout result, runtime attempt, shadow truth, task carrier, or status truth mutation.
+- No generated skills, plugin, workflow, or PR template mutation.
+- No `/speckit.*` command names or `.specify/` layout.

--- a/.loom/specs/WI-1118/plan.md
+++ b/.loom/specs/WI-1118/plan.md
@@ -1,0 +1,28 @@
+# WI-1118 Plan
+
+## Implementation Plan
+
+1. Add a forbidden truth-surface fixture list to `tools/check_cli_contract.py`.
+2. Hash pre-seeded forbidden surfaces before scaffold commands and compare after dry-run/apply.
+3. Assert `planned_writes` and `created_locators` stay inside the scaffold artifact whitelist.
+4. Keep `tools/loom.py` unchanged unless the negative fixtures expose a behavior gap.
+5. Record spec and implementation reviews after validation passes.
+
+## Validation Plan
+
+- `python3 tools/check_cli_contract.py`
+- `git diff --check`
+- focused `rg` for forbidden truth-surface fixtures and scaffold boundary assertions
+- `python3 tools/skills_surface.py check`
+- `python3 tools/check_release_surface.py`
+- `python3 tools/version_surface_check.py`
+- `python3 tools/check_npm_package.py`
+- `python3 tools/host_adapter_check.py`
+- `python3 tools/loom_check.py --profile source --source-surface contract-only .`
+- `python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118`
+
+## Out Of Scope
+
+- No host, review, merge-ready, closeout, generated skill, task-carrier, `/speckit.*`, or `.specify/` write surface.
+- No generated skills/reference synchronization.
+- No rollback execution command.

--- a/.loom/specs/WI-1118/spec.md
+++ b/.loom/specs/WI-1118/spec.md
@@ -1,0 +1,33 @@
+# WI-1118 Spec
+
+## Goal
+
+Prove `loom suite scaffold` remains a repo-local scaffold writer and cannot mutate host truth, review truth, merge-ready truth, closeout truth, task carriers, or generated skills surfaces.
+
+## Scope
+
+- Add negative contract fixtures around `loom suite scaffold` dry-run and apply.
+- Pre-seed forbidden truth surfaces and assert their content remains unchanged.
+- Assert scaffold `planned_writes` and `created_locators` stay limited to the allowed `.loom/specs/<item>/` scaffold artifacts.
+- Preserve existing #1114-#1117 scaffold behavior.
+
+## Non-Goals
+
+- No host integration or GitHub issue, Project, or PR writes.
+- No review, merge-ready, closeout, task-carrier, generated skills, runtime attempt, or shadow truth writes.
+- No new scaffold artifacts.
+- No rollback execution command.
+- No `/speckit.*` command names or `.specify/` layout.
+
+## Acceptance Criteria
+
+- AC-1118-1: Full-suite dry-run leaves forbidden truth surfaces and the target tree unchanged.
+- AC-1118-2: Minimal apply creates only `spec.md` and `plan.md` for the requested item and leaves forbidden truth surfaces unchanged.
+- AC-1118-3: Full apply creates only the six standard full-suite scaffold artifacts and leaves forbidden truth surfaces unchanged.
+- AC-1118-4: Scaffold JSON does not emit host/review/merge-ready/closeout/generated-skill action keys.
+- AC-1118-5: Contract tests continue to pass without changing the established `suite scaffold` CLI behavior.
+
+## Guardrails
+
+- CLI output remains evidence only; it does not replace Work Item truth, recovery truth, review records, merge-ready evidence, closeout evidence, or docs/source contracts.
+- Existing generated skills/reference drift remains owned by the skills surface workflow.

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -2,34 +2,34 @@
 
 ## Derived Fact Chain View
 
-- Item ID: WI-1117
-- Goal: Define and verify scaffold overwrite, rollback, and created locator JSON audit fields.
-- Scope: #1117 only: harden `loom suite scaffold` JSON contract coverage for `planned_writes`, `source_templates`, `overwrite_policy`, `apply_required`, `rollback_note`, and `created_locators`, including ambiguous overwrite fail-closed evidence. Do not add rollback execution, new scaffold artifacts, host writes, review writes, merge-ready writes, closeout writes, generated skills, spec-kit command names, or `.specify/` layout.
-- Execution Path: issue #1117 -> branch work/1117-scaffold-json -> worktree /Users/mc/dev/Loom-worktrees/1117-scaffold-json -> PR pending
+- Item ID: WI-1118
+- Goal: Prove `loom suite scaffold` cannot mutate host truth, review truth, merge-ready truth, closeout truth, task carriers, or generated skills surfaces it does not own.
+- Scope: #1118 only: add negative scaffold contract fixtures for forbidden truth surfaces while preserving the #1114-#1117 scaffold behavior. Do not add host integration, new scaffold artifacts, rollback execution, generated skills sync, `/speckit.*`, or `.specify/` layout.
+- Execution Path: issue #1118 -> branch work/1118-scaffold-truth-safeguards -> worktree /Users/mc/dev/Loom-worktrees/1118-scaffold-truth-safeguards -> PR pending
 - Workspace Entry: .
-- Recovery Entry: .loom/progress/WI-1117.md
-- Review Entry: .loom/reviews/WI-1117.json
-- Validation Entry: python3 tools/check_cli_contract.py; git diff --check; focused rg; python3 tools/skills_surface.py check; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py
-- Closing Condition: #1117 PR is merged to main, closeout evidence records PR/head/merge/target branch/validation/Project state, #1117 is closed completed, and #1113 can consume the evidence.
-- Current Checkpoint: PR checkpoint
-- Current Stop: Branch work/1117-scaffold-json has validated scaffold JSON audit contract coverage and formal reviews recorded; PR creation is next.
-- Next Step: Push branch, open PR for #1117, run PR gate and GitHub checks, then merge and close out #1117.
+- Recovery Entry: .loom/progress/WI-1118.md
+- Review Entry: .loom/reviews/WI-1118.json
+- Validation Entry: python3 tools/check_cli_contract.py; git diff --check; focused rg; python3 tools/skills_surface.py check; python3 tools/loom_check.py --profile source --source-surface contract-only .
+- Closing Condition: #1118 PR is merged to main, closeout evidence records PR/head/merge/target branch/validation/Project state, #1118 is closed completed, and #1113 can consume the evidence.
+- Current Checkpoint: build checkpoint
+- Current Stop: Branch work/1118-scaffold-truth-safeguards has #1118 negative scaffold truth-surface fixtures implemented and local validation/build checkpoint passed.
+- Next Step: Push branch, open PR for #1118, run PR gate and GitHub checks, then merge and close out #1118.
 - Blockers: None
-- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; git diff --check; focused rg for rollback_note, ambiguous_overwrite, created_locators, planned_writes, source_templates, apply_required, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1117; formal spec and general reviews recorded.
-- Recovery Boundary: #1117 owns scaffold JSON contract coverage for overwrite, rollback, planned write, source template, apply-required, and created locator fields only. It must not add rollback execution, new scaffold artifacts, host writes, review writes, merge-ready writes, closeout writes, generated skills, /speckit.*, or .specify surfaces.
-- Current Lane: full-spec-suite-cli/scaffold-json-audit
+- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; git diff --check; focused rg for forbidden truth fixtures, scaffold write boundaries, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118.
+- Recovery Boundary: #1118 owns negative scaffold regression coverage only. It must not implement host integration, new scaffold artifacts, rollback execution, generated skills sync, review writes, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.
+- Current Lane: full-spec-suite-cli/scaffold-truth-safeguards
 
 ## Runtime Evidence
 
 - Run Entry: not_applicable
 - Logs Entry: not_applicable
 - Diagnostics Entry: not_applicable
-- Verification Entry: git diff --check; focused rg checks for suite scaffold anchors; python3 tools/skills_surface.py check; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_cli_contract.py; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking.
+- Verification Entry: git diff --check; focused rg checks for scaffold truth-surface boundaries; python3 tools/check_cli_contract.py; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118.
 - Lane Entry: not_applicable
 
 ## Sources
 
-- Static Truth: .loom/work-items/WI-1117.md
-- Dynamic Truth: .loom/progress/WI-1117.md
+- Static Truth: .loom/work-items/WI-1118.md
+- Dynamic Truth: .loom/progress/WI-1118.md
 - Locator Truth: .loom/bootstrap/init-result.json
 - Fact Chain CLI: python3 .loom/bin/loom_init.py fact-chain --target .

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -11,9 +11,9 @@
 - Review Entry: .loom/reviews/WI-1118.json
 - Validation Entry: python3 tools/check_cli_contract.py; git diff --check; focused rg; python3 tools/skills_surface.py check; python3 tools/loom_check.py --profile source --source-surface contract-only .
 - Closing Condition: #1118 PR is merged to main, closeout evidence records PR/head/merge/target branch/validation/Project state, #1118 is closed completed, and #1113 can consume the evidence.
-- Current Checkpoint: build checkpoint
-- Current Stop: Branch work/1118-scaffold-truth-safeguards has #1118 negative scaffold truth-surface fixtures implemented and local validation/build checkpoint passed.
-- Next Step: Push branch, open PR for #1118, run PR gate and GitHub checks, then merge and close out #1118.
+- Current Checkpoint: PR checkpoint
+- Current Stop: Branch work/1118-scaffold-truth-safeguards is pushed and PR #1164 is open for #1118 after local validation/build checkpoint passed.
+- Next Step: Run PR gate and GitHub checks for PR #1164, then merge and close out #1118.
 - Blockers: None
 - Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; git diff --check; focused rg for forbidden truth fixtures, scaffold write boundaries, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118.
 - Recovery Boundary: #1118 owns negative scaffold regression coverage only. It must not implement host integration, new scaffold artifacts, rollback execution, generated skills sync, review writes, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.

--- a/.loom/work-items/WI-1118.md
+++ b/.loom/work-items/WI-1118.md
@@ -1,0 +1,28 @@
+# WI-1118
+
+## Static Facts
+
+- Item ID: WI-1118
+- Goal: Prove `loom suite scaffold` cannot mutate host truth, review truth, merge-ready truth, closeout truth, task carriers, or generated skills surfaces it does not own.
+- Scope: #1118 only: add negative scaffold contract fixtures for forbidden truth surfaces while preserving the #1114-#1117 scaffold behavior. Do not add host integration, new scaffold artifacts, rollback execution, generated skills sync, `/speckit.*`, or `.specify/` layout.
+- Execution Path: issue #1118 -> branch work/1118-scaffold-truth-safeguards -> worktree /Users/mc/dev/Loom-worktrees/1118-scaffold-truth-safeguards -> PR pending
+- Workspace Entry: .
+- Recovery Entry: .loom/progress/WI-1118.md
+- Review Entry: .loom/reviews/WI-1118.json
+- Validation Entry: python3 tools/check_cli_contract.py; git diff --check; focused rg; python3 tools/skills_surface.py check; python3 tools/loom_check.py --profile source --source-surface contract-only .
+- Closing Condition: #1118 PR is merged to main, closeout evidence records PR/head/merge/target branch/validation/Project state, #1118 is closed completed, and #1113 can consume the evidence.
+
+## Associated Artifacts
+
+- `.loom/work-items/WI-1118.md`
+- `.loom/progress/WI-1118.md`
+- `.loom/reviews/WI-1118.json`
+- `.loom/reviews/WI-1118.spec.json`
+- `.loom/status/current.md`
+- `tools/check_cli_contract.py`
+- `.loom/specs/WI-1118/spec.md`
+- `.loom/specs/WI-1118/plan.md`
+- `.loom/specs/WI-1118/implementation-contract.md`
+- `.loom/shadow/merge-ready-loom.json`
+- `.loom/shadow/closeout-loom.json`
+- `.loom/progress/WI-1117.md`

--- a/tools/check_cli_contract.py
+++ b/tools/check_cli_contract.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import subprocess
 import sys
 import tempfile
@@ -13,6 +14,44 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parents[1]
 LOOM = REPO_ROOT / "tools" / "loom.py"
 LEGACY_FIXTURES = REPO_ROOT / "docs" / "evidence" / "fixtures" / "legacy-migration-validation-fixtures.json"
+
+SCAFFOLD_FORBIDDEN_TRUTH_SURFACES = (
+    ".loom/work-items/WI-truth.md",
+    ".loom/progress/WI-truth.md",
+    ".loom/status/current.md",
+    ".loom/reviews/WI-truth.json",
+    ".loom/reviews/WI-truth.spec.json",
+    ".loom/runtime/attempts/WI-truth/latest.json",
+    ".loom/runtime/review/WI-truth/head/context-pack.json",
+    ".loom/shadow/review-loom.json",
+    ".loom/shadow/merge-ready-loom.json",
+    ".loom/shadow/closeout-loom.json",
+    ".loom/specs/WI-truth/evidence-map.md",
+    ".loom/specs/WI-truth/consistency-analysis.md",
+    ".loom/specs/WI-truth/task-carrier.md",
+    ".loom/tasks/WI-truth.md",
+    "tasks.md",
+    "skills/registry.json",
+    "skills/loom-init/SKILL.md",
+    "src/skills/route-matrix.md",
+    "plugins/loom/.codex-plugin/plugin.json",
+    ".github/PULL_REQUEST_TEMPLATE.md",
+    ".github/workflows/loom.yml",
+)
+
+SCAFFOLD_FORBIDDEN_ACTION_KEYS = {
+    "closeout_actions",
+    "closeout_result",
+    "generated_skills",
+    "host_actions",
+    "issue_actions",
+    "managed_writes",
+    "merge_ready_result",
+    "pr_actions",
+    "project_actions",
+    "review_record",
+    "review_verdict",
+}
 
 REQUIRED_COMMANDS = {
     "version",
@@ -100,6 +139,61 @@ def run_json(args: list[str], *, expect: int | None = None) -> tuple[int, dict[s
 
 def snapshot_tree(target: Path) -> list[str]:
     return sorted(path.relative_to(target).as_posix() for path in target.rglob("*"))
+
+
+def digest_path(path: Path) -> dict[str, str]:
+    if path.is_dir():
+        return {"kind": "directory"}
+    return {
+        "kind": "file",
+        "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+    }
+
+
+def snapshot_paths(target: Path, relatives: tuple[str, ...]) -> dict[str, dict[str, str]]:
+    snapshot: dict[str, dict[str, str]] = {}
+    for relative in relatives:
+        path = target / relative
+        if path.exists():
+            snapshot[relative] = digest_path(path)
+    return snapshot
+
+
+def write_forbidden_truth_fixture(target: Path) -> dict[str, dict[str, str]]:
+    for index, relative in enumerate(SCAFFOLD_FORBIDDEN_TRUTH_SURFACES):
+        path = target / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.suffix == ".json":
+            path.write_text(json.dumps({"fixture_surface": relative, "index": index}, indent=2) + "\n", encoding="utf-8")
+        else:
+            path.write_text(f"# Forbidden scaffold truth fixture\n\n- locator: {relative}\n- index: {index}\n", encoding="utf-8")
+    return snapshot_paths(target, SCAFFOLD_FORBIDDEN_TRUTH_SURFACES)
+
+
+def assert_forbidden_truth_unchanged(target: Path, before: dict[str, dict[str, str]]) -> None:
+    after = snapshot_paths(target, SCAFFOLD_FORBIDDEN_TRUTH_SURFACES)
+    if after != before:
+        raise AssertionError("suite scaffold modified forbidden host/review/merge-ready/closeout/generated-skill truth surfaces")
+
+
+def assert_scaffold_write_boundary(payload: dict[str, Any], *, item: str, allowed_artifacts: list[str]) -> None:
+    allowed_locators = {f".loom/specs/{item}/{artifact}" for artifact in allowed_artifacts}
+    planned = payload.get("planned_writes", [])
+    if not isinstance(planned, list):
+        raise AssertionError("suite scaffold planned_writes is not a list")
+    for entry in planned:
+        locator = entry.get("locator")
+        if locator not in allowed_locators:
+            raise AssertionError(f"suite scaffold planned write escaped allowed artifact set: {locator}")
+    created = payload.get("created_locators", [])
+    if not isinstance(created, list):
+        raise AssertionError("suite scaffold created_locators is not a list")
+    unexpected_created = sorted(locator for locator in created if locator not in allowed_locators)
+    if unexpected_created:
+        raise AssertionError(f"suite scaffold created forbidden locators: {unexpected_created}")
+    forbidden_keys = sorted(SCAFFOLD_FORBIDDEN_ACTION_KEYS & set(payload))
+    if forbidden_keys:
+        raise AssertionError(f"suite scaffold emitted forbidden host/truth action keys: {forbidden_keys}")
 
 
 def run_suite_inspect_fixture(target: Path, item: str) -> dict[str, Any]:
@@ -695,6 +789,42 @@ def main() -> int:
             or full_apply_again_payload.get("overwrite_policy", {}).get("existing_files") != expected_full_created
         ):
             raise AssertionError("suite scaffold full-suite repeat preservation drifted")
+
+        truth_dry_run_target = tmp / "suite-scaffold-truth-dry-run"
+        truth_dry_run_target.mkdir()
+        truth_dry_run_before = write_forbidden_truth_fixture(truth_dry_run_target)
+        truth_dry_run_tree_before = snapshot_tree(truth_dry_run_target)
+        suite_scaffold_truth_dry_run = run_suite_scaffold_fixture(
+            truth_dry_run_target,
+            "WI-truth",
+            ["--suite", "full"],
+        )
+        truth_dry_run_payload = suite_scaffold_truth_dry_run.get("payload", {})
+        assert_forbidden_truth_unchanged(truth_dry_run_target, truth_dry_run_before)
+        assert_scaffold_write_boundary(truth_dry_run_payload, item="WI-truth", allowed_artifacts=full_artifacts)
+        if snapshot_tree(truth_dry_run_target) != truth_dry_run_tree_before:
+            raise AssertionError("suite scaffold dry-run changed host/review/closeout/generated-skill fixture tree")
+
+        truth_minimal_target = tmp / "suite-scaffold-truth-minimal"
+        truth_minimal_target.mkdir()
+        truth_minimal_before = write_forbidden_truth_fixture(truth_minimal_target)
+        suite_scaffold_truth_minimal = run_suite_scaffold_apply_fixture(truth_minimal_target, "WI-truth")
+        truth_minimal_payload = suite_scaffold_truth_minimal.get("payload", {})
+        assert_forbidden_truth_unchanged(truth_minimal_target, truth_minimal_before)
+        assert_scaffold_write_boundary(truth_minimal_payload, item="WI-truth", allowed_artifacts=["spec.md", "plan.md"])
+        if truth_minimal_payload.get("created_locators") != [".loom/specs/WI-truth/spec.md", ".loom/specs/WI-truth/plan.md"]:
+            raise AssertionError("suite scaffold minimal truth-boundary fixture created unexpected locators")
+
+        truth_full_target = tmp / "suite-scaffold-truth-full"
+        truth_full_target.mkdir()
+        truth_full_before = write_forbidden_truth_fixture(truth_full_target)
+        suite_scaffold_truth_full = run_suite_scaffold_apply_fixture(truth_full_target, "WI-truth", ["--suite", "full"])
+        truth_full_payload = suite_scaffold_truth_full.get("payload", {})
+        expected_truth_full_created = [f".loom/specs/WI-truth/{artifact}" for artifact in full_artifacts]
+        assert_forbidden_truth_unchanged(truth_full_target, truth_full_before)
+        assert_scaffold_write_boundary(truth_full_payload, item="WI-truth", allowed_artifacts=full_artifacts)
+        if truth_full_payload.get("created_locators") != expected_truth_full_created:
+            raise AssertionError("suite scaffold full truth-boundary fixture created unexpected locators")
 
         missing_target = tmp / "missing"
         missing_target.mkdir()


### PR DESCRIPTION
Loom Work Item: WI-1118

## Summary
- Add negative `loom suite scaffold` contract fixtures for host/review/merge-ready/closeout/task-carrier/generated-skill truth boundaries.
- Assert dry-run leaves forbidden surfaces and the fixture tree unchanged.
- Assert minimal/full apply only creates allowed `.loom/specs/<item>/` scaffold locators and emits no host/truth action keys.
- Terminalize stale WI-1117 recovery state after #1117 closeout so #1118 owns the active workspace.

## Validation
- `python3 tools/check_cli_contract.py`
- `git diff --check`
- focused `rg` for forbidden truth fixtures, scaffold write boundaries, `/speckit`, and `.specify`
- `python3 tools/skills_surface.py check`
- `python3 tools/check_release_surface.py`
- `python3 tools/version_surface_check.py`
- `python3 tools/check_npm_package.py`
- `python3 tools/host_adapter_check.py`
- `python3 tools/loom_check.py --profile source --source-surface contract-only .`
- `python3 .loom/bin/loom_init.py fact-chain --target .`
- `python3 .loom/bin/loom_init.py verify --target .`
- `python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking`
- `python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118`

## Guardrails
- Does not add host integration, new scaffold artifacts, rollback execution, generated skills sync, review writes, merge-ready writes, closeout writes, `/speckit.*`, or `.specify/` layout.

Related Work: #1118
