### PR TITLE
Validate suite path artifacts

### DIFF
--- a/.loom/bootstrap/init-result.json
+++ b/.loom/bootstrap/init-result.json
@@ -7,7 +7,7 @@
     "contract_version": "1.3.0"
   },
   "run": {
-    "target": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance",
+    "target": "/Users/mc/dev/Loom-worktrees/1121-suite-path-artifacts",
     "scenario": "复杂既有仓库",
     "scenario_key": "complex-existing",
     "integration_mode": "companion",
@@ -76,9 +76,9 @@
     "mode": "work-item + recovery-entry + derived status-surface",
     "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
     "entry_points": {
-      "current_item_id": "WI-1120",
-      "work_item": ".loom/work-items/WI-1120.md",
-      "recovery_entry": ".loom/progress/WI-1120.md",
+      "current_item_id": "WI-1121",
+      "work_item": ".loom/work-items/WI-1121.md",
+      "recovery_entry": ".loom/progress/WI-1121.md",
       "status_surface": ".loom/status/current.md"
     }
   },

--- a/.loom/progress/WI-1120.md
+++ b/.loom/progress/WI-1120.md
@@ -3,11 +3,11 @@
 ## Dynamic Facts
 
 - Item ID: WI-1120
-- Current Checkpoint: merge
-- Current Stop: Branch work/1120-suite-validate-core is pushed and PR #1165 is open after local validation, shadow parity, and build checkpoint passed.
-- Next Step: Run PR gate and GitHub checks for PR #1165, then merge and close out #1120.
+- Current Checkpoint: closed
+- Current Stop: PR #1165 was squash merged to main at merge commit 786dc5d45407f903fb398f1850f1394bb7705997, #1120 is CLOSED / COMPLETED, and Project `Loom` is Done.
+- Next Step: Terminal; #1119 consumed #1120 closeout evidence and continued to #1121.
 - Blockers: None
-- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1120.
+- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1120; PR gate, controlled-merge, reconciliation sync, and closeout check passed.
 - Recovery Boundary: #1120 owns core `loom suite validate` command behavior only. It must not implement #1121 path-depth checks, #1122 not_applicable rationale enforcement, #1123 spec/plan mapping, #1124 final taxonomy expansion, #1125 spec-review integration, host writes, review writes, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.
 - Current Lane: full-spec-suite-cli/validate-core
 

--- a/.loom/progress/WI-1121.md
+++ b/.loom/progress/WI-1121.md
@@ -1,0 +1,21 @@
+# WI-1121 Progress
+
+## Dynamic Facts
+
+- Item ID: WI-1121
+- Current Checkpoint: build
+- Current Stop: Branch work/1121-suite-path-artifacts has implemented path decision and required/conditional artifact validation with focused local checks passing.
+- Next Step: Record reviews, run build checkpoint, open PR, pass merge gate, merge, and close out #1121.
+- Blockers: None
+- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite_path, conditional artifacts, conflicting_suite_path_decision, invalid_suite_path_decision, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .
+- Recovery Boundary: #1121 owns suite path decision legality, required artifact existence/regular-file validation, and conditional artifact inventory only. It must not implement #1122 not_applicable/deferred rationale enforcement, #1123 spec/plan mapping checks, #1124 final taxonomy expansion, #1125 spec-review integration, host writes, review writes from the CLI command, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.
+- Current Lane: full-spec-suite-cli/validate-path-artifacts
+
+## Execution Ledger
+
+- Ledger Binding: recovery_entry
+- Plan Locator: .loom/specs/WI-1121/plan.md
+- Acceptance Locator: .loom/specs/WI-1121/spec.md
+- Validation Evidence Locator: .loom/progress/WI-1121.md
+- Handoff Notes Locator: https://github.com/MC-and-his-Agents/Loom/issues/1121#issuecomment-4559904393
+- Evidence Freshness: current

--- a/.loom/progress/WI-1121.md
+++ b/.loom/progress/WI-1121.md
@@ -4,10 +4,10 @@
 
 - Item ID: WI-1121
 - Current Checkpoint: build
-- Current Stop: Branch work/1121-suite-path-artifacts has implemented path decision and required/conditional artifact validation with focused local checks passing.
-- Next Step: Record reviews, run build checkpoint, open PR, pass merge gate, merge, and close out #1121.
+- Current Stop: PR #1166 is open with WI-1121 implementation and review carriers recorded.
+- Next Step: Refresh PR gate after retained validation evidence alignment, merge PR #1166, and close out #1121.
 - Blockers: None
-- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite_path, conditional artifacts, conflicting_suite_path_decision, invalid_suite_path_decision, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .
+- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite_path, conditional artifacts, conflicting_suite_path_decision, invalid_suite_path_decision, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1121.
 - Recovery Boundary: #1121 owns suite path decision legality, required artifact existence/regular-file validation, and conditional artifact inventory only. It must not implement #1122 not_applicable/deferred rationale enforcement, #1123 spec/plan mapping checks, #1124 final taxonomy expansion, #1125 spec-review integration, host writes, review writes from the CLI command, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.
 - Current Lane: full-spec-suite-cli/validate-path-artifacts
 

--- a/.loom/progress/WI-1121.md
+++ b/.loom/progress/WI-1121.md
@@ -3,9 +3,9 @@
 ## Dynamic Facts
 
 - Item ID: WI-1121
