### PR TITLE
chore: sync WI-1286 post-merge closeout carrier

### DIFF
--- a/.loom/progress/WI-1286.md
+++ b/.loom/progress/WI-1286.md
@@ -3,13 +3,13 @@
 ## Dynamic Facts
 
 - Item ID: WI-1286
-- Current Checkpoint: pre-review
-- Current Stop: PR #1299 has the review disposition and PR head binding contract documentation implemented, is rebased on main after #1307, and carries formal WI-1286 suite path and spec review records instead of fake minimal suite artifacts.
-- Next Step: Refresh retained carriers, rerun root-self-governance and PR gate against the pushed head, and consume hosted checks.
+- Current Checkpoint: closed
+- Current Stop: PR #1299 merged to main at 2026-06-04T18:36:17Z with merge commit 71d0451ffdc02f817f94c70904181c0dbf0c9462; issue #1286 closed at 2026-06-04T18:36:18Z; controlled merge and hosted checks passed before closeout sync.
+- Next Step: None; WI-1286 is terminal and retained only as review disposition / PR head binding contract evidence for the #1285 implementation sequence.
 - Blockers: None
-- Latest Validation Summary: `git diff --check` passed; `python3 tools/loom.py fact-chain --target . --json` passed for WI-1286; `python3 tools/loom.py suite validate --target . --item WI-1286 --json` returned `result=not_applicable` with no blocking gaps and valid suite-level rationale; `.loom/reviews/WI-1286.spec.json` approves the docs-only suite path decision at head 382e32d6556eaf77d00c70550b52e3e7b2adc0b1.
-- Recovery Boundary: Keep this PR limited to WI-1286 carriers, formal suite not_applicable locator, review disposition/head-binding contract docs, repo companion boundary wording, and validation evidence. Do not implement #1287/#1288/#1289, change pr-gate/merge-gate runtime behavior, add downstream repository rules, or add fake minimal suite artifacts.
-- Current Lane: pre-review/review-head-binding-contract
+- Latest Validation Summary: Post-merge closeout sync validation passed `git diff --check`, `python3 tools/loom.py fact-chain --target . --json`, and `PYTHONDONTWRITEBYTECODE=1 python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking`.
+- Recovery Boundary: Terminal closeout carrier only. Do not resume WI-1286 implementation here; PR gate, merge check/run, and closeout runtime work continue through separate #1285 follow-up issues.
+- Current Lane: terminal-closeout
 
 ## Execution Ledger
 

--- a/.loom/reviews/WI-1286.json
+++ b/.loom/reviews/WI-1286.json
@@ -3,10 +3,10 @@
   "item_id": "WI-1286",
   "decision": "allow",
   "kind": "code_review",
-  "summary": "Implementation review for WI-1286 at 7e143a6a: review disposition and PR head binding contract docs freeze `semantic_review_disposition`, allowed dispositions, PR head binding, gate consumption boundaries, and repo companion / guardian evidence-only boundaries. Diff remains limited to WI-1286 carriers, formal suite not_applicable locator, true spec review artifact, review/head-binding documentation, repo companion boundary wording, and validation evidence; no runtime pr-gate/merge-gate behavior, downstream repository rules, release behavior, or fake minimal suite artifacts were introduced.",
+  "summary": "Post-merge closeout sync review for WI-1286 at 4760dec8: diff only terminalizes WI-1286 recovery/status carrier after PR #1299 merged and refreshes closeout/merge-ready shadow hashes. It does not change review-head-binding docs, runtime code, downstream repository rules, release scope, or A-D PR branches.",
   "reviewer": "codex-main",
