### PR TITLE
Implement suite validate core

### DIFF
--- a/.loom/bootstrap/init-result.json
+++ b/.loom/bootstrap/init-result.json
@@ -76,9 +76,9 @@
     "mode": "work-item + recovery-entry + derived status-surface",
     "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
     "entry_points": {
-      "current_item_id": "WI-1118",
-      "work_item": ".loom/work-items/WI-1118.md",
-      "recovery_entry": ".loom/progress/WI-1118.md",
+      "current_item_id": "WI-1120",
+      "work_item": ".loom/work-items/WI-1120.md",
+      "recovery_entry": ".loom/progress/WI-1120.md",
       "status_surface": ".loom/status/current.md"
     }
   },

--- a/.loom/progress/WI-1118.md
+++ b/.loom/progress/WI-1118.md
@@ -3,13 +3,13 @@
 ## Dynamic Facts
 
 - Item ID: WI-1118
-- Current Checkpoint: PR checkpoint
-- Current Stop: Branch work/1118-scaffold-truth-safeguards is pushed and PR #1164 is open for #1118 after local validation/build checkpoint passed.
-- Next Step: Run PR gate and GitHub checks for PR #1164, then merge and close out #1118.
+- Current Checkpoint: merged
+- Current Stop: #1118 is closed completed after PR #1164 merged into main at `61580d6b0278e4c66f0977a8d488e7ed24e5f8f8`; Project `Loom` status is Done and #1113 consumed the closeout evidence.
+- Next Step: None for #1118; continue Phase #1107 with #1120 under FR #1119.
 - Blockers: None
 - Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; git diff --check; focused rg for forbidden truth fixtures, scaffold write boundaries, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118.
 - Recovery Boundary: #1118 owns negative scaffold regression coverage only. It must not implement host integration, new scaffold artifacts, rollback execution, generated skills sync, review writes, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.
-- Current Lane: full-spec-suite-cli/scaffold-truth-safeguards
+- Current Lane: terminal/full-spec-suite-cli/scaffold-truth-safeguards
 
 ## Execution Ledger
 

--- a/.loom/progress/WI-1120.md
+++ b/.loom/progress/WI-1120.md
@@ -3,9 +3,9 @@
 ## Dynamic Facts
 
 - Item ID: WI-1120
-- Current Checkpoint: build checkpoint
-- Current Stop: Branch work/1120-suite-validate-core has passed local validation, shadow parity, and build checkpoint for #1120.
-- Next Step: Push branch, open PR, run PR gate and GitHub checks, then merge and close out #1120.
+- Current Checkpoint: merge
+- Current Stop: Branch work/1120-suite-validate-core is pushed and PR #1165 is open after local validation, shadow parity, and build checkpoint passed.
+- Next Step: Run PR gate and GitHub checks for PR #1165, then merge and close out #1120.
 - Blockers: None
 - Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1120.
 - Recovery Boundary: #1120 owns core `loom suite validate` command behavior only. It must not implement #1121 path-depth checks, #1122 not_applicable rationale enforcement, #1123 spec/plan mapping, #1124 final taxonomy expansion, #1125 spec-review integration, host writes, review writes, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.

--- a/.loom/progress/WI-1120.md
+++ b/.loom/progress/WI-1120.md
@@ -3,11 +3,11 @@
 ## Dynamic Facts
 
 - Item ID: WI-1120
-- Current Checkpoint: implementation checkpoint
-- Current Stop: Branch work/1120-suite-validate-core is implementing the core read-only `loom suite validate` command and local contract fixtures.
-- Next Step: Finish focused validation, record reviews, build checkpoint, open PR, run PR gate, merge, and close out #1120.
+- Current Checkpoint: build checkpoint
+- Current Stop: Branch work/1120-suite-validate-core has passed local validation, shadow parity, and build checkpoint for #1120.
+- Next Step: Push branch, open PR, run PR gate and GitHub checks, then merge and close out #1120.
 - Blockers: None
-- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .
+- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1120.
 - Recovery Boundary: #1120 owns core `loom suite validate` command behavior only. It must not implement #1121 path-depth checks, #1122 not_applicable rationale enforcement, #1123 spec/plan mapping, #1124 final taxonomy expansion, #1125 spec-review integration, host writes, review writes, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.
 - Current Lane: full-spec-suite-cli/validate-core
 

--- a/.loom/progress/WI-1120.md
+++ b/.loom/progress/WI-1120.md
@@ -1,0 +1,21 @@
+# WI-1120 Progress
+
+## Dynamic Facts
+
+- Item ID: WI-1120
+- Current Checkpoint: implementation checkpoint
+- Current Stop: Branch work/1120-suite-validate-core is implementing the core read-only `loom suite validate` command and local contract fixtures.
+- Next Step: Finish focused validation, record reviews, build checkpoint, open PR, run PR gate, merge, and close out #1120.
+- Blockers: None
+- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .
+- Recovery Boundary: #1120 owns core `loom suite validate` command behavior only. It must not implement #1121 path-depth checks, #1122 not_applicable rationale enforcement, #1123 spec/plan mapping, #1124 final taxonomy expansion, #1125 spec-review integration, host writes, review writes, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.
+- Current Lane: full-spec-suite-cli/validate-core
+
+## Execution Ledger
+
+- Ledger Binding: recovery_entry
+- Plan Locator: .loom/specs/WI-1120/plan.md
+- Acceptance Locator: .loom/specs/WI-1120/spec.md
+- Validation Evidence Locator: .loom/progress/WI-1120.md
+- Handoff Notes Locator: https://github.com/MC-and-his-Agents/Loom/issues/1120#issuecomment-4559723693
+- Evidence Freshness: current

--- a/.loom/reviews/WI-1120.json
+++ b/.loom/reviews/WI-1120.json
@@ -5,7 +5,7 @@
   "kind": "general_review",
   "summary": "General review allows WI-1120 at build checkpoint: the patch adds the implemented `suite validate` CLI surface, keeps it read-only, reuses suite inspect state, returns structured pass/block/advisory/not_applicable envelopes, and adds contract fixtures for the core result classes. The implementation does not add writes, host integration, generated skills sync, `/speckit.*`, `.specify/`, or spec-review flow integration.",
   "reviewer": "Codex",
-  "reviewed_head": "40fd7d4f71214ffb32c61a413d4d1ba9faead166",
+  "reviewed_head": "a2e9013c4d4bc2570660f2880fd33a452d7d7f2a",
   "reviewed_validation_summary": "Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-1120.json