-- Current Checkpoint: build
-- Current Stop: PR #1166 is open with WI-1121 implementation and review carriers recorded.
-- Next Step: Refresh PR gate after retained validation evidence alignment, merge PR #1166, and close out #1121.
+- Current Checkpoint: merge
+- Current Stop: PR #1166 is open with WI-1121 implementation, validation, spec review, and implementation review carriers recorded.
+- Next Step: Pass PR gate, merge PR #1166, and close out #1121.
 - Blockers: None
 - Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite_path, conditional artifacts, conflicting_suite_path_decision, invalid_suite_path_decision, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1121.
 - Recovery Boundary: #1121 owns suite path decision legality, required artifact existence/regular-file validation, and conditional artifact inventory only. It must not implement #1122 not_applicable/deferred rationale enforcement, #1123 spec/plan mapping checks, #1124 final taxonomy expansion, #1125 spec-review integration, host writes, review writes from the CLI command, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.

--- a/.loom/reviews/WI-1121.json
+++ b/.loom/reviews/WI-1121.json
@@ -5,7 +5,7 @@
   "kind": "general_review",
   "summary": "General review allows WI-1121 at build checkpoint: `loom suite validate` now fails closed on missing, invalid, or conflicting suite path decisions; blocks missing or non-file required artifacts; inventories full path conditional artifacts without enforcing #1122 rationale; and preserves the read-only envelope and deferred boundaries for #1123-#1125.",
   "reviewer": "Codex",
-  "reviewed_head": "7415226f295ae4ed0285e7f873beed789e3a3c45",
+  "reviewed_head": "27da41caa03e7c426a03c3d668645ed18237ccb6",
   "reviewed_validation_summary": "Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite_path, conditional artifacts, conflicting_suite_path_decision, invalid_suite_path_decision, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1121.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-1121.json
+++ b/.loom/reviews/WI-1121.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-1121",
+  "decision": "allow",
+  "kind": "general_review",
+  "summary": "General review allows WI-1121 at build checkpoint: `loom suite validate` now fails closed on missing, invalid, or conflicting suite path decisions; blocks missing or non-file required artifacts; inventories full path conditional artifacts without enforcing #1122 rationale; and preserves the read-only envelope and deferred boundaries for #1123-#1125.",
+  "reviewer": "Codex",
+  "reviewed_head": "7415226f295ae4ed0285e7f873beed789e3a3c45",
+  "reviewed_validation_summary": "Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite_path, conditional artifacts, conflicting_suite_path_decision, invalid_suite_path_decision, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1121.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-1121.md",
+    "recovery_entry": ".loom/progress/WI-1121.md",
+    "status_surface": ".loom/status/current.md",
+    "build_checkpoint": "pass",
+    "budget_risk": {
+      "schema_version": "loom-execution-budget-risk/v1",
+      "status": "not_applicable",
+      "enforcement": "advisory",
+      "highest_risk": "none",
+      "risk_dimensions": [],
+      "summary": "execution budget is not_applicable; budget risk remains advisory and non-blocking",
+      "budget_summary": "execution budget is not collected for this invocation.",
+      "adapter_evidence_locator": "",
+      "provenance": {
+        "source": "github_host"
+      }
+    }
+  }
+}

--- a/.loom/reviews/WI-1121.spec.json
+++ b/.loom/reviews/WI-1121.spec.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-1121",
+  "decision": "allow",
+  "kind": "spec_review",
+  "summary": "Spec review allows WI-1121: the authored suite limits scope to path decision legality, required artifact regular-file validation, and conditional artifact inventory. not_applicable/deferred rationale, spec/plan mapping, final taxonomy expansion, and spec-review integration remain correctly deferred to #1122-#1125.",
+  "reviewer": "Codex",
+  "reviewed_head": "7415226f295ae4ed0285e7f873beed789e3a3c45",
+  "reviewed_validation_summary": "Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite_path, conditional artifacts, conflicting_suite_path_decision, invalid_suite_path_decision, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1121.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-1121.md",
+    "recovery_entry": ".loom/progress/WI-1121.md",
+    "status_surface": ".loom/status/current.md",
+    "spec": ".loom/specs/WI-1121/spec.md",
+    "plan": ".loom/specs/WI-1121/plan.md",
+    "implementation_contract": ".loom/specs/WI-1121/implementation-contract.md"
+  }
+}

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "e990383b1f7cbaf29062180123b3fad696d161d0c99a1e53005518820379127b"
+    ".loom/status/current.md": "caf2f54a56a68fb3ac6a7ce715dc5a20d7b2272b2c4f6ad61ec22eb66b93f134"
   }
 }

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "caf2f54a56a68fb3ac6a7ce715dc5a20d7b2272b2c4f6ad61ec22eb66b93f134"
+    ".loom/status/current.md": "7f5d7e0a7a496c0a235b5916d72a5630b4f0896ab547c9c109a4a6fb6b76d321"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "e990383b1f7cbaf29062180123b3fad696d161d0c99a1e53005518820379127b"
+    ".loom/status/current.md": "caf2f54a56a68fb3ac6a7ce715dc5a20d7b2272b2c4f6ad61ec22eb66b93f134"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "caf2f54a56a68fb3ac6a7ce715dc5a20d7b2272b2c4f6ad61ec22eb66b93f134"
+    ".loom/status/current.md": "7f5d7e0a7a496c0a235b5916d72a5630b4f0896ab547c9c109a4a6fb6b76d321"
   }
 }

--- a/.loom/specs/WI-1121/implementation-contract.md
+++ b/.loom/specs/WI-1121/implementation-contract.md
@@ -1,0 +1,23 @@
+# WI-1121 Implementation Contract
+
+## Owned Surface
+
+- `loom suite validate` path decision and required/conditional artifact validation.
+- CLI contract fixtures proving the #1121 result envelope.
+
+## Required Behavior
+
+- The command must never mutate the target repository.
+- Missing, invalid, or conflicting suite path decisions fail closed.
+- Required artifacts must be present as ordinary files.
+- Full path required artifacts are `suite-index.md`, `spec.md`, and `plan.md`.
+- Minimal path required artifacts are `spec.md` and `plan.md`.
+- Full path conditional artifacts are inventoried as conditional when absent.
+- Existing #1120 pass, block, advisory, and not_applicable envelopes remain stable.
+
+## Forbidden Surface
+
+- No GitHub issue, Project, PR, branch, worktree, or host-control mutation.
+- No review record, merge-ready result, closeout result, runtime attempt, shadow truth, task carrier, or status truth mutation by the CLI command.
+- No generated skills, plugin, workflow, or PR template mutation.
+- No `/speckit.*` command names or `.specify/` layout.