-  "reviewed_head": "7e143a6a1f49f21b675a626b34bca68021ea70b3",
-  "reviewed_validation_summary": "`git diff --check` passed; `python3 tools/loom.py fact-chain --target . --json` passed for WI-1286; `python3 tools/loom.py suite validate --target . --item WI-1286 --json` returned `result=not_applicable` with no blocking gaps and valid suite-level rationale; `.loom/reviews/WI-1286.spec.json` approves the docs-only suite path decision at head 382e32d6556eaf77d00c70550b52e3e7b2adc0b1.",
+  "reviewed_head": "4760dec89856fff7d2c840d7d551b21ebacb29fb",
+  "reviewed_validation_summary": "Post-merge closeout sync at head 4760dec89856fff7d2c840d7d551b21ebacb29fb passed `git diff --check`, `python3 tools/loom.py fact-chain --target . --json`, and `PYTHONDONTWRITEBYTECODE=1 python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking`.",
   "fallback_to": null,
   "findings": [],
   "blocking_issues": [],
@@ -15,19 +15,18 @@
     "work_item": ".loom/work-items/WI-1286.md",
     "recovery_entry": ".loom/progress/WI-1286.md",
     "status_surface": ".loom/status/current.md",
-    "suite_path_decision": ".loom/specs/WI-1286/spec.md",
     "build_checkpoint": "pass",
     "budget_risk": {
       "schema_version": "loom-execution-budget-risk/v1",
-      "status": "not_applicable",
+      "status": "unavailable",
       "enforcement": "advisory",
       "highest_risk": "none",
       "risk_dimensions": [],
-      "summary": "execution budget is not_applicable; budget risk remains advisory and non-blocking",
-      "budget_summary": "execution budget is not collected for this invocation.",
+      "summary": "execution budget is unavailable; budget risk remains advisory and non-blocking",
+      "budget_summary": "post-merge closeout sync uses local carrier/shadow validation only; hosted checks will be consumed from the closeout PR.",
       "adapter_evidence_locator": "",
       "provenance": {
-        "source": "github_host"
+        "source": "github_control_plane"
       }
     },
     "engine_adapter": null,
@@ -38,13 +37,7 @@
     "suite_evidence_map": null,
     "suite_consistency_analysis": null,
     "suite_task_carriers": [],
-    "suite_evidence_consumed_contracts": [
-      "docs/methodology/harness/full-spec-suite-cli-surface.md",
-      "docs/methodology/templates/spec-suite.md"
-    ],
-    "suite_carrier_consumed_contracts": [
-      "docs/methodology/harness/full-spec-suite-cli-surface.md",
-      "docs/methodology/templates/spec-suite.md"
-    ]
+    "suite_evidence_consumed_contracts": [],
+    "suite_carrier_consumed_contracts": []
   }
 }

--- a/.loom/reviews/WI-1286.json
+++ b/.loom/reviews/WI-1286.json
@@ -6,7 +6,7 @@
   "summary": "Post-merge closeout sync review for WI-1286 at 4760dec8: diff only terminalizes WI-1286 recovery/status carrier after PR #1299 merged and refreshes closeout/merge-ready shadow hashes. It does not change review-head-binding docs, runtime code, downstream repository rules, release scope, or A-D PR branches.",
   "reviewer": "codex-main",
   "reviewed_head": "4760dec89856fff7d2c840d7d551b21ebacb29fb",
-  "reviewed_validation_summary": "Post-merge closeout sync at head 4760dec89856fff7d2c840d7d551b21ebacb29fb passed `git diff --check`, `python3 tools/loom.py fact-chain --target . --json`, and `PYTHONDONTWRITEBYTECODE=1 python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking`.",
+  "reviewed_validation_summary": "Post-merge closeout sync validation passed `git diff --check`, `python3 tools/loom.py fact-chain --target . --json`, and `PYTHONDONTWRITEBYTECODE=1 python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking`.",
   "fallback_to": null,
   "findings": [],
   "blocking_issues": [],

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "c09f368f985b442268c9f57408df6fa8814ff6bba4a7f4cec31be72362a9ed43"
+    ".loom/status/current.md": "cc973c1d82838bcced3a15a91f8a2ddd376ade31f29a3186e005012225668214"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "c09f368f985b442268c9f57408df6fa8814ff6bba4a7f4cec31be72362a9ed43"
+    ".loom/status/current.md": "cc973c1d82838bcced3a15a91f8a2ddd376ade31f29a3186e005012225668214"
   }
 }

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -11,21 +11,21 @@
 - Review Entry: .loom/reviews/WI-1286.json
 - Validation Entry: git diff --check; focused rg for review disposition/head-binding contract terms; PR CI.
 - Closing Condition: PR #1299 is merged to main, #1286 is closed with contract evidence, and follow-up gate/runtime implementation issues remain explicitly out of scope.