+++ b/.loom/reviews/WI-1120.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-1120",
+  "decision": "allow",
+  "kind": "general_review",
+  "summary": "General review allows WI-1120 at build checkpoint: the patch adds the implemented `suite validate` CLI surface, keeps it read-only, reuses suite inspect state, returns structured pass/block/advisory/not_applicable envelopes, and adds contract fixtures for the core result classes. The implementation does not add writes, host integration, generated skills sync, `/speckit.*`, `.specify/`, or spec-review flow integration.",
+  "reviewer": "Codex",
+  "reviewed_head": "40fd7d4f71214ffb32c61a413d4d1ba9faead166",
+  "reviewed_validation_summary": "Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-1120.md",
+    "recovery_entry": ".loom/progress/WI-1120.md",
+    "status_surface": ".loom/status/current.md",
+    "build_checkpoint": "pending",
+    "budget_risk": {
+      "schema_version": "loom-execution-budget-risk/v1",
+      "status": "not_applicable",
+      "enforcement": "advisory",
+      "highest_risk": "none",
+      "risk_dimensions": [],
+      "summary": "execution budget is not_applicable; budget risk remains advisory and non-blocking",
+      "budget_summary": "execution budget is not collected for this invocation.",
+      "adapter_evidence_locator": "",
+      "provenance": {
+        "source": "github_host"
+      }
+    },
+    "engine_adapter": null,
+    "engine_evidence": null,
+    "normalized_findings": null
+  }
+}

--- a/.loom/reviews/WI-1120.json
+++ b/.loom/reviews/WI-1120.json
@@ -6,7 +6,7 @@
   "summary": "General review allows WI-1120 at build checkpoint: the patch adds the implemented `suite validate` CLI surface, keeps it read-only, reuses suite inspect state, returns structured pass/block/advisory/not_applicable envelopes, and adds contract fixtures for the core result classes. The implementation does not add writes, host integration, generated skills sync, `/speckit.*`, `.specify/`, or spec-review flow integration.",
   "reviewer": "Codex",
   "reviewed_head": "a2e9013c4d4bc2570660f2880fd33a452d7d7f2a",
-  "reviewed_validation_summary": "Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .",
+  "reviewed_validation_summary": "Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1120.",
   "fallback_to": null,
   "findings": [],
   "blocking_issues": [],
@@ -15,7 +15,7 @@
     "work_item": ".loom/work-items/WI-1120.md",
     "recovery_entry": ".loom/progress/WI-1120.md",
     "status_surface": ".loom/status/current.md",
-    "build_checkpoint": "pending",
+    "build_checkpoint": "pass",
     "budget_risk": {
       "schema_version": "loom-execution-budget-risk/v1",
       "status": "not_applicable",

--- a/.loom/reviews/WI-1120.spec.json
+++ b/.loom/reviews/WI-1120.spec.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-1120",
+  "decision": "allow",
+  "kind": "spec_review",
+  "summary": "Spec review allows WI-1120: the implementation scope is limited to the core read-only `loom suite validate` command, command matrix/docs updates, and contract fixtures for pass, block, advisory, and not_applicable. Deeper suite path validation, not_applicable rationale enforcement, spec/plan mapping, taxonomy expansion, and spec-review integration remain deferred to #1121-#1125.",
+  "reviewer": "Codex",
+  "reviewed_head": "87c5054756aea665ad83d05aac7d7ee62d720d12",
+  "reviewed_validation_summary": "Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-1120.md",
+    "recovery_entry": ".loom/progress/WI-1120.md",
+    "status_surface": ".loom/status/current.md",
+    "spec": ".loom/specs/WI-1120/spec.md",
+    "plan": ".loom/specs/WI-1120/plan.md",
+    "implementation_contract": ".loom/specs/WI-1120/implementation-contract.md"
+  }
+}

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "27f9442563715c907052a3ecd0301678460535df1ac5b45712477c5b2897a745"
+    ".loom/status/current.md": "a6c458d1ebc27289525f792fb22fccd1118f2dfedf507be7e0553f5bc71bb8d9"
   }
 }

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "a6c458d1ebc27289525f792fb22fccd1118f2dfedf507be7e0553f5bc71bb8d9"
+    ".loom/status/current.md": "e990383b1f7cbaf29062180123b3fad696d161d0c99a1e53005518820379127b"
   }
 }

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "ed8b7bbf17dd699070410887985aeba85c4e27901e63835fe00e1e9c72908df7"
+    ".loom/status/current.md": "27f9442563715c907052a3ecd0301678460535df1ac5b45712477c5b2897a745"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "27f9442563715c907052a3ecd0301678460535df1ac5b45712477c5b2897a745"
+    ".loom/status/current.md": "a6c458d1ebc27289525f792fb22fccd1118f2dfedf507be7e0553f5bc71bb8d9"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "a6c458d1ebc27289525f792fb22fccd1118f2dfedf507be7e0553f5bc71bb8d9"
+    ".loom/status/current.md": "e990383b1f7cbaf29062180123b3fad696d161d0c99a1e53005518820379127b"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "ed8b7bbf17dd699070410887985aeba85c4e27901e63835fe00e1e9c72908df7"
+    ".loom/status/current.md": "27f9442563715c907052a3ecd0301678460535df1ac5b45712477c5b2897a745"
   }
 }

--- a/.loom/specs/WI-1120/implementation-contract.md
+++ b/.loom/specs/WI-1120/implementation-contract.md
@@ -1,0 +1,23 @@
+# WI-1120 Implementation Contract
+
+## Owned Surface
+
+- `loom suite validate` core read-only command.
+- CLI contract fixtures proving the core result envelope.
+
+## Required Behavior
+
+- The command must never mutate the target repository.
+- Missing `--item` or unsafe item ids fail closed.
+- Missing suite path decisions return `block` with `missing_suite_path_decision`.
+- Missing required artifacts return `block` with `missing_required_artifact`.
+- Valid minimal and complete full suite fixtures return `pass`.
+- `not_applicable` path decisions return `not_applicable`.
+- Deferred evidence, consistency, and carrier surfaces may be advisory in #1120.
+
+## Forbidden Surface
+
+- No GitHub issue, Project, PR, branch, worktree, or host-control mutation.
+- No review record, merge-ready result, closeout result, runtime attempt, shadow truth, task carrier, or status truth mutation by the CLI command.
+- No generated skills, plugin, workflow, or PR template mutation.
+- No `/speckit.*` command names or `.specify/` layout.