--- a/.loom/specs/WI-1121/plan.md
+++ b/.loom/specs/WI-1121/plan.md
@@ -1,0 +1,31 @@
+# WI-1121 Plan
+
+## Implementation Plan
+
+1. Reuse the existing `suite inspect` and `suite validate` helper structure.
+2. Add path decision collection that can detect invalid or conflicting path decisions.
+3. Add required artifact validation for non-file artifacts.
+4. Add full path conditional artifact inventory for `research.md`, `contracts.md`, and `readiness-checklist.md`.
+5. Extend CLI contract fixtures for conflict, invalid required artifact, and conditional artifact inventory.
+6. Update CLI surface docs to mark #1121 as the path/artifact validation deepening slice.
+
+## Validation Plan
+
+- `python3 tools/check_cli_contract.py`
+- `python3 -m py_compile tools/loom.py tools/check_cli_contract.py`
+- `git diff --check`
+- focused `rg` for `suite_path`, `conditional`, `conflicting_suite_path_decision`, `/speckit`, and `.specify`
+- `python3 tools/skills_surface.py check`
+- `python3 tools/check_release_surface.py`
+- `python3 tools/version_surface_check.py`
+- `python3 tools/check_npm_package.py`
+- `python3 tools/host_adapter_check.py`
+- `python3 tools/loom_check.py --profile source --source-surface contract-only .`
+- `python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1121`
+
+## Out Of Scope
+
+- No #1122 not_applicable/deferred rationale enforcement.
+- No #1123 spec/plan mapping checks.
+- No #1124 final failure taxonomy expansion.
+- No #1125 `flow spec-review` integration.

--- a/.loom/specs/WI-1121/spec.md
+++ b/.loom/specs/WI-1121/spec.md
@@ -1,0 +1,37 @@
+# WI-1121 Spec
+
+## Goal
+
+Validate suite path decisions and required/conditional suite artifacts before later formal spec gates consume them.
+
+## Scope
+
+- Detect missing, invalid, or conflicting suite path decisions.
+- Keep legal path decisions limited to `full`, `minimal`, and `not_applicable`.
+- Treat full path required artifacts as `suite-index.md`, `spec.md`, and `plan.md`.
+- Treat minimal path required artifacts as `spec.md` and `plan.md`.
+- Block required artifacts that are missing, directories, symlinks, or otherwise not ordinary files.
+- Include full path conditional artifacts in artifact inventory without enforcing rationale in this Work Item.
+
+## Non-Goals
+
+- No not_applicable/deferred rationale enforcement.
+- No spec to plan mapping validation.
+- No final failure taxonomy expansion beyond the existing #1052 failure kinds already consumed by #1120.
+- No `flow spec-review` or `gate spec-review` integration.
+- No host, issue, PR, Project, review, merge-ready, or closeout writes from `loom suite validate`.
+- No `/speckit.*` command names or `.specify/` layout.
+
+## Acceptance Criteria
+
+- AC-1121-1: Conflicting suite path decision fixtures fail closed.
+- AC-1121-2: Invalid path decision carriers fail closed without selecting a suite path.
+- AC-1121-3: Missing full path required artifacts continue to block.
+- AC-1121-4: Required artifact directories or symlinks block as required artifact gaps.
+- AC-1121-5: Full path conditional artifacts are represented in inventory as conditional and absent when not present.
+- AC-1121-6: Minimal and complete full fixtures that satisfy required artifacts continue to pass.
+
+## Guardrails
+
+- CLI output remains evidence only; it does not replace Work Item truth, recovery truth, review records, merge-ready evidence, closeout evidence, or docs/source contracts.
+- Deeper validation remains owned by #1122-#1125.

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -11,11 +11,11 @@
 - Review Entry: .loom/reviews/WI-1121.json
 - Validation Entry: python3 tools/check_cli_contract.py; git diff --check; focused rg; python3 tools/skills_surface.py check; python3 tools/loom_check.py --profile source --source-surface contract-only .
 - Closing Condition: #1121 PR is merged to main, closeout evidence records PR/head/merge/target branch/validation/Project state, #1121 is closed completed, and #1119 can consume the evidence.
-- Current Checkpoint: build
-- Current Stop: Branch work/1121-suite-path-artifacts has implemented path decision and required/conditional artifact validation with focused local checks passing.
-- Next Step: Record reviews, run build checkpoint, open PR, pass merge gate, merge, and close out #1121.
+- Current Checkpoint: merge
+- Current Stop: PR #1166 is open with WI-1121 implementation, validation, spec review, and implementation review carriers recorded.
+- Next Step: Pass PR gate, merge PR #1166, and close out #1121.
 - Blockers: None
-- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite_path, conditional artifacts, conflicting_suite_path_decision, invalid_suite_path_decision, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .
+- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite_path, conditional artifacts, conflicting_suite_path_decision, invalid_suite_path_decision, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1121.
 - Recovery Boundary: #1121 owns suite path decision legality, required artifact existence/regular-file validation, and conditional artifact inventory only. It must not implement #1122 not_applicable/deferred rationale enforcement, #1123 spec/plan mapping checks, #1124 final taxonomy expansion, #1125 spec-review integration, host writes, review writes from the CLI command, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.
 - Current Lane: full-spec-suite-cli/validate-path-artifacts
 

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -2,34 +2,34 @@
 
 ## Derived Fact Chain View
 