-- Current Checkpoint: pre-review
-- Current Stop: PR #1299 has the review disposition and PR head binding contract documentation implemented, is rebased on main after #1307, and carries formal WI-1286 suite path and spec review records instead of fake minimal suite artifacts.
-- Next Step: Refresh retained carriers, rerun root-self-governance and PR gate against the pushed head, and consume hosted checks.
+- Current Checkpoint: closed
+- Current Stop: PR #1299 merged to main at 2026-06-04T18:36:17Z with merge commit 71d0451ffdc02f817f94c70904181c0dbf0c9462; issue #1286 closed at 2026-06-04T18:36:18Z; controlled merge and hosted checks passed before closeout sync.
+- Next Step: None; WI-1286 is terminal and retained only as review disposition / PR head binding contract evidence for the #1285 implementation sequence.
 - Blockers: None
-- Latest Validation Summary: `git diff --check` passed; `python3 tools/loom.py fact-chain --target . --json` passed for WI-1286; `python3 tools/loom.py suite validate --target . --item WI-1286 --json` returned `result=not_applicable` with no blocking gaps and valid suite-level rationale; `.loom/reviews/WI-1286.spec.json` approves the docs-only suite path decision at head 382e32d6556eaf77d00c70550b52e3e7b2adc0b1.
-- Recovery Boundary: Keep this PR limited to WI-1286 carriers, formal suite not_applicable locator, review disposition/head-binding contract docs, repo companion boundary wording, and validation evidence. Do not implement #1287/#1288/#1289, change pr-gate/merge-gate runtime behavior, add downstream repository rules, or add fake minimal suite artifacts.
-- Current Lane: pre-review/review-head-binding-contract
+- Latest Validation Summary: Post-merge closeout sync validation passed `git diff --check`, `python3 tools/loom.py fact-chain --target . --json`, and `PYTHONDONTWRITEBYTECODE=1 python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking`.
+- Recovery Boundary: Terminal closeout carrier only. Do not resume WI-1286 implementation here; PR gate, merge check/run, and closeout runtime work continue through separate #1285 follow-up issues.
+- Current Lane: terminal-closeout
 
 ## Runtime Evidence
 
 - Run Entry: not_applicable
 - Logs Entry: not_applicable
 - Diagnostics Entry: not_applicable
-- Verification Entry: PR #1299 validation section and hosted CI
-- Lane Entry: pre-review/review-head-binding-contract
+- Verification Entry: PR #1299 local pr-gate, hosted required checks, and merge commit 71d0451ffdc02f817f94c70904181c0dbf0c9462
+- Lane Entry: terminal-closeout
 
 ## Sources
 


### PR DESCRIPTION
## Summary
- terminalize WI-1286 repo-local recovery/status carrier after PR #1299 merged
- record #1299 merge commit and #1286 closed timestamp in the retained status surface
- keep #1285 follow-up runtime/gate work explicitly out of scope

## Validation
- git diff --check
- python3 tools/loom.py fact-chain --target . --json
- PYTHONDONTWRITEBYTECODE=1 python3 .loom/bin/loom_flow.py shadow-parity --target . --surface all --blocking

## Scope
This is a post-merge carrier closeout sync only. It does not change review-head-binding docs, runtime code, downstream repository rules, release scope, or A-D PR branches.

## PR Metadata Machine Carrier

Loom Work Item: WI-1286
Branch: work/1286-post-merge-closeout-sync
Head SHA: 4afef2b5f27f23cf27491adcca563ae302d59260
Workspace: /Users/mc/dev/Loom-worktrees/1286-post-merge-closeout-sync