### PR TITLE
chore: sync WI-1304 post-merge closeout carrier

### DIFF
--- a/.loom/progress/WI-1304.md
+++ b/.loom/progress/WI-1304.md
@@ -3,13 +3,13 @@
 ## Dynamic Facts
 
 - Item ID: WI-1304
-- Current Checkpoint: merge
-- Current Stop: hosted checks green and local pr-gate passed; ready for controlled merge readback
-- Next Step: merge PR #1305, then run closeout/readback before returning to A-D PR sequence
-- Blockers: none
+- Current Checkpoint: closed
+- Current Stop: PR #1305 merged to main at 2026-06-04T16:13:33Z with merge commit 444cc71ed1d5d828ee85a122ac1216d4e6d217eb; issue #1304 closed at 2026-06-04T16:13:34Z; closeout check/sync passed before returning to A-D PR closeout.
+- Next Step: None; WI-1304 is terminal and retained only as post-merge closeout evidence for the A-D PR sequence.
+- Blockers: None
 - Latest Validation Summary: 2026-06-04 final validation at d8f62124: local pr-gate passed; hosted checks all passed for PR #1305 including py-compile, demo-bootstrap, repo-local-cli, root-self-governance, loom-pr-merge-gate, release-judgment, node installer gate, and two loom-check jobs.
-- Recovery Boundary: WI-1304 unblocker only; A-D PR branches remain read-only until #1305 is merged
-- Current Lane: merge-ready
+- Recovery Boundary: Terminal closeout carrier only. Do not resume WI-1304 implementation here; A-D PR closeout continues on their own branches.
+- Current Lane: terminal-closeout
 
 ## Execution Ledger
 

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "6d967daff45db3cbf5dc72f250d843bd3c3dc5c6bab43aee1d4c054b0ae73328"
+    ".loom/status/current.md": "19b8efcffea214dd4a3238658fde466a04e67c3b0ce4579c84dfc8500fcada2a"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "6d967daff45db3cbf5dc72f250d843bd3c3dc5c6bab43aee1d4c054b0ae73328"
+    ".loom/status/current.md": "19b8efcffea214dd4a3238658fde466a04e67c3b0ce4579c84dfc8500fcada2a"
   }
 }

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -11,13 +11,13 @@
 - Review Entry: .loom/reviews/WI-1304.json
 - Validation Entry: git diff --check; python3 .loom/bin/loom_init.py verify --target .; python3 .loom/bin/loom_flow.py governance-profile status --target /Users/mc/dev/Loom-worktrees/1264-regression-surface-contract --host github; python3 tools/loom_check.py --profile source --source-surface bootstrap-regression .
 - Closing Condition: PR for #1304 is merged and PR-A can consume docs-only not_applicable maturity after rebasing onto main.
-- Current Checkpoint: merge
-- Current Stop: hosted checks green and local pr-gate passed; ready for controlled merge readback
-- Next Step: merge PR #1305, then run closeout/readback before returning to A-D PR sequence
-- Blockers: none
+- Current Checkpoint: closed
+- Current Stop: PR #1305 merged to main at 2026-06-04T16:13:33Z with merge commit 444cc71ed1d5d828ee85a122ac1216d4e6d217eb; issue #1304 closed at 2026-06-04T16:13:34Z; closeout check/sync passed before returning to A-D PR closeout.
+- Next Step: None; WI-1304 is terminal and retained only as post-merge closeout evidence for the A-D PR sequence.
+- Blockers: None
 - Latest Validation Summary: 2026-06-04 final validation at d8f62124: local pr-gate passed; hosted checks all passed for PR #1305 including py-compile, demo-bootstrap, repo-local-cli, root-self-governance, loom-pr-merge-gate, release-judgment, node installer gate, and two loom-check jobs.
-- Recovery Boundary: WI-1304 unblocker only; A-D PR branches remain read-only until #1305 is merged
-- Current Lane: merge-ready
+- Recovery Boundary: Terminal closeout carrier only. Do not resume WI-1304 implementation here; A-D PR closeout continues on their own branches.
+- Current Lane: terminal-closeout
 
 ## Runtime Evidence
 


### PR DESCRIPTION
## Summary
- terminalize WI-1304 repo-local recovery/status carrier after PR #1305 merged
- record #1305 merge commit and #1304 closed timestamp in the retained status surface
- unblock A-D PR closeout review purity by removing WI-1304 from active merge state

## Validation
- git diff --check
- python3 tools/loom.py fact-chain --target . --json
- python3 .loom/bin/loom_flow.py closeout check --target . --issue 1304 --pr 1305 --branch work/1304-docs-only-governance-maturity --owner MC-and-his-Agents --repo Loom --skip-gate

## Scope
This is a post-merge carrier closeout sync only. It does not change runtime code, docs-only suite semantics, PR #1305 implementation, or A-D PR branches.

## PR Metadata Machine Carrier

Loom Work Item: WI-1304
Branch: work/1304-post-merge-closeout-sync
Head SHA: fb965bc735e2541037c545eab2caf371b9e0c75e
Workspace: /Users/mc/dev/Loom-worktrees/1304-post-merge-closeout-sync