-- Item ID: WI-1120
-- Goal: Implement the core read-only `loom suite validate` command.
-- Scope: #1120 only: add the command matrix entry, read-only validate envelope, core pass/block/advisory/not_applicable behavior, and CLI contract fixtures. Defer deeper path artifact validation, not_applicable rationale enforcement, spec/plan mapping, taxonomy expansion, and spec-review integration to #1121-#1125.
-- Execution Path: issue #1120 -> branch work/1120-suite-validate-core -> worktree /Users/mc/dev/Loom-worktrees/1120-suite-validate-core -> PR pending
+- Item ID: WI-1121
+- Goal: Validate suite path decisions and required/conditional suite artifacts.
+- Scope: #1121 only: block missing, invalid, or conflicting suite path decisions; block missing or non-file required artifacts; inventory full path conditional artifacts without enforcing rationale. Defer not_applicable/deferred rationale to #1122, spec/plan mapping to #1123, taxonomy expansion to #1124, and spec-review integration to #1125.
+- Execution Path: issue #1121 -> branch work/1121-suite-path-artifacts -> worktree /Users/mc/dev/Loom-worktrees/1121-suite-path-artifacts -> PR pending
 - Workspace Entry: .
-- Recovery Entry: .loom/progress/WI-1120.md
-- Review Entry: .loom/reviews/WI-1120.json
+- Recovery Entry: .loom/progress/WI-1121.md
+- Review Entry: .loom/reviews/WI-1121.json
 - Validation Entry: python3 tools/check_cli_contract.py; git diff --check; focused rg; python3 tools/skills_surface.py check; python3 tools/loom_check.py --profile source --source-surface contract-only .
-- Closing Condition: #1120 PR is merged to main, closeout evidence records PR/head/merge/target branch/validation/Project state, #1120 is closed completed, and #1119 can consume the evidence.
-- Current Checkpoint: merge
-- Current Stop: Branch work/1120-suite-validate-core is pushed and PR #1165 is open after local validation, shadow parity, and build checkpoint passed.
-- Next Step: Run PR gate and GitHub checks for PR #1165, then merge and close out #1120.
+- Closing Condition: #1121 PR is merged to main, closeout evidence records PR/head/merge/target branch/validation/Project state, #1121 is closed completed, and #1119 can consume the evidence.
+- Current Checkpoint: build
+- Current Stop: Branch work/1121-suite-path-artifacts has implemented path decision and required/conditional artifact validation with focused local checks passing.
+- Next Step: Record reviews, run build checkpoint, open PR, pass merge gate, merge, and close out #1121.
 - Blockers: None
-- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1120.
-- Recovery Boundary: #1120 owns core `loom suite validate` command behavior only. It must not implement #1121 path-depth checks, #1122 not_applicable rationale enforcement, #1123 spec/plan mapping, #1124 final taxonomy expansion, #1125 spec-review integration, host writes, review writes, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.
-- Current Lane: full-spec-suite-cli/validate-core
+- Latest Validation Summary: Passed: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite_path, conditional artifacts, conflicting_suite_path_decision, invalid_suite_path_decision, forbidden /speckit and .specify surfaces; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .
+- Recovery Boundary: #1121 owns suite path decision legality, required artifact existence/regular-file validation, and conditional artifact inventory only. It must not implement #1122 not_applicable/deferred rationale enforcement, #1123 spec/plan mapping checks, #1124 final taxonomy expansion, #1125 spec-review integration, host writes, review writes from the CLI command, merge-ready writes, closeout writes, /speckit.*, or .specify surfaces.
+- Current Lane: full-spec-suite-cli/validate-path-artifacts
 
 ## Runtime Evidence
 
 - Run Entry: not_applicable
 - Logs Entry: not_applicable
 - Diagnostics Entry: not_applicable
-- Verification Entry: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite validate, suite validate constants, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .; python3 .loom/bin/loom_init.py fact-chain --target .; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking; python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1120.
+- Verification Entry: python3 tools/check_cli_contract.py; python3 -m py_compile tools/loom.py tools/check_cli_contract.py; git diff --check; focused rg for suite_path, conditional artifacts, conflicting_suite_path_decision, invalid_suite_path_decision, /speckit, and .specify; python3 tools/skills_surface.py check; python3 tools/check_release_surface.py; python3 tools/version_surface_check.py; python3 tools/check_npm_package.py; python3 tools/host_adapter_check.py; python3 tools/loom_check.py --profile source --source-surface contract-only .
 - Lane Entry: not_applicable
 
 ## Sources
 
-- Static Truth: .loom/work-items/WI-1120.md
-- Dynamic Truth: .loom/progress/WI-1120.md
+- Static Truth: .loom/work-items/WI-1121.md
+- Dynamic Truth: .loom/progress/WI-1121.md
 - Locator Truth: .loom/bootstrap/init-result.json
 - Fact Chain CLI: python3 .loom/bin/loom_init.py fact-chain --target .