--- a/.loom/specs/WI-1120/plan.md
+++ b/.loom/specs/WI-1120/plan.md
@@ -1,0 +1,32 @@
+# WI-1120 Plan
+
+## Implementation Plan
+
+1. Add `suite validate` to `tools/loom.py` command metadata and usage.
+2. Implement a read-only validate helper that consumes `suite_inspect_payload`.
+3. Map unknown suite paths and missing required artifacts to blocking gaps.
+4. Preserve `not_applicable` and advisory result envelopes for the core command.
+5. Add CLI contract fixtures for pass, block, advisory, and not_applicable.
+6. Update CLI surface docs to mark #1120 as the implemented core validate slice.
+
+## Validation Plan
+
+- `python3 tools/check_cli_contract.py`
+- `python3 -m py_compile tools/loom.py tools/check_cli_contract.py`
+- `git diff --check`
+- focused `rg` for `suite validate`, validate constants, `/speckit`, and `.specify`
+- `python3 tools/skills_surface.py check`
+- `python3 tools/check_release_surface.py`
+- `python3 tools/version_surface_check.py`
+- `python3 tools/check_npm_package.py`
+- `python3 tools/host_adapter_check.py`
+- `python3 tools/loom_check.py --profile source --source-surface contract-only .`
+- `python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1120`
+
+## Out Of Scope
+
+- No #1121 path-depth validation.
+- No #1122 not_applicable rationale enforcement.
+- No #1123 spec/plan mapping checks.
+- No #1124 final failure taxonomy expansion.
+- No #1125 `flow spec-review` integration.

--- a/.loom/specs/WI-1120/spec.md
+++ b/.loom/specs/WI-1120/spec.md
@@ -1,0 +1,35 @@
+# WI-1120 Spec
+
+## Goal
+
+Implement the core read-only `loom suite validate` command.
+
+## Scope
+
+- Add `suite validate` to the help JSON command matrix.
+- Reuse the existing suite inspect state as the validate read model.
+- Emit the standard `loom-cli-output/v1` envelope with `pass`, `block`, `advisory`, or `not_applicable`.
+- Include `failed_layer`, `fail_closed_reason`, `missing_inputs`, `blocking_gaps`, `advisory_gaps`, and consumed contract locators.
+- Keep the command read-only.
+
+## Non-Goals
+
+- No scaffold writes.
+- No host, issue, PR, Project, review, merge-ready, or closeout writes.
+- No generated skills synchronization.
+- No `flow spec-review` integration.
+- No `/speckit.*` command names or `.specify/` layout.
+
+## Acceptance Criteria
+
+- AC-1120-1: `loom help --json` declares `suite validate` as an implemented suite command.
+- AC-1120-2: Missing suite path decisions fail closed with a blocking gap.
+- AC-1120-3: Minimal and complete full suite fixtures pass core validation.
+- AC-1120-4: `not_applicable` suite path decisions return `not_applicable` without mutation.
+- AC-1120-5: Core advisory gaps are represented without upgrading deferred evidence/carrier work to blocking.
+- AC-1120-6: Missing required artifacts fail closed with `missing_required_artifact`.
+
+## Guardrails
+
+- CLI output remains evidence only; it does not replace Work Item truth, recovery truth, review records, merge-ready evidence, closeout evidence, or docs/source contracts.
+- Deeper validation remains owned by #1121-#1125.

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -11,11 +11,11 @@
 - Review Entry: .loom/reviews/WI-1120.json
 - Validation Entry: python3 tools/check_cli_contract.py; git diff --check; focused rg; python3 tools/skills_surface.py check; python3 tools/loom_check.py --profile source --source-surface contract-only .
 - Closing Condition: #1120 PR is merged to main, closeout evidence records PR/head/merge/target branch/validation/Project state, #1120 is closed completed, and #1119 can consume the evidence.
-- Current Checkpoint: implementation checkpoint
-- Current Stop: Branch work/1120-suite-validate-core is implementing the core read-only `loom suite validate` command and local contract fixtures.
-- Next Step: Finish focused validation, record reviews, build checkpoint, open PR, run PR gate, merge, and close out #1120.
+- Current Checkpoint: build checkpoint
+- Current Stop: Branch work/1120-suite-validate-core has passed local validation, shadow parity, and build checkpoint for #1120.
+- Next Step: Push branch, open PR, run PR gate and GitHub checks, then merge and close out #1120.
 - Blockers: None
-- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .
+- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1120.
 - Recovery Boundary: #1120 owns core `loom suite validate` command behavior only. It must not implement #1121 path-depth checks, #1122 not_applicable rationale enforcement, #1123 spec/plan mapping, #1124 final taxonomy expansion, #1125 spec-review integration, host writes, review writes, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.
 - Current Lane: full-spec-suite-cli/validate-core
 
@@ -24,7 +24,7 @@
 - Run Entry: not_applicable
 - Logs Entry: not_applicable
 - Diagnostics Entry: not_applicable
-- Verification Entry: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .
+- Verification Entry: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1120.
 - Lane Entry: not_applicable
 
 ## Sources

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -2,34 +2,34 @@
 
 ## Derived Fact Chain View
 
-- Item ID: WI-1118
-- Goal: Prove `loom suite scaffold` cannot mutate host truth, review truth, merge-ready truth, closeout truth, task carriers, or generated skills surfaces it does not own.
-- Scope: #1118 only: add negative scaffold contract fixtures for forbidden truth surfaces while preserving the #1114-#1117 scaffold behavior. Do not add host integration, new scaffold artifacts, rollback execution, generated skills sync, `/speckit.*`, or `.specify/` layout.
-- Execution Path: issue #1118 -> branch work/1118-scaffold-truth-safeguards -> worktree /Users/mc/dev/Loom-worktrees/1118-scaffold-truth-safeguards -> PR pending
+- Item ID: WI-1120
+- Goal: Implement the core read-only `loom suite validate` command.
+- Scope: #1120 only: add the command matrix entry, read-only validate envelope, core pass/block/advisory/not_applicable behavior, and CLI contract fixtures. Defer deeper path artifact validation, not_applicable rationale enforcement, spec/plan mapping, taxonomy expansion, and spec-review integration to #1121-#1125.
+- Execution Path: issue #1120 -> branch work/1120-suite-validate-core -> worktree /Users/mc/dev/Loom-worktrees/1120-suite-validate-core -> PR pending
 - Workspace Entry: .
