### PR TITLE
docs: clarify runtime provider modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ Install the root Loom CLI:
 npm install -g @mc-and-his-agents/loom
 ```
 
+Choose the repository runtime provider mode explicitly:
+
+- `global-cli`: the repository records Loom adoption metadata and depends on
+  the installed root `loom` command as the runtime provider. No `.loom/bin`
+  runtime carrier is expected in this mode; workstation/global CLI availability
+  is diagnosed separately from repository truth.
+- `repo-local-wrapper`: the repository intentionally keeps repo-local wrapper
+  carriers such as `.loom/bin`. Those carriers remain valid when installed-state
+  declares them, including compatibility windows where the wrapper delegates to
+  the global CLI provider.
+
+See [docs/adoption/unified-install-experience.md](./docs/adoption/unified-install-experience.md),
+[docs/adoption/installation-taxonomy.md](./docs/adoption/installation-taxonomy.md),
+and [docs/adoption/loom-installed-state-v2.md](./docs/adoption/loom-installed-state-v2.md)
+for the detailed adoption contracts and validation commands.
+
 Install and verify the Codex host payload for a target repository:
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,6 +39,20 @@ python3 tools/loom.py skills release-check --json
 npm install -g @mc-and-his-agents/loom
 ```
 
+明确选择仓库 runtime provider mode：
+
+- `global-cli`：仓库记录 Loom adoption metadata，并依赖已安装的根
+  `loom` 命令作为 runtime provider。该模式不期望存在 `.loom/bin`
+  runtime carrier；workstation/global CLI 可用性会和仓库真相分开诊断。
+- `repo-local-wrapper`：仓库有意保留 `.loom/bin` 等 repo-local wrapper
+  carrier。只要 installed-state 明确声明，这些 carrier 仍然有效；在
+  wrapper 委托给 global CLI provider 的兼容窗口中也同样有效。
+
+详细接入合同与验证命令见
+[docs/adoption/unified-install-experience.md](./docs/adoption/unified-install-experience.md)、
+[docs/adoption/installation-taxonomy.md](./docs/adoption/installation-taxonomy.md)
+和 [docs/adoption/loom-installed-state-v2.md](./docs/adoption/loom-installed-state-v2.md)。
+
 为目标仓库安装并验证 Codex 宿主 payload：
 
 ```bash

--- a/docs/adoption/README.md
+++ b/docs/adoption/README.md
@@ -36,6 +36,17 @@
 - CLI-first installed-state 合同：[loom-installed-state-v2.md](./loom-installed-state-v2.md)
 - 版本权威图：[version-authority-map.md](./version-authority-map.md)
 
+Runtime provider modes:
+
+- `global-cli` repositories consume the installed root `loom` command as the
+  runtime provider. No `.loom/bin` carrier is expected; use
+  `loom installed-state validate`, `loom doctor`, `loom verify`, and
+  `loom repair plan` to diagnose repository metadata and external provider
+  readiness without recording workstation state as repository truth.
+- `repo-local-wrapper` repositories intentionally keep repo-local carriers such
+  as `.loom/bin`; those carriers remain valid when installed-state declares
+  them as current, retained, audit-only, obsolete, or compatibility-only.
+
 边界约束：
 
 - Adoption 只负责说明项目如何进入 Loom operating layer，不把 Loom 收窄成治理套件。

--- a/docs/adoption/external-runtime-companion-contract.md
+++ b/docs/adoption/external-runtime-companion-contract.md
@@ -15,16 +15,25 @@ external-runtime 的目标是让成熟 adopted repo 最终可以：
 
 ## 2. 当前默认
 
-当前稳定默认仍是 vendored `.loom/bin` runtime。
+当前用户入口默认使用根 `loom` CLI，但仓库必须显式声明 runtime provider
+mode：
 
-原因：
+- `global-cli` repo 依赖已安装的根 `loom` 命令作为 runtime provider，不期望
+  提交 `.loom/bin` carrier；
+- `repo-local-wrapper` repo 有意保留 `.loom/bin` 或等价 wrapper carrier；
+  这些 carrier 只在 installed-state 明确声明时才是有效仓库 runtime
+  carrier。
 
-- `loom_init verify` 已经要求 `.loom/bin/*` 与 `.loom/bootstrap/manifest.json` 一致
-- manifest 中的 runtime artifact `sha256` 是当前 fail-closed trust boundary
-- strong-governance adopted repo 仍需要本地可审计 runtime provenance
-- vendored `.loom/bin/**` 在该阶段属于 [.loom surfaces 版本控制策略](./loom-surfaces-version-control.md) 中的稳定 carrier，必须 Git 可见
+历史 strong-governance adopted repo 可能仍需要本地可审计 runtime provenance。
+在这类 repo 中，vendored `.loom/bin/**` 仍可作为
+[.loom surfaces 版本控制策略](./loom-surfaces-version-control.md) 下的稳定
+carrier 保留，但它不再由文件存在本身证明 active provider。manifest
+provenance、installed-state 与 provider requirements 必须共同说明它是
+current、retained、audit-only、obsolete 还是 compatibility-only。
 
-因此，external-runtime 只是一条显式迁移路径，不是当前默认安装形态。
+因此，external-runtime 迁移是一条显式迁移路径；它不得把 workstation
+provider state 写成仓库 truth，也不得把未声明的 `.loom/bin` residue 当成
+当前 runtime provider。
 
 ## 3. Companion 保留面
 

--- a/docs/adoption/installation-taxonomy.md
+++ b/docs/adoption/installation-taxonomy.md
@@ -140,6 +140,31 @@ Metadata-only adoption may retain runtime carriers for audit or consumer gates.
 That retention must not make the repository look like an embedded skills
 payload install.
 
+## Runtime Provider Modes
+
+Loom exposes two user-facing runtime provider modes:
+
+| Mode | Repository expectation | Provider authority | Validation entry |
+| --- | --- | --- | --- |
+| `global-cli` | `.loom/installed-state.json` records a dependency on the installed root `loom` command. No `.loom/bin` carrier is expected. | Global CLI runtime provider; workstation/user-level state remains outside repository truth. | `loom installed-state validate`, `loom doctor`, `loom verify`, `loom repair plan` |
+| `repo-local-wrapper` | `.loom/bin` or equivalent repo-local wrapper carriers are intentionally present and classified by installed-state. | Repository runtime carrier for wrapper/provenance, or compatibility delegation to the declared provider. | Same commands, plus wrapper residue/provenance classification in diagnostics |
+
+For `global-cli` repositories, a detected `.loom/bin` directory is legacy or
+retained residue until installed-state explicitly says otherwise. It must not be
+used as proof that the repository owns the active runtime provider. For
+`repo-local-wrapper` repositories, `.loom/bin` remains a valid repository
+carrier when the metadata declares its current or retained role.
+
+Copyable validation commands for a `global-cli` repository:
+
+```bash
+loom installed-state validate --target . --json
+loom detect --target . --json
+loom doctor --target . --json
+loom verify --target . --json
+loom repair plan --target . --json
+```
+
 ## Repo-Local Wrapper Compatibility
 
 `repo-local-wrapper` is a compatibility carrier, not a third authority line.

--- a/docs/adoption/loom-installed-state-v2.md
+++ b/docs/adoption/loom-installed-state-v2.md
@@ -296,6 +296,67 @@ Detected `.loom/bin` by itself is still only a hint. It becomes meaningful only
 when installed-state explicitly models a current, retained, audit, obsolete, or
 compatibility-only carrier state.
 
+### Global CLI Without Repo-Local Wrapper
+
+A `global-cli` repository may omit `.loom/bin` entirely. In that mode,
+installed-state records repository adoption truth and provider requirements,
+while the root `loom` executable and its packaged runtime remain external
+workstation/user-level provider state:
+
+```json
+{
+  "provider_requirements": {
+    "global_cli": {
+      "required": true,
+      "provider": "loom-cli",
+      "authority": "workstation",
+      "compatibility_mode_allowed": false
+    }
+  },
+  "layers": [
+    {
+      "id": "adoption-metadata",
+      "layer_type": "repository-adoption-metadata",
+      "installed_path": ".loom/installed-state.json",
+      "runtime_state": "ready",
+      "upgrade_eligibility": "current",
+      "provides": ["repository adoption truth"],
+      "consumes": ["global-cli-provider"]
+    },
+    {
+      "id": "global-cli-provider",
+      "layer_type": "global-cli-runtime-provider",
+      "installed_path": "workstation:loom-cli",
+      "runtime_state": "unknown",
+      "upgrade_eligibility": "unknown",
+      "provides": ["loom command semantics", "runtime provider"],
+      "consumes": []
+    }
+  ],
+  "installation_graph": {
+    "layers": ["adoption-metadata", "global-cli-provider"],
+    "edges": [
+      {"from": "adoption-metadata", "to": "global-cli-provider", "relationship": "requires-external-provider"}
+    ]
+  }
+}
+```
+
+Copyable validation commands for this mode:
+
+```bash
+loom installed-state validate --target . --json
+loom detect --target . --json
+loom doctor --target . --json
+loom verify --target . --json
+loom repair plan --target . --json
+```
+
+Passing repository metadata validation does not prove that every developer
+workstation has the global CLI installed. `doctor` and `verify` diagnose that
+external provider boundary; their output must not copy local workstation paths,
+cache state, or registration outcomes into repository truth.
+
 ## Compatibility Mode
 
 Compatibility mode is valid installed-state only when the metadata says so. It

--- a/docs/adoption/unified-install-experience.md
+++ b/docs/adoption/unified-install-experience.md
@@ -28,6 +28,35 @@ Install path status:
 - Historical: `@mc-and-his-agents/loom-installer` references retained only for deprecated evidence and compatibility records.
 - Unsupported: presenting plugin install, SKILLS install, single-skill install, or installer commands as an independent primary Loom install surface.
 
+## Runtime Provider Modes
+
+The root CLI install supports two repository runtime provider modes:
+
+- `global-cli`: the target repository records adoption metadata and depends on
+  the installed root `loom` command as the runtime provider. No `.loom/bin`
+  carrier is expected in this mode.
+- `repo-local-wrapper`: the target repository intentionally retains repo-local
+  wrapper carriers such as `.loom/bin`. That remains valid when installed-state
+  declares the wrapper/carrier role, including compatibility delegation to the
+  global CLI provider.
+
+For `global-cli` repositories, validate the repository metadata and external
+provider boundary with:
+
+```bash
+loom installed-state validate --target . --json
+loom detect --target . --json
+loom doctor --target . --json
+loom verify --target . --json
+loom repair plan --target . --json
+```
+
+These commands may report missing or incompatible workstation/global CLI state,
+but user-level provider state is not repository truth. For
+`repo-local-wrapper` repositories, `.loom/bin` is still a valid repository
+runtime carrier only when installed-state classifies it as current, retained,
+audit-only, obsolete, or compatibility-only.
+
 ## Source And Generated Surfaces
 
 - `src/skills/` is the only editable source truth for Loom skills.

--- a/docs/methodology/harness/cli-command-matrix.md
+++ b/docs/methodology/harness/cli-command-matrix.md
@@ -28,8 +28,8 @@ Regression bucket / named surface / fast-vs-full validation semantics for long-r
 | `loom installed-state validate` | implemented | Validates schema, layers, graph, and version metadata. |
 | `loom installed-state export` | implemented | Emits valid installed-state plus installation graph. |
 | `loom detect` | implemented | Detects current, legacy, symlink, single-skill, metadata-only, embedded plugin, and mixed installed surfaces. |
-| `loom doctor` | implemented | Diagnoses installed-state, declared adoption mode, provider readiness, and legacy surface readiness with fail-closed repair fallback. |
-| `loom repair plan` | implemented | Emits a non-mutating repair plan for missing, invalid, or legacy installed surfaces. |
+| `loom doctor` | implemented | Diagnoses installed-state, declared adoption mode, runtime provider mode (`global-cli` or `repo-local-wrapper`), provider readiness, and legacy surface readiness with fail-closed repair fallback. |
+| `loom repair plan` | implemented | Emits a non-mutating repair plan for missing, invalid, legacy, or runtime-provider carrier drift. |
 | `loom repair apply` | implemented | Fails closed until write ownership and rollback semantics are approved by a later Work Item. |
 
 ## Implemented Phase Commands
@@ -151,6 +151,10 @@ the target artifact/scope is explicit. Metadata-only repository adoption,
 embedded repository payload, compatibility skills export, single-skill export,
 workstation registration, and runtime carrier changes are separate operations
 under the [installation taxonomy](../../adoption/installation-taxonomy.md).
+The runtime provider mode is also explicit: `global-cli` repositories expect the
+installed root `loom` command and do not require `.loom/bin`, while
+`repo-local-wrapper` repositories keep `.loom/bin` or equivalent wrappers only
+when installed-state declares that carrier role.
 `upgrade-plan` is non-mutating and emits ordered repair /
 legacy-classification / no-op actions. `verify` consumes `doctor` so
 installed-state, declared adoption mode, provider readiness, and legacy-surface
@@ -158,6 +162,16 @@ readiness stay aligned. `upgrade` requires `--apply` and refuses to mutate while
 installed-state is invalid or legacy surfaces remain unclassified. `rollback`
 remains a structured fail-closed command because rollback/delete ownership
 cannot be inferred from installed surface detection.
+
+Copyable validation commands for a `global-cli` repository:
+
+```bash
+loom installed-state validate --target . --json
+loom detect --target . --json
+loom doctor --target . --json
+loom verify --target . --json
+loom repair plan --target . --json
+```
 
 ## Scenario Commands
 

--- a/tools/loom.py
+++ b/tools/loom.py
@@ -106,7 +106,7 @@ COMMANDS: list[dict[str, Any]] = [
         "domain": "installation",
         "status": "implemented",
         "json": True,
-        "summary": "Validate installed-state schema, layers, graph, and fail-closed metadata.",
+        "summary": "Validate installed-state schema, layers, graph, runtime-provider declarations, and fail-closed metadata.",
     },
     {
         "command": "installed-state export",
@@ -127,14 +127,14 @@ COMMANDS: list[dict[str, Any]] = [
         "domain": "diagnostics",
         "status": "implemented",
         "json": True,
-        "summary": "Diagnose detected surfaces and installed-state readiness.",
+        "summary": "Diagnose installed-state readiness and runtime provider mode: global-cli without .loom/bin, or repo-local-wrapper with declared .loom/bin carriers.",
     },
     {
         "command": "repair plan",
         "domain": "repair",
         "status": "implemented",
         "json": True,
-        "summary": "Emit a non-mutating repair plan for detected legacy or drifted surfaces.",
+        "summary": "Emit a non-mutating repair plan for legacy, drifted, or runtime-provider carrier surfaces.",
     },
     {
         "command": "repair apply",
@@ -148,12 +148,24 @@ COMMANDS: list[dict[str, Any]] = [
         "domain": "delivery",
         "status": "implemented",
         "json": True,
-        "summary": "Install explicit repository adoption metadata, embedded payload, or compatibility skills surfaces.",
+        "summary": "Install explicit repository adoption metadata, embedded payload, compatibility skills surfaces, or declared runtime-provider mode.",
     },
-    {"command": "upgrade-plan", "domain": "delivery", "status": "implemented", "json": True},
+    {
+        "command": "upgrade-plan",
+        "domain": "delivery",
+        "status": "implemented",
+        "json": True,
+        "summary": "Plan non-mutating upgrades across installed-state, legacy surfaces, and runtime-provider carriers.",
+    },
     {"command": "upgrade", "domain": "delivery", "status": "implemented", "json": True},
     {"command": "rollback", "domain": "delivery", "status": "implemented", "json": True},
-    {"command": "verify", "domain": "delivery", "status": "implemented", "json": True},
+    {
+        "command": "verify",
+        "domain": "delivery",
+        "status": "implemented",
+        "json": True,
+        "summary": "Verify the same readiness boundary as doctor, including global-cli versus repo-local-wrapper runtime provider mode.",
+    },
     {"command": "init", "domain": "scenario", "status": "implemented", "json": True},
     {"command": "adopt", "domain": "scenario", "status": "implemented", "json": True},
     {"command": "route", "domain": "scenario", "status": "implemented", "json": True},
@@ -695,6 +707,10 @@ def print_usage(stream) -> None:
         "  version [--json]\n"
         "  help [--json]\n"
         "  installed-state show|validate|export --target <repo> [--json]\n\n"
+        "install, provider, and repair commands:\n"
+        "  install, doctor, verify, upgrade-plan, repair plan\n"
+        "  global-cli repos use the root loom provider and do not expect .loom/bin\n"
+        "  repo-local-wrapper repos keep declared .loom/bin carriers as valid wrappers\n\n"
         "scenario and gate commands:\n"
         "  init, adopt, route, status, fact-chain, profile, checkpoint, gate\n"
         "  resume, spec-review, review, merge-ready, check\n"


### PR DESCRIPTION
## Summary
- Name `global-cli` and `repo-local-wrapper` as explicit runtime provider modes in README and adoption docs.
- Add copyable `global-cli` validation commands and document `.loom/bin` expectations for both modes.
- Surface provider-mode guidance in CLI help / command matrix without changing runtime behavior.

## Loom metadata
Loom Work Item: #1245
Branch: docs/1245-runtime-provider-modes
Head SHA: 706aa65810b403ba1875f74f45368e15db4edc68
Base SHA: a1712a017d597b22a9bf08ca5fd991d78127acf8
Workspace: /Users/mc/.codex/worktrees/a9fc/Loom
Gate owner: scheduler
Suite path: not_applicable
Suite rationale: docs/help-only runtime provider guidance; no formal spec suite artifacts are changed or required.
Consumer boundary: README, adoption docs, CLI command matrix, and CLI help summaries.
Recheck condition: rerun local CLI help/contract checks after any PR body, docs, or tools/loom.py changes that affect gate input.
Review requirement: scheduler-owned review/gate before merge.

## Validation
- `python3 tools/loom.py help --json`
- `python3 -m py_compile tools/loom.py`
- `rg -n "repo-local-wrapper|global-cli|\.loom/bin|workstation" README.md README.zh-CN.md docs/adoption/README.md docs/adoption/installation-taxonomy.md docs/adoption/loom-installed-state-v2.md docs/adoption/unified-install-experience.md docs/adoption/external-runtime-companion-contract.md docs/methodology/harness/cli-command-matrix.md tools/loom.py`
- `python3 tools/check_cli_contract.py`
- `node bin/loom.mjs --help`
- `git diff --check`

## Notes
No runtime semantics, parser/schema behavior, failure vocabulary, repair behavior, fixtures, generated skills payload, release surface, or carrier state changed.