--- a/.loom/work-items/WI-1121.md
+++ b/.loom/work-items/WI-1121.md
@@ -1,0 +1,32 @@
+# WI-1121
+
+## Static Facts
+
+- Item ID: WI-1121
+- Goal: Validate suite path decisions and required/conditional suite artifacts.
+- Scope: #1121 only: block missing, invalid, or conflicting suite path decisions; block missing or non-file required artifacts; inventory full path conditional artifacts without enforcing rationale. Defer not_applicable/deferred rationale to #1122, spec/plan mapping to #1123, taxonomy expansion to #1124, and spec-review integration to #1125.
+- Execution Path: issue #1121 -> branch work/1121-suite-path-artifacts -> worktree /Users/mc/dev/Loom-worktrees/1121-suite-path-artifacts -> PR pending
+- Workspace Entry: .
+- Recovery Entry: .loom/progress/WI-1121.md
+- Review Entry: .loom/reviews/WI-1121.json
+- Validation Entry: python3 tools/check_cli_contract.py; git diff --check; focused rg; python3 tools/skills_surface.py check; python3 tools/loom_check.py --profile source --source-surface contract-only .
+- Closing Condition: #1121 PR is merged to main, closeout evidence records PR/head/merge/target branch/validation/Project state, #1121 is closed completed, and #1119 can consume the evidence.
+
+## Associated Artifacts
+
+- `.loom/work-items/WI-1121.md`
+- `.loom/progress/WI-1120.md`
+- `.loom/progress/WI-1121.md`
+- `.loom/reviews/WI-1121.json`
+- `.loom/reviews/WI-1121.spec.json`
+- `.loom/status/current.md`
+- `.loom/bootstrap/init-result.json`
+- `.loom/shadow/merge-ready-loom.json`
+- `.loom/shadow/closeout-loom.json`
+- `.loom/specs/WI-1121/spec.md`
+- `.loom/specs/WI-1121/plan.md`
+- `.loom/specs/WI-1121/implementation-contract.md`
+- `tools/loom.py`
+- `tools/check_cli_contract.py`
+- `docs/methodology/harness/cli-command-matrix.md`
+- `docs/methodology/harness/full-spec-suite-cli-surface.md`