-- Recovery Entry: .loom/progress/WI-1118.md
-- Review Entry: .loom/reviews/WI-1118.json
+- Recovery Entry: .loom/progress/WI-1120.md
+- Review Entry: .loom/reviews/WI-1120.json
 - Validation Entry: python3 tools/check_cli_contract.py; git diff --check; focused rg; python3 tools/skills_surface.py check; python3 tools/loom_check.py --profile source --source-surface contract-only .
-- Closing Condition: #1118 PR is merged to main, closeout evidence records PR/head/merge/target branch/validation/Project state, #1118 is closed completed, and #1113 can consume the evidence.
-- Current Checkpoint: PR checkpoint
-- Current Stop: Branch work/1118-scaffold-truth-safeguards is pushed and PR #1164 is open for #1118 after local validation/build checkpoint passed.
-- Next Step: Run PR gate and GitHub checks for PR #1164, then merge and close out #1118.
+- Closing Condition: #1120 PR is merged to main, closeout evidence records PR/head/merge/target branch/validation/Project state, #1120 is closed completed, and #1119 can consume the evidence.
+- Current Checkpoint: implementation checkpoint
+- Current Stop: Branch work/1120-suite-validate-core is implementing the core read-only `loom suite validate` command and local contract fixtures.
+- Next Step: Finish focused validation, record reviews, build checkpoint, open PR, run PR gate, merge, and close out #1120.
 - Blockers: None
-- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; git diff --check; focused rg for forbidden truth fixtures, scaffold write boundaries, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118.
-- Recovery Boundary: #1118 owns negative scaffold regression coverage only. It must not implement host integration, new scaffold artifacts, rollback execution, generated skills sync, review writes, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.
-- Current Lane: full-spec-suite-cli/scaffold-truth-safeguards
+- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .
+- Recovery Boundary: #1120 owns core `loom suite validate` command behavior only. It must not implement #1121 path-depth checks, #1122 not_applicable rationale enforcement, #1123 spec/plan mapping, #1124 final taxonomy expansion, #1125 spec-review integration, host writes, review writes, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.
+- Current Lane: full-spec-suite-cli/validate-core
 
 ## Runtime Evidence
 
 - Run Entry: not_applicable
 - Logs Entry: not_applicable
 - Diagnostics Entry: not_applicable
-- Verification Entry: git diff --check; focused rg checks for scaffold truth-surface boundaries; python3 tools/check_cli_contract.py; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1118.
+- Verification Entry: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .
 - Lane Entry: not_applicable
 
 ## Sources
 
-- Static Truth: .loom/work-items/WI-1118.md
-- Dynamic Truth: .loom/progress/WI-1118.md
+- Static Truth: .loom/work-items/WI-1120.md
+- Dynamic Truth: .loom/progress/WI-1120.md
 - Locator Truth: .loom/bootstrap/init-result.json
 - Fact Chain CLI: python3 .loom/bin/loom_init.py fact-chain --target .

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -11,9 +11,9 @@
 - Review Entry: .loom/reviews/WI-1120.json
 - Validation Entry: python3 tools/check_cli_contract.py; git diff --check; focused rg; python3 tools/skills_surface.py check; python3 tools/loom_check.py --profile source --source-surface contract-only .
 - Closing Condition: #1120 PR is merged to main, closeout evidence records PR/head/merge/target branch/validation/Project state, #1120 is closed completed, and #1119 can consume the evidence.
-- Current Checkpoint: build checkpoint
-- Current Stop: Branch work/1120-suite-validate-core has passed local validation, shadow parity, and build checkpoint for #1120.
-- Next Step: Push branch, open PR, run PR gate and GitHub checks, then merge and close out #1120.
+- Current Checkpoint: merge
+- Current Stop: Branch work/1120-suite-validate-core is pushed and PR #1165 is open after local validation, shadow parity, and build checkpoint passed.
+- Next Step: Run PR gate and GitHub checks for PR #1165, then merge and close out #1120.
 - Blockers: None
 - Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1120.
 - Recovery Boundary: #1120 owns core `loom suite validate` command behavior only. It must not implement #1121 path-depth checks, #1122 not_applicable rationale enforcement, #1123 spec/plan mapping, #1124 final taxonomy expansion, #1125 spec-review integration, host writes, review writes, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.

--- a/.loom/work-items/WI-1120.md
+++ b/.loom/work-items/WI-1120.md
@@ -1,0 +1,29 @@
+# WI-1120
+
+## Static Facts
+
+- Item ID: WI-1120
+- Goal: Implement the core read-only `loom suite validate` command.
+- Scope: #1120 only: add the command matrix entry, read-only validate envelope, core pass/block/advisory/not_applicable behavior, and CLI contract fixtures. Defer deeper path artifact validation, not_applicable rationale enforcement, spec/plan mapping, taxonomy expansion, and spec-review integration to #1121-#1125.
+- Execution Path: issue #1120 -> branch work/1120-suite-validate-core -> worktree /Users/mc/dev/Loom-worktrees/1120-suite-validate-core -> PR pending
+- Workspace Entry: .
+- Recovery Entry: .loom/progress/WI-1120.md
+- Review Entry: .loom/reviews/WI-1120.json
+- Validation Entry: python3 tools/check_cli_contract.py; git diff --check; focused rg; python3 tools/skills_surface.py check; python3 tools/loom_check.py --profile source --source-surface contract-only .
+- Closing Condition: #1120 PR is merged to main, closeout evidence records PR/head/merge/target branch/validation/Project state, #1120 is closed completed, and #1119 can consume the evidence.
+
+## Associated Artifacts
+
+- `.loom/work-items/WI-1120.md`
+- `.loom/progress/WI-1120.md`
+- `.loom/reviews/WI-1120.json`
+- `.loom/reviews/WI-1120.spec.json`
+- `.loom/status/current.md`
+- `.loom/bootstrap/init-result.json`
+- `.loom/specs/WI-1120/spec.md`
+- `.loom/specs/WI-1120/plan.md`
+- `.loom/specs/WI-1120/implementation-contract.md`
+- `tools/loom.py`
+- `tools/check_cli_contract.py`
+- `docs/methodology/harness/cli-command-matrix.md`
+- `docs/methodology/harness/full-spec-suite-cli-surface.md`