--- a/docs/methodology/harness/cli-command-matrix.md
+++ b/docs/methodology/harness/cli-command-matrix.md
@@ -144,7 +144,7 @@ loom suite scaffold
 loom suite validate
 ```
 
-`suite validate` is read-only. It reuses the suite inspect state and returns a readiness envelope with `pass`, `block`, `advisory`, or `not_applicable`, plus `failed_layer`, `fail_closed_reason`, `missing_inputs`, `blocking_gaps`, and `advisory_gaps`. The #1120 slice is intentionally core-only: missing suite path decisions and missing required suite artifacts block; later evidence, consistency, and carrier artifacts can appear as advisory gaps until their owning Work Items deepen validation. It does not write suite files, review truth, merge-ready truth, closeout truth, host state, generated skills, `/speckit.*`, or `.specify/` surfaces.
+`suite validate` is read-only. It reuses the suite inspect state and returns a readiness envelope with `pass`, `block`, `advisory`, or `not_applicable`, plus `failed_layer`, `fail_closed_reason`, `missing_inputs`, `blocking_gaps`, and `advisory_gaps`. The #1120/#1121 slice covers core path and artifact validation: missing, invalid, or conflicting suite path decisions block; missing or non-file required artifacts block; full path conditional artifacts are inventoried without enforcing rationale in this Work Item. Later evidence, consistency, and carrier artifacts can appear as advisory gaps until their owning Work Items deepen validation. It does not write suite files, review truth, merge-ready truth, closeout truth, host state, generated skills, `/speckit.*`, or `.specify/` surfaces.
 
 The remaining suite namespace stays planned until later implementation Work Items add those commands to `loom help --json` and the CLI contract checks. The planned namespace is documented in [full-spec-suite-cli-surface.md](./full-spec-suite-cli-surface.md):
 

--- a/docs/methodology/harness/full-spec-suite-cli-surface.md
+++ b/docs/methodology/harness/full-spec-suite-cli-surface.md
@@ -27,7 +27,7 @@
 | --- | --- | --- | --- |
 | `loom suite inspect` | planned | read-only | 读取 Work Item、suite path decision、artifact inventory、delivery planning、task carrier、evidence-map、consistency-analysis 与 gate-chain locators。 |
 | `loom suite scaffold` | planned | scaffold-write | 生成或补齐 suite scaffold 文件；必须显式 `--apply`，默认只输出 plan。 |
-| `loom suite validate` | implemented core (#1120) | validate | 校验 suite path decision 与 core required artifact envelope；minimal `not_applicable` rationale、spec -> plan mapping、task carrier mapping 与 evidence-map freshness 由后续 Work Items 加深。 |
+| `loom suite validate` | implemented core (#1120/#1121) | validate | 校验 suite path decision、core required artifact envelope 与 full path conditional artifact inventory；minimal `not_applicable` rationale、spec -> plan mapping、task carrier mapping 与 evidence-map freshness 由后续 Work Items 加深。 |
 | `loom suite analyze` | planned | analyze | 运行 consistency-analysis 风格的跨工件分析，只输出 finding 与 remediation direction，不修文件。 |
 | `loom suite evidence inspect` | planned | read-only | 读取 evidence-map row、source locator、freshness、HEAD / PR / merge binding。 |
 | `loom suite evidence scaffold` | planned | scaffold-write | 为当前 suite 生成 evidence-map scaffold；必须显式 `--apply`。 |
@@ -235,7 +235,7 @@ Scenario skills 仍是 agent-facing entrance；CLI 是 machine interface。后�
 
 1. `suite inspect` read-only：读取 suite path decision、artifact inventory、core locators 与 host binding。
 2. `suite scaffold` dry-run / apply：基于 docs scaffold 生成 suite artifacts，默认 fail closed without `--apply`。
-3. `suite validate`：#1120 先校验 full/minimal/not_applicable path 与 core required artifacts；后续 Work Items 继续加深 `not_applicable` rationale、spec -> plan mapping 与 delivery planning locators。
+3. `suite validate`：#1120 先校验 full/minimal/not_applicable path 与 core required artifacts；#1121 加深 path decision 合法性、required artifact 普通文件约束与 full path conditional artifact inventory；后续 Work Items 继续加深 `not_applicable` rationale、spec -> plan mapping 与 delivery planning locators。
 4. `suite carrier inspect|validate`：读取 execution breakdown / task carrier normalized status 与 truth conflict。
 5. `suite evidence inspect|scaffold|validate`：生成并校验 evidence-map locator、row fields、freshness 与 evidence binding。
 6. `suite consistency inspect|analyze`：输出 consistency-analysis findings、classification 与 remediation direction。

--- a/tools/check_cli_contract.py
+++ b/tools/check_cli_contract.py
@@ -447,6 +447,27 @@ def main() -> int:
         ):
             raise AssertionError("suite validate unknown-state block payload drifted")
 
+        suite_conflict_target = tmp / "suite-conflict"
+        suite_conflict = suite_conflict_target / ".loom" / "specs" / "WI-conflict"
+        suite_conflict.mkdir(parents=True)
+        (suite_conflict / "suite-index.md").write_text("# Suite\n\n- Suite path: full\n", encoding="utf-8")
+        (suite_conflict / "spec.md").write_text("# Spec\n\n- Suite path: minimal\n", encoding="utf-8")
+        (suite_conflict / "plan.md").write_text("# Plan\n", encoding="utf-8")
+        suite_conflict_validate = run_suite_validate_fixture(suite_conflict_target, "WI-conflict", expect=1)
+        conflict_missing = suite_conflict_validate.get("payload", {}).get("missing_inputs", [])
+        if (
+            suite_conflict_validate.get("result") != "block"
+            or suite_conflict_validate.get("fail_closed_reason") != "missing_suite_path_decision"
+            or "suite_path_decision" not in conflict_missing
+            or not any(str(entry).startswith("conflicting_suite_path_decision:") for entry in conflict_missing)
+            or not any(
+                gap.get("failure_kind") == "missing_suite_path_decision"
+                and gap.get("source_locator") == ".loom/specs/WI-conflict/spec.md"
+                for gap in suite_conflict_validate.get("blocking_gaps", [])
+            )
+        ):
+            raise AssertionError("suite validate conflicting path decision payload drifted")
+
         minimal_target = tmp / "suite-minimal"
         minimal_suite = minimal_target / ".loom" / "specs" / "WI-minimal"
         minimal_suite.mkdir(parents=True)
@@ -560,6 +581,16 @@ def main() -> int:
             or suite_full_advisory_validate.get("payload", {}).get("suite_path") != "full"
         ):
             raise AssertionError("suite validate advisory payload drifted")
+        full_advisory_inventory = {
+            entry["artifact"]: entry
+            for entry in suite_full_advisory_validate.get("payload", {}).get("artifact_inventory", [])
+        }
+        for artifact in ("research.md", "contracts.md", "readiness-checklist.md"):
+            if (
+                full_advisory_inventory.get(artifact, {}).get("status") != "absent"
+                or full_advisory_inventory.get(artifact, {}).get("requirement") != "conditional"
+            ):
+                raise AssertionError(f"suite validate conditional artifact handling drifted for {artifact}")
 
         full_missing_target = tmp / "suite-full-missing"
         full_missing_suite = full_missing_target / ".loom" / "specs" / "WI-full-missing"
@@ -590,6 +621,29 @@ def main() -> int:
             )
         ):
             raise AssertionError("suite validate missing required artifact payload drifted")
+
+        full_invalid_target = tmp / "suite-full-invalid"
+        full_invalid_suite = full_invalid_target / ".loom" / "specs" / "WI-full-invalid"
+        full_invalid_suite.mkdir(parents=True)
+        (full_invalid_suite / "suite-index.md").write_text(
+            "# Full Suite Index\n\n- Schema marker: loom-full-suite-index/v1\n- Suite path: full\n",
+            encoding="utf-8",
+        )
+        (full_invalid_suite / "spec.md").write_text("# Spec\n", encoding="utf-8")
+        (full_invalid_suite / "plan.md").mkdir()
+        suite_full_invalid_validate = run_suite_validate_fixture(full_invalid_target, "WI-full-invalid", expect=1)
+        invalid_inventory = {
+            entry["artifact"]: entry
+            for entry in suite_full_invalid_validate.get("payload", {}).get("artifact_inventory", [])
+        }
+        if (
+            suite_full_invalid_validate.get("result") != "block"
+            or suite_full_invalid_validate.get("fail_closed_reason") != "missing_required_artifact"
+            or invalid_inventory.get("plan.md", {}).get("status") != "invalid"
+            or "required_artifact:.loom/specs/WI-full-invalid/plan.md"
+            not in suite_full_invalid_validate.get("payload", {}).get("missing_inputs", [])
+        ):
+            raise AssertionError("suite validate invalid required artifact payload drifted")
 
         scaffold_target = tmp / "suite-scaffold"
         scaffold_target.mkdir()

--- a/tools/loom.py
+++ b/tools/loom.py
@@ -1881,31 +1881,46 @@ def suite_item_segment_error(item: str) -> str | None:
 
 def first_existing_locator(paths: list[Path], target_root: Path) -> str | None:
     for path in paths:
-        if path.exists() and path.is_file():
+        if path.exists() and path.is_file() and not path.is_symlink():
             return repo_locator(path, target_root)
     return None
 
 
-def suite_path_marker(text: str) -> str | None:
+def suite_path_marker_values(text: str) -> tuple[list[str], list[str]]:
     lowered = text.lower()
+    values: list[str] = []
+    invalid_values: list[str] = []
     for line in lowered.splitlines():
         stripped = line.strip().lstrip("-").strip()
         if stripped.startswith("suite path:"):
-            value = stripped.split(":", 1)[1].strip().replace(" ", "_")
+            value = stripped.split(":", 1)[1].strip().replace(" ", "_").replace("-", "_")
             if value in {"full", "minimal", "not_applicable", "unknown"}:
-                return value
+                values.append(value)
+            else:
+                invalid_values.append(value)
     if "loom-full-suite-index/v1" in lowered:
-        return "full"
-    return None
+        values.append("full")
+    return values, invalid_values
 
 
-def read_suite_path_marker(path: Path) -> str | None:
-    if not path.exists() or not path.is_file():
-        return None
+def read_suite_path_marker_values(path: Path) -> tuple[list[str], list[str]]:
+    if not path.exists() or path.is_symlink() or not path.is_file():
+        return [], []
     try:
-        return suite_path_marker(path.read_text(encoding="utf-8"))
+        return suite_path_marker_values(path.read_text(encoding="utf-8"))
     except OSError:
-        return None
+        return [], ["unreadable"]
+
+
+def first_artifact_locator_or_invalid(paths: list[Path], target_root: Path) -> tuple[str | None, str | None]:
+    for path in paths:
+        if not path.exists():
+            continue
+        locator = repo_locator(path, target_root)
+        if path.is_symlink() or not path.is_file():
+            return None, locator
+        return locator, None
+    return None, None
 
 
 def suite_artifact_paths(target: Path, item: str | None) -> dict[str, list[Path]]:
@@ -1916,6 +1931,9 @@ def suite_artifact_paths(target: Path, item: str | None) -> dict[str, list[Path]
         "suite-index.md": [suite_root / "suite-index.md"],
         "spec.md": [suite_root / "spec.md"],
         "plan.md": [suite_root / "plan.md"],
+        "research.md": [suite_root / "research.md"],
+        "contracts.md": [suite_root / "contracts.md"],
+        "readiness-checklist.md": [suite_root / "readiness-checklist.md"],
         "evidence-map.md": [suite_root / "evidence-map.md"],
         "consistency-analysis.md": [suite_root / "consistency-analysis.md"],
         "execution-breakdown.md": [suite_root / "execution-breakdown.md"],
@@ -1962,6 +1980,20 @@ SUITE_SCAFFOLD_REQUIRED_ARTIFACTS = {
 SUITE_SCAFFOLD_CONDITIONAL_ARTIFACTS = {
     "minimal": (),
     "full": ("research.md", "contracts.md", "readiness-checklist.md"),
+}
+
+SUITE_REQUIRED_ARTIFACTS_BY_PATH = {
+    "minimal": {"spec.md", "plan.md"},
+    "full": {"suite-index.md", "spec.md", "plan.md"},
+    "not_applicable": set(),
+    "unknown": set(),
+}
+
+SUITE_CONDITIONAL_ARTIFACTS_BY_PATH = {
+    "minimal": set(),
+    "full": {"research.md", "contracts.md", "readiness-checklist.md"},
+    "not_applicable": set(),
+    "unknown": set(),
 }
 
 SUITE_SCAFFOLD_CONTRACT_LOCATORS = (
@@ -2117,29 +2149,69 @@ def suite_inspect_payload(target: Path, item: str | None) -> tuple[str, dict[str
 
     path_decision_locator: str | None = None
     suite_path = "unknown"
+    path_decisions: list[dict[str, Any]] = []
+    decision_values: list[str] = []
+    invalid_decision_locators: list[str] = []
     for path in (suite_index, spec, plan):
         if path is None:
             continue
-        marker = read_suite_path_marker(path)
-        if marker:
-            suite_path = marker
-            path_decision_locator = repo_locator(path, target)
-            break
+        if path.exists() and (path.is_symlink() or not path.is_file()):
+            if path == suite_index:
+                locator = repo_locator(path, target)
+                invalid_decision_locators.append(locator)
+                path_decisions.append(
+                    {
+                        "locator": locator,
+                        "value": None,
+                        "status": "invalid",
+                        "reason": "path decision candidate is not a regular file",
+                    }
+                )
+            continue
+        values, invalid_values = read_suite_path_marker_values(path)
+        if not values and not invalid_values:
+            continue
+        locator = repo_locator(path, target)
+        for value in values:
+            path_decisions.append({"locator": locator, "value": value, "status": "present"})
+            decision_values.append(value)
+        for value in invalid_values:
+            invalid_decision_locators.append(locator)
+            path_decisions.append({"locator": locator, "value": value, "status": "invalid"})
 
-    required_by_path = {
-        "full": {"suite-index.md", "spec.md", "plan.md"},
-        "minimal": {"spec.md", "plan.md"},
-        "not_applicable": set(),
-        "unknown": set(),
-    }
-    required = required_by_path.get(suite_path, set())
+    unique_decision_values = sorted(set(decision_values))
+    if len(unique_decision_values) == 1 and not invalid_decision_locators:
+        suite_path = unique_decision_values[0]
+        path_decision_locator = next(
+            (entry["locator"] for entry in path_decisions if entry.get("value") == suite_path),
+            None,
+        )
+
+    required = SUITE_REQUIRED_ARTIFACTS_BY_PATH.get(suite_path, set())
+    conditional = SUITE_CONDITIONAL_ARTIFACTS_BY_PATH.get(suite_path, set())
+    advisory = set(SUITE_VALIDATE_ADVISORY_ARTIFACTS.get(suite_path, ()))
 
     artifact_inventory: list[dict[str, Any]] = []
     missing_inputs: list[str] = []
     locators: dict[str, Any] = {}
+    if invalid_decision_locators or len(unique_decision_values) > 1:
+        missing_inputs.append("suite_path_decision")
+        for locator in sorted(set(invalid_decision_locators)):
+            missing_inputs.append(f"invalid_suite_path_decision:{locator}")
+        if len(unique_decision_values) > 1:
+            for entry in path_decisions:
+                if entry.get("status") == "present":
+                    missing_inputs.append(f"conflicting_suite_path_decision:{entry['locator']}")
     for artifact, candidates in paths.items():
-        locator = first_existing_locator(candidates, target)
+        locator, invalid_locator = first_artifact_locator_or_invalid(candidates, target)
         is_required = artifact in required
+        is_conditional = artifact in conditional
+        is_advisory = artifact in advisory
+        requirement = (
+            "required"
+            if is_required
+            else ("conditional" if is_conditional else ("extension" if is_advisory else "optional"))
+        )
         if locator is not None:
             artifact_inventory.append(
                 {
@@ -2147,8 +2219,21 @@ def suite_inspect_payload(target: Path, item: str | None) -> tuple[str, dict[str
                     "locator": locator,
                     "status": "present",
                     "required": is_required,
+                    "requirement": requirement,
                 }
             )
+        elif invalid_locator is not None:
+            artifact_inventory.append(
+                {
+                    "artifact": artifact,
+                    "locator": invalid_locator,
+                    "status": "invalid",
+                    "required": is_required,
+                    "requirement": requirement,
+                }
+            )
+            if is_required:
+                missing_inputs.append(f"required_artifact:{invalid_locator}")
         elif is_required:
             expected = repo_locator(candidates[0], target)
             artifact_inventory.append(
@@ -2157,9 +2242,20 @@ def suite_inspect_payload(target: Path, item: str | None) -> tuple[str, dict[str
                     "locator": expected,
                     "status": "missing",
                     "required": True,
+                    "requirement": requirement,
                 }
             )
             missing_inputs.append(f"required_artifact:{expected}")
+        elif is_conditional or is_advisory:
+            artifact_inventory.append(
+                {
+                    "artifact": artifact,
+                    "locator": repo_locator(candidates[0], target),
+                    "status": "absent",
+                    "required": False,
+                    "requirement": requirement,
+                }
+            )
 
         key = artifact.replace("-", "_").removesuffix(".md") + "_locator"
         if artifact == "task-carrier":
@@ -2167,7 +2263,7 @@ def suite_inspect_payload(target: Path, item: str | None) -> tuple[str, dict[str
         else:
             locators[key] = locator
 
-    if suite_path == "unknown":
+    if suite_path == "unknown" and "suite_path_decision" not in missing_inputs:
         missing_inputs.insert(0, "suite_path_decision")
 
     advisory_gaps = []
@@ -2215,6 +2311,7 @@ def suite_inspect_payload(target: Path, item: str | None) -> tuple[str, dict[str
         "suite_path": suite_path,
         "suite_locator": locators.get("suite_index_locator"),
         "path_decision_locator": path_decision_locator,
+        "path_decisions": path_decisions,
         "artifact_inventory": artifact_inventory,
         "missing_inputs": missing_inputs,
         "advisory_gaps": advisory_gaps,
@@ -2299,6 +2396,19 @@ def suite_validate_payload(target: Path, item: str) -> tuple[str, str, dict[str,
                     source_locator=None,
                     consumer_impact="spec review cannot determine whether the suite is full, minimal, or not_applicable",
                     remediation_direction="Author a suite path decision before validating readiness.",
+                    fallback_to="loom suite inspect --target <repo> --item <item> --json",
+                )
+            )
+        elif missing.startswith("invalid_suite_path_decision:") or missing.startswith("conflicting_suite_path_decision:"):
+            locator = missing.split(":", 1)[1]
+            blocking_gaps.append(
+                suite_validate_finding(
+                    gap_id=f"suite-validate-invalid-path-decision-{Path(locator).name}",
+                    classification="blocking",
+                    failure_kind="missing_suite_path_decision",
+                    source_locator=locator,
+                    consumer_impact="spec review cannot consume an invalid or conflicting suite path decision",
+                    remediation_direction="Keep exactly one legal suite path decision: full, minimal, or not_applicable.",
                     fallback_to="loom suite inspect --target <repo> --item <item> --json",
                 )
             )


### PR DESCRIPTION
Loom Work Item: WI-1121

## Summary

- deepens `loom suite validate` path decision validation for missing, invalid, and conflicting suite path decisions
- blocks required suite artifacts that are missing or not ordinary files
- reports full path conditional artifacts in inventory without enforcing #1122 rationale
- terminalizes #1120 local carrier state and refreshes shadow parity hashes needed for the #1121 workspace

## Scope Boundaries

- no not_applicable/deferred rationale enforcement; reserved for #1122
- no spec/plan mapping validation; reserved for #1123
- no final taxonomy expansion; reserved for #1124
- no `flow spec-review` or `gate spec-review` integration; reserved for #1125
- no host, review, merge-ready, or closeout writes from `loom suite validate`
- no `/speckit.*` command names or `.specify/` layout

## Validation

- `python3 tools/check_cli_contract.py`
- `python3 -m py_compile tools/loom.py tools/check_cli_contract.py`
- `git diff --check`
- focused `rg` for `suite_path`, conditional artifacts, `conflicting_suite_path_decision`, `invalid_suite_path_decision`, `/speckit`, and `.specify`
- `python3 tools/skills_surface.py check`
- `python3 tools/check_release_surface.py`
- `python3 tools/version_surface_check.py`
- `python3 tools/check_npm_package.py`
- `python3 tools/host_adapter_check.py`
- `python3 tools/loom_check.py --profile source --source-surface contract-only .`
- `python3 .loom/bin/loom_init.py fact-chain --target .`
- `python3 .loom/bin/loom_init.py verify --target .`
- `python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking`
- `python3 .loom/bin/loom_flow.py checkpoint build --target . --item WI-1121`

Closes #1121.