--- a/docs/methodology/harness/cli-command-matrix.md
+++ b/docs/methodology/harness/cli-command-matrix.md
@@ -138,10 +138,18 @@ loom suite scaffold
 
 `suite scaffold` defaults to dry-run, emits `mutates: false`, and plans suite artifacts under `.loom/specs/<item>/`. Its JSON reports planned writes, source templates, consumed locators, required versus conditional artifacts, overwrite policy, `apply_required`, rollback note, and `created_locators`. #1115 implements `--apply` for repo-local minimal scaffold writes: missing `spec.md` and `plan.md` files are created from the Loom templates, existing files are preserved, and the response reports only the locators actually created. #1116 implements `--suite full` for the standard full suite scaffold artifacts: `suite-index.md`, `spec.md`, `plan.md`, `research.md`, `contracts.md`, and `readiness-checklist.md`. Traversal items, absolute items, symlink paths, and non-file artifact placeholders fail closed before writes.
 
+#1120 implements the first validate command:
+
+```text
+loom suite validate
+```
+
+`suite validate` is read-only. It reuses the suite inspect state and returns a readiness envelope with `pass`, `block`, `advisory`, or `not_applicable`, plus `failed_layer`, `fail_closed_reason`, `missing_inputs`, `blocking_gaps`, and `advisory_gaps`. The #1120 slice is intentionally core-only: missing suite path decisions and missing required suite artifacts block; later evidence, consistency, and carrier artifacts can appear as advisory gaps until their owning Work Items deepen validation. It does not write suite files, review truth, merge-ready truth, closeout truth, host state, generated skills, `/speckit.*`, or `.specify/` surfaces.
+
 The remaining suite namespace stays planned until later implementation Work Items add those commands to `loom help --json` and the CLI contract checks. The planned namespace is documented in [full-spec-suite-cli-surface.md](./full-spec-suite-cli-surface.md):
 
 ```text
-loom suite validate|analyze
+loom suite analyze
 loom suite evidence inspect|scaffold|validate
 loom suite consistency inspect|analyze
 loom suite carrier inspect|validate
@@ -215,3 +223,5 @@ For #1109-#1114 it also checks:
 - `suite scaffold --apply` creates only missing scaffold files for the requested suite path, reports created locators, and preserves existing files;
 - `suite scaffold --apply` fails closed for traversal items, absolute items, symlink paths, and non-file artifact placeholders before writing artifacts;
 - `suite scaffold --suite full` plans and applies the standard six full-suite scaffold artifacts without creating evidence-map, consistency-analysis, task-carrier, review, merge-ready, closeout, generated skill, `/speckit.*`, or `.specify/` surfaces.
+- `suite validate` is declared as an implemented suite command in `loom help --json`;
+- `suite validate` stays read-only and covers pass, block, advisory, and not_applicable fixtures with structured readiness gaps.

--- a/docs/methodology/harness/full-spec-suite-cli-surface.md
+++ b/docs/methodology/harness/full-spec-suite-cli-surface.md
@@ -27,7 +27,7 @@
 | --- | --- | --- | --- |
 | `loom suite inspect` | planned | read-only | 读取 Work Item、suite path decision、artifact inventory、delivery planning、task carrier、evidence-map、consistency-analysis 与 gate-chain locators。 |
 | `loom suite scaffold` | planned | scaffold-write | 生成或补齐 suite scaffold 文件；必须显式 `--apply`，默认只输出 plan。 |
-| `loom suite validate` | planned | validate | 校验 suite locator、required / conditional artifact、minimal `not_applicable` rationale、spec -> plan mapping、task carrier mapping 与 evidence-map freshness。 |
+| `loom suite validate` | implemented core (#1120) | validate | 校验 suite path decision 与 core required artifact envelope；minimal `not_applicable` rationale、spec -> plan mapping、task carrier mapping 与 evidence-map freshness 由后续 Work Items 加深。 |
 | `loom suite analyze` | planned | analyze | 运行 consistency-analysis 风格的跨工件分析，只输出 finding 与 remediation direction，不修文件。 |
 | `loom suite evidence inspect` | planned | read-only | 读取 evidence-map row、source locator、freshness、HEAD / PR / merge binding。 |
 | `loom suite evidence scaffold` | planned | scaffold-write | 为当前 suite 生成 evidence-map scaffold；必须显式 `--apply`。 |
@@ -235,7 +235,7 @@ Scenario skills 仍是 agent-facing entrance；CLI 是 machine interface。后�
 
 1. `suite inspect` read-only：读取 suite path decision、artifact inventory、core locators 与 host binding。
 2. `suite scaffold` dry-run / apply：基于 docs scaffold 生成 suite artifacts，默认 fail closed without `--apply`。
-3. `suite validate`：校验 full/minimal path、required artifacts、`not_applicable`、spec -> plan mapping 与 delivery planning locators。
+3. `suite validate`：#1120 先校验 full/minimal/not_applicable path 与 core required artifacts；后续 Work Items 继续加深 `not_applicable` rationale、spec -> plan mapping 与 delivery planning locators。
 4. `suite carrier inspect|validate`：读取 execution breakdown / task carrier normalized status 与 truth conflict。
 5. `suite evidence inspect|scaffold|validate`：生成并校验 evidence-map locator、row fields、freshness 与 evidence binding。
 6. `suite consistency inspect|analyze`：输出 consistency-analysis findings、classification 与 remediation direction。

--- a/tools/check_cli_contract.py
+++ b/tools/check_cli_contract.py
@@ -115,6 +115,7 @@ REQUIRED_COMMANDS = {
     "skills release-check",
     "suite inspect",
     "suite scaffold",
+    "suite validate",
 }
 
 
@@ -234,6 +235,21 @@ def run_suite_scaffold_apply_fixture(target: Path, item: str, extra_args: list[s
         raise AssertionError(f"suite scaffold apply envelope drifted for {item}")
     if payload.get("item_id") != item:
         raise AssertionError(f"suite scaffold apply item binding drifted for {item}")
+    return payload
+
+
+def run_suite_validate_fixture(target: Path, item: str, *, expect: int = 0) -> dict[str, Any]:
+    before = snapshot_tree(target)
+    _, payload = run_json(["suite", "validate", "--target", str(target), "--item", item, "--json"], expect=expect)
+    after = snapshot_tree(target)
+    if before != after:
+        raise AssertionError(f"suite validate mutated fixture target for {item}")
+    if payload.get("command") != "suite validate" or payload.get("mutates") is not False:
+        raise AssertionError(f"suite validate envelope drifted for {item}")
+    if payload.get("item_id") != item:
+        raise AssertionError(f"suite validate item binding drifted for {item}")
+    if not isinstance(payload.get("blocking_gaps"), list) or not isinstance(payload.get("advisory_gaps"), list):
+        raise AssertionError(f"suite validate gaps are not structured for {item}")
     return payload
 
 
@@ -402,6 +418,8 @@ def main() -> int:
         raise AssertionError("suite inspect must be declared in help matrix for #1111")
     if matrix["suite scaffold"]["status"] != "implemented" or matrix["suite scaffold"]["domain"] != "suite":
         raise AssertionError("suite scaffold must be declared in help matrix for #1114")
+    if matrix["suite validate"]["status"] != "implemented" or matrix["suite validate"]["domain"] != "suite":
+        raise AssertionError("suite validate must be declared in help matrix for #1120")
 
     _, version_payload = run_json(["version", "--json"], expect=0)
     if version_payload["result"] != "pass" or not version_payload["versions"]["repo_version"]:
@@ -418,6 +436,16 @@ def main() -> int:
             or "suite_path_decision" not in suite_unknown.get("payload", {}).get("missing_inputs", [])
         ):
             raise AssertionError("suite inspect unknown-state payload drifted")
+        suite_unknown_validate = run_suite_validate_fixture(suite_unknown_target, "WI-1109", expect=1)
+        if (
+            suite_unknown_validate.get("result") != "block"
+            or suite_unknown_validate.get("failed_layer") != "suite"
+            or suite_unknown_validate.get("fail_closed_reason") != "missing_suite_path_decision"
+            or "suite_path_decision" not in suite_unknown_validate.get("missing_inputs", [])
+            or not suite_unknown_validate.get("blocking_gaps")
+            or suite_unknown_validate.get("advisory_gaps")
+        ):
+            raise AssertionError("suite validate unknown-state block payload drifted")
 
         minimal_target = tmp / "suite-minimal"
         minimal_suite = minimal_target / ".loom" / "specs" / "WI-minimal"
@@ -437,6 +465,18 @@ def main() -> int:
             or minimal_payload.get("missing_inputs")
         ):
             raise AssertionError("suite inspect minimal locator payload drifted")
+        suite_minimal_validate = run_suite_validate_fixture(minimal_target, "WI-minimal")
+        if (
+            suite_minimal_validate.get("result") != "pass"
+            or suite_minimal_validate.get("failed_layer") is not None
+            or suite_minimal_validate.get("fail_closed_reason") is not None
+            or suite_minimal_validate.get("missing_inputs")
+            or suite_minimal_validate.get("blocking_gaps")
+            or suite_minimal_validate.get("advisory_gaps")
+            or "docs/methodology/harness/full-spec-suite-cli-surface.md"
+            not in suite_minimal_validate.get("payload", {}).get("consumed_contracts", [])
+        ):
+            raise AssertionError("suite validate minimal pass payload drifted")
 
         not_applicable_target = tmp / "suite-not-applicable"
         not_applicable_suite = not_applicable_target / ".loom" / "specs" / "WI-not-applicable"
@@ -450,6 +490,13 @@ def main() -> int:
             or not_applicable_payload.get("missing_inputs")
         ):
             raise AssertionError("suite inspect not_applicable payload drifted")
+        suite_not_applicable_validate = run_suite_validate_fixture(not_applicable_target, "WI-not-applicable", expect=1)
+        if (
+            suite_not_applicable_validate.get("result") != "not_applicable"
+            or suite_not_applicable_validate.get("payload", {}).get("suite_path") != "not_applicable"
+            or suite_not_applicable_validate.get("blocking_gaps")
+        ):
+            raise AssertionError("suite validate not_applicable payload drifted")
 
         full_target = tmp / "suite-full"
         full_suite = full_target / ".loom" / "specs" / "WI-full"
@@ -488,6 +535,31 @@ def main() -> int:
                 raise AssertionError("suite inspect emitted absolute artifact locator")
         if full_payload.get("task_carrier_locators") != [".loom/specs/WI-full/task-carrier.md"]:
             raise AssertionError("suite inspect task carrier locators drifted")
+        suite_full_validate = run_suite_validate_fixture(full_target, "WI-full")
+        if (
+            suite_full_validate.get("result") != "pass"
+            or suite_full_validate.get("blocking_gaps")
+            or suite_full_validate.get("advisory_gaps")
+        ):
+            raise AssertionError("suite validate full pass payload drifted")
+
+        full_advisory_target = tmp / "suite-full-advisory"
+        full_advisory_suite = full_advisory_target / ".loom" / "specs" / "WI-full-advisory"
+        full_advisory_suite.mkdir(parents=True)
+        (full_advisory_suite / "suite-index.md").write_text(
+            "# Full Suite Index\n\n- Schema marker: loom-full-suite-index/v1\n- Suite path: full\n",
+            encoding="utf-8",
+        )
+        (full_advisory_suite / "spec.md").write_text("# Spec\n", encoding="utf-8")
+        (full_advisory_suite / "plan.md").write_text("# Plan\n", encoding="utf-8")
+        suite_full_advisory_validate = run_suite_validate_fixture(full_advisory_target, "WI-full-advisory", expect=1)
+        if (
+            suite_full_advisory_validate.get("result") != "advisory"
+            or suite_full_advisory_validate.get("blocking_gaps")
+            or not suite_full_advisory_validate.get("advisory_gaps")
+            or suite_full_advisory_validate.get("payload", {}).get("suite_path") != "full"
+        ):
+            raise AssertionError("suite validate advisory payload drifted")
 
         full_missing_target = tmp / "suite-full-missing"
         full_missing_suite = full_missing_target / ".loom" / "specs" / "WI-full-missing"
@@ -507,6 +579,17 @@ def main() -> int:
             or missing_inventory.get("plan.md", {}).get("status") != "missing"
         ):
             raise AssertionError("suite inspect missing required artifact payload drifted")
+        suite_full_missing_validate = run_suite_validate_fixture(full_missing_target, "WI-full-missing", expect=1)
+        if (
+            suite_full_missing_validate.get("result") != "block"
+            or suite_full_missing_validate.get("failed_layer") != "suite"
+            or suite_full_missing_validate.get("fail_closed_reason") != "missing_required_artifact"
+            or not any(
+                gap.get("failure_kind") == "missing_required_artifact"
+                for gap in suite_full_missing_validate.get("blocking_gaps", [])
+            )
+        ):
+            raise AssertionError("suite validate missing required artifact payload drifted")
 
         scaffold_target = tmp / "suite-scaffold"
         scaffold_target.mkdir()

--- a/tools/loom.py
+++ b/tools/loom.py
@@ -179,6 +179,13 @@ COMMANDS: list[dict[str, Any]] = [
         "json": True,
         "summary": "Plan or explicitly apply repo-local minimal or full spec suite scaffold writes.",
     },
+    {
+        "command": "suite validate",
+        "domain": "suite",
+        "status": "implemented",
+        "json": True,
+        "summary": "Validate the current suite path decision and core readiness envelope without mutating files.",
+    },
 ]
 
 COMMAND_INDEX = {entry["command"]: entry for entry in COMMANDS}
@@ -362,6 +369,7 @@ def print_usage(stream) -> None:
         "  resume, spec-review, review, merge-ready, check\n"
         "  suite inspect --target <repo> --item <item> [--json]\n"
         "  suite scaffold --target <repo> --item <item> [--suite minimal|full] [--apply] [--json]\n\n"
+        "  suite validate --target <repo> --item <item> [--json]\n\n"
         "Use `loom help --json` for the full frozen command matrix, including reserved commands.\n"
     )
 
@@ -1961,6 +1969,22 @@ SUITE_SCAFFOLD_CONTRACT_LOCATORS = (
     "docs/methodology/templates/spec-suite.md",
 )
 
+SUITE_VALIDATE_CONTRACT_LOCATORS = (
+    "docs/methodology/harness/full-spec-suite-cli-surface.md",
+    "docs/methodology/templates/spec-suite.md",
+)
+
+SUITE_VALIDATE_ADVISORY_ARTIFACTS = {
+    "full": (
+        "evidence-map.md",
+        "consistency-analysis.md",
+        "execution-breakdown.md",
+        "task-carrier",
+    ),
+    "minimal": (),
+    "not_applicable": (),
+}
+
 
 def suite_scaffold_payload(target: Path, item: str, suite_path: str, *, apply: bool) -> tuple[str, dict[str, Any], str | None]:
     item_error = suite_item_segment_error(item)
@@ -2199,6 +2223,159 @@ def suite_inspect_payload(target: Path, item: str | None) -> tuple[str, dict[str
     return summary, payload
 
 
+def suite_validate_finding(
+    *,
+    gap_id: str,
+    classification: str,
+    failure_kind: str,
+    source_locator: str | None,
+    consumer_impact: str,
+    remediation_direction: str,
+    fallback_to: str,
+) -> dict[str, Any]:
+    return {
+        "id": gap_id,
+        "classification": classification,
+        "failure_kind": failure_kind,
+        "surface": "suite",
+        "source_locator": source_locator,
+        "conflicting_locator": None,
+        "freshness": "missing" if classification == "missing" else None,
+        "binding": "suite-validate-core",
+        "consumer_impact": consumer_impact,
+        "remediation_direction": remediation_direction,
+        "fallback_to": fallback_to,
+    }
+
+
+def suite_validate_payload(target: Path, item: str) -> tuple[str, str, dict[str, Any], str | None, str | None, list[str]]:
+    item_error = suite_item_segment_error(item)
+    if item_error:
+        blocking_gaps = [
+            suite_validate_finding(
+                gap_id="suite-validate-invalid-item",
+                classification="blocking",
+                failure_kind="invalid_suite_item",
+                source_locator=None,
+                consumer_impact="suite validation cannot bind an unsafe item segment",
+                remediation_direction="Use a single repo-local Work Item id as the suite item.",
+                fallback_to="loom suite inspect --target <repo> --item <item> --json",
+            )
+        ]
+        payload = {
+            "suite_path": "unknown",
+            "suite_locator": None,
+            "path_decision_locator": None,
+            "artifact_inventory": [],
+            "consumed_contracts": list(SUITE_VALIDATE_CONTRACT_LOCATORS),
+            "missing_inputs": [item_error],
+            "blocking_gaps": blocking_gaps,
+            "advisory_gaps": [],
+            "findings": blocking_gaps,
+            "remediation_directions": [blocking_gaps[0]["remediation_direction"]],
+        }
+        return (
+            "Suite validate failed closed before resolving artifact paths.",
+            "block",
+            payload,
+            "suite-input",
+            "invalid_suite_item",
+            ["loom suite inspect --target <repo> --item <item> --json"],
+        )
+
+    inspect_summary, inspect_payload = suite_inspect_payload(target, item)
+    suite_path = inspect_payload.get("suite_path", "unknown")
+    missing_inputs = list(inspect_payload.get("missing_inputs", []))
+    blocking_gaps: list[dict[str, Any]] = []
+    advisory_gaps: list[dict[str, Any]] = []
+
+    for missing in missing_inputs:
+        if missing == "suite_path_decision":
+            blocking_gaps.append(
+                suite_validate_finding(
+                    gap_id="suite-validate-missing-suite-path-decision",
+                    classification="missing",
+                    failure_kind="missing_suite_path_decision",
+                    source_locator=None,
+                    consumer_impact="spec review cannot determine whether the suite is full, minimal, or not_applicable",
+                    remediation_direction="Author a suite path decision before validating readiness.",
+                    fallback_to="loom suite inspect --target <repo> --item <item> --json",
+                )
+            )
+        elif missing.startswith("required_artifact:"):
+            locator = missing.split(":", 1)[1]
+            blocking_gaps.append(
+                suite_validate_finding(
+                    gap_id=f"suite-validate-missing-{Path(locator).name}",
+                    classification="missing",
+                    failure_kind="missing_required_artifact",
+                    source_locator=locator,
+                    consumer_impact="spec review readiness cannot pass while a required suite artifact is absent",
+                    remediation_direction="Run suite scaffold dry-run or author the missing repo-relative artifact.",
+                    fallback_to="loom suite scaffold --target <repo> --item <item> --json",
+                )
+            )
+
+    artifact_inventory = {
+        entry.get("artifact"): entry
+        for entry in inspect_payload.get("artifact_inventory", [])
+        if isinstance(entry, dict)
+    }
+    for artifact in SUITE_VALIDATE_ADVISORY_ARTIFACTS.get(str(suite_path), ()):
+        if artifact_inventory.get(artifact, {}).get("status") == "present":
+            continue
+        locator_field = "task_carrier_locators" if artifact == "task-carrier" else artifact.replace("-", "_").removesuffix(".md") + "_locator"
+        locator_value = inspect_payload.get(locator_field)
+        if locator_value:
+            continue
+        expected_locator = f".loom/specs/{item}/{artifact if artifact != 'task-carrier' else 'task-carrier.md'}"
+        advisory_gaps.append(
+            suite_validate_finding(
+                gap_id=f"suite-validate-advisory-missing-{artifact.replace('.', '-').replace('_', '-')}",
+                classification="advisory",
+                failure_kind="missing_optional_suite_artifact",
+                source_locator=expected_locator,
+                consumer_impact="core suite validation can continue, but later evidence/carrier checks may require this artifact",
+                remediation_direction="Leave for the owning evidence, consistency, or carrier validation Work Item unless the current consumer requires it.",
+                fallback_to="loom suite validate --target <repo> --item <item> --json",
+            )
+        )
+
+    findings = [*blocking_gaps, *advisory_gaps]
+    result = "pass"
+    failed_layer: str | None = None
+    fail_closed_reason: str | None = None
+    fallback_to = ["loom suite inspect --target <repo> --item <item> --json"]
+    if blocking_gaps:
+        result = "block"
+        failed_layer = "suite"
+        fail_closed_reason = blocking_gaps[0]["failure_kind"]
+        fallback_to = [blocking_gaps[0]["fallback_to"]]
+        summary = "Suite validate found blocking readiness gaps."
+    elif suite_path == "not_applicable":
+        result = "not_applicable"
+        summary = "Suite validate found a not_applicable suite path decision."
+    elif advisory_gaps:
+        result = "advisory"
+        summary = "Suite validate found no core blocking gaps, but later suite checks still have advisory gaps."
+    else:
+        summary = {
+            "full": "Suite validate found a full suite path with core required artifacts present.",
+            "minimal": "Suite validate found a minimal suite path with core required artifacts present.",
+        }.get(str(suite_path), inspect_summary)
+
+    payload = {
+        **inspect_payload,
+        "consumed_contracts": list(SUITE_VALIDATE_CONTRACT_LOCATORS),
+        "missing_inputs": missing_inputs,
+        "blocking_gaps": blocking_gaps,
+        "advisory_gaps": advisory_gaps,
+        "findings": findings,
+        "remediation_directions": [entry["remediation_direction"] for entry in findings],
+    }
+    return summary, result, payload, failed_layer, fail_closed_reason, fallback_to
+
+
 def handle_suite(argv: list[str]) -> int:
     if not argv:
         return emit(
@@ -2214,7 +2391,7 @@ def handle_suite(argv: list[str]) -> int:
         )
 
     action = argv[0]
-    if action not in {"inspect", "scaffold"}:
+    if action not in {"inspect", "scaffold", "validate"}:
         return emit(
             output(
                 f"suite {action}",
@@ -2224,6 +2401,51 @@ def handle_suite(argv: list[str]) -> int:
                 failed_layer="suite-input",
                 fail_closed_reason=f"unsupported suite action: {action}",
                 fallback_to=["loom suite inspect --target <repo> --item <item> --json"],
+            )
+        )
+
+    if action == "validate":
+        parser = argparse.ArgumentParser(prog="loom suite validate")
+        parser.add_argument("--target", default=".")
+        parser.add_argument("--item")
+        parser.add_argument("--json", action="store_true")
+        args = parser.parse_args(argv[1:])
+        target = resolve_target(args.target)
+        if not target.exists():
+            return emit(block_target("suite validate", target, "target path does not exist"))
+        if not args.item:
+            return emit(
+                output(
+                    "suite validate",
+                    "block",
+                    target=str(target),
+                    item_id=args.item,
+                    summary="Suite validate requires a Work Item id.",
+                    mutates=False,
+                    failed_layer="suite-input",
+                    fail_closed_reason="missing_work_item",
+                    missing_inputs=["missing_work_item"],
+                    blocking_gaps=[],
+                    advisory_gaps=[],
+                    fallback_to=["loom suite validate --target <repo> --item <item> --json"],
+                )
+            )
+        summary, result, validate_payload, failed_layer, fail_closed_reason, fallback_to = suite_validate_payload(target, args.item)
+        return emit(
+            output(
+                "suite validate",
+                result,
+                target=str(target),
+                item_id=args.item,
+                summary=summary,
+                mutates=False,
+                failed_layer=failed_layer,
+                fail_closed_reason=fail_closed_reason,
+                missing_inputs=validate_payload.get("missing_inputs", []),
+                blocking_gaps=validate_payload.get("blocking_gaps", []),
+                advisory_gaps=validate_payload.get("advisory_gaps", []),
+                fallback_to=fallback_to,
+                payload=validate_payload,
             )
         )
 


### PR DESCRIPTION
Loom Work Item: WI-1120

## Summary

- implements core read-only `loom suite validate` surface
- adds CLI contract fixtures for pass, block, advisory, and not_applicable results
- records WI-1120 Loom carriers and updates CLI surface docs for the implemented core slice

## Scope Boundaries

- no scaffold writes or host mutations
- no review, merge-ready, closeout, Project, PR, or issue writes from `suite validate`
- no `/speckit.*` command names or `.specify/` layout
- defers #1121 path-depth checks, #1122 not_applicable rationale, #1123 spec/plan mapping, #1124 taxonomy expansion, and #1125 spec-review integration

## Validation

- `python3 tools/check_cli_contract.py`
- `python3 -m py_compile tools/loom.py tools/check_cli_contract.py`
- `git diff --check`
- focused `rg` for suite validate, validate constants, `/speckit`, and `.specify`
- `python3 tools/skills_surface.py check`
- `python3 tools/check_release_surface.py`
- `python3 tools/version_surface_check.py`
- `python3 tools/check_npm_package.py`
- `python3 tools/host_adapter_check.py`
- `python3 tools/loom_check.py --profile source --source-surface contract-only .`
- `python3 .loom/bin/loom_init.py fact-chain --target .`
- `python3 .loom/bin/loom_init.py verify --target .`
- `python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking`
- `python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1120`

Closes #1120.

