### PR TITLE
fix: 修复 closeout hosted admission 冻结面

### DIFF
--- a/examples/new-project/.loom/bin/loom_flow.py
+++ b/examples/new-project/.loom/bin/loom_flow.py
@@ -679,6 +679,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     carrier.add_argument("--dry-run", action="store_true", default=True, help="Preview refresh actions without writing files; this is the default")
     carrier.add_argument("--write", dest="dry_run", action="store_false", help="Write Loom-owned carrier metadata refreshes")
     carrier.add_argument("--apply", dest="dry_run", action="store_false", help="Apply explicit versioned carrier closeout metadata writes")
+    carrier.add_argument(
+        "--surface",
+        choices=("pre_review", "review", "merge_ready", "closeout"),
+        default="merge_ready",
+        help="Gate surface whose carrier refresh drift policy should be evaluated",
+    )
     carrier.add_argument("--terminal-state", choices=tuple(sorted(TERMINAL_CLOSEOUT_STATES)), help="Terminal closeout state to write")
     carrier.add_argument("--issue", help="Issue locator or number bound to terminal closeout")
     carrier.add_argument("--pr", help="PR locator or number bound to terminal closeout")
@@ -821,7 +827,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     gate_freeze.add_argument("--compare-body-file", help="Optional repo-relative post-edit/readback PR body markdown to compare against --body-file")
     gate_freeze.add_argument(
         "--surface",
-        choices=("pre_review", "review", "merge_ready"),
+        choices=("pre_review", "review", "merge_ready", "closeout"),
         default="merge_ready",
         help="Gate surface whose PR metadata contract is consumed by the snapshot",
     )
@@ -14144,7 +14150,14 @@ def apply_shadow_evidence_actions(target_root: Path, actions: list[dict[str, Any
             write_json_file(path, payload)
 
 
-def carrier_refresh_payload(target_root: Path, output_relative: str, expected_item: str | None, *, dry_run: bool) -> dict[str, Any]:
+def carrier_refresh_payload(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    dry_run: bool,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
     runtime_state = runtime_state_payload(target_root)
     context, context_errors = load_context(target_root, output_relative, expected_item)
     idle_context = is_idle_context_errors(context_errors)
@@ -14196,7 +14209,13 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         assert context
         review_record, review_path, review_errors = load_review_record(target_root, context["item_id"], context["review_entry"])
         spec_review_path = default_spec_review_path(context["item_id"])
-        allowed_paths = allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+        terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+        allowed_paths = (
+            allowed_terminal_closeout_carrier_paths(context, review_path, spec_review_path)
+            if terminal_closeout_surface
+            else allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        )
         if review_errors or review_record is None:
             review_status = {"status": "missing", "path": review_path, "missing_inputs": review_errors or [f"missing review artifact: {review_path}"]}
         else:
@@ -14205,7 +14224,17 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
                 reviewed_head=str(review_record.get("reviewed_head", "")),
                 allowed_paths=allowed_paths,
             )
-            review_status = {"path": review_path, "head_binding": binding, "missing_inputs": binding_errors}
+            review_status = {
+                "path": review_path,
+                "head_binding": binding,
+                "missing_inputs": binding_errors,
+                "surface": surface,
+                "allowed_paths_policy": (
+                    "terminal closeout carrier paths only; requires terminal checkpoint"
+                    if terminal_closeout_surface
+                    else "post-review carrier paths only"
+                ),
+            }
             if binding.get("status") in {"implementation-drift-only", "stale"}:
                 review_status["status"] = "block"
                 missing_inputs.append("review artifact is stale because non-carrier drift is present")
@@ -14238,6 +14267,7 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         "missing_inputs": missing_inputs,
         "fallback_to": None if result == "pass" else "adoption",
         "dry_run": dry_run,
+        "surface": surface,
         "runtime_state": runtime_state,
         "actions": actions,
         "refresh_needed": refresh_needed,
@@ -15188,7 +15218,7 @@ def handle_carrier(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     if args.operation == "closeout-sync":
         return emit(carrier_closeout_sync_payload(target_root, args.output, args.item, args))
-    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run))
+    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run, surface=args.surface))
 
 
 def github_commit_pulls(root: Path, owner: str, repo_name: str, head_sha: str) -> tuple[list[dict[str, Any]], list[str]]:
@@ -17178,7 +17208,7 @@ def gate_freeze_command_surface(context: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None) -> dict[str, Any]:
+def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None, surface: str = "merge_ready") -> dict[str, Any]:
     review_entry = context.get("review_entry")
     review_relative = str(review_entry) if isinstance(review_entry, str) and review_entry else None
     review_record, review_path, review_errors = load_review_record(
@@ -17212,11 +17242,18 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
     binding["decision"] = review_record.get("decision")
     binding["kind"] = review_record.get("kind")
     binding["reviewed_head"] = review_record.get("reviewed_head")
+    normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+    terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+    allowed_paths = (
+        allowed_terminal_closeout_carrier_paths(context, review_path)
+        if terminal_closeout_surface
+        else allowed_post_review_carrier_paths(context, review_path)
+    )
     head_binding, head_errors = review_head_binding_for_head(
         context["target_root"],
         reviewed_head=review_record.get("reviewed_head") if isinstance(review_record.get("reviewed_head"), str) else None,
         target_head=head_sha or git_head_sha(context["target_root"]),
-        allowed_paths=allowed_post_review_carrier_paths(context, review_path),
+        allowed_paths=allowed_paths,
     )
     binding["head_binding"] = head_binding
     binding["current_head"] = head_binding.get("current_head")
@@ -17230,6 +17267,12 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
         current_validation_summary=context.get("latest_validation_summary"),
     )
     binding["semantic_review_disposition"] = disposition
+    binding["surface"] = surface
+    binding["allowed_paths_policy"] = (
+        "terminal closeout carrier paths only; requires terminal checkpoint"
+        if terminal_closeout_surface
+        else "post-review carrier paths only"
+    )
     binding["missing_inputs"] = [*head_errors, *disposition_errors]
     if review_record.get("decision") != "allow":
         binding["missing_inputs"].append("review artifact decision is not allow")
@@ -17384,8 +17427,17 @@ def gate_freeze_shadow_freshness_binding(target_root: Path, governance_surface: 
     }
 
 
-def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str, expected_item: str | None) -> dict[str, Any]:
-    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True)
+def gate_freeze_carrier_refresh_binding(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
+    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True, surface=surface)
+    refresh_command = "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+    if surface != "merge_ready":
+        refresh_command = f"{refresh_command} --surface {surface}"
     refresh_needed = [
         action for action in dry_run_payload.get("refresh_needed", []) if isinstance(action, dict)
     ]
@@ -17414,10 +17466,10 @@ def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str,
         "subject": "carrier_refresh",
         "why_blocking": "hosted admission cannot trust a frozen snapshot while carrier refresh dry-run reports pending updates.",
         "fallback_to": "carrier_refresh",
-        "refresh_suggestion": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "refresh_suggestion": refresh_command
         if refresh_needed
         else None,
-        "next_action": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "next_action": refresh_command
         if refresh_needed
         else dry_run_payload.get("fallback_to"),
     }
@@ -18408,9 +18460,9 @@ def gate_freeze_payload(args: argparse.Namespace, *, operation: str) -> dict[str
         "status_surface": status_binding,
         "pr_metadata": pr_metadata,
         "pr_body_pin": gate_freeze_pr_body_pin_binding(pr_metadata),
-        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha),
+        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha, surface=args.surface),
         "shadow_parity": gate_freeze_shadow_binding(target_root, governance_surface),
-        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"]),
+        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"], surface=args.surface),
         "shadow_freshness": gate_freeze_shadow_freshness_binding(target_root, governance_surface),
         "suite_validation": suite_validation,
         "suite_evidence_validation": suite_evidence_validation,
@@ -18591,7 +18643,7 @@ def hosted_freeze_admission_payload(
             "failure_classifier": failure_classifier_payload([]),
         }
 
-    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready"} else "merge_ready"
+    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready", "closeout"} else "merge_ready"
     freeze_args = argparse.Namespace(
         target=str(target_root),
         output=output_relative,

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -432,7 +432,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "cba2775dd9461e453218d01ba82a1da2fae30c059678d684febb461041218918"
+      "sha256": "db9308eb00e979789578cb4d65b10250cc066eeaf0c7bef83ac4f187f027a798"
     },
     {
       "path": ".loom/bin/loom_status.py",

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -138,7 +138,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "cba2775dd9461e453218d01ba82a1da2fae30c059678d684febb461041218918"
+      "sha256": "db9308eb00e979789578cb4d65b10250cc066eeaf0c7bef83ac4f187f027a798"
     },
     {
       "path": ".loom/bin/loom_status.py",

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -679,6 +679,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     carrier.add_argument("--dry-run", action="store_true", default=True, help="Preview refresh actions without writing files; this is the default")
     carrier.add_argument("--write", dest="dry_run", action="store_false", help="Write Loom-owned carrier metadata refreshes")
     carrier.add_argument("--apply", dest="dry_run", action="store_false", help="Apply explicit versioned carrier closeout metadata writes")
+    carrier.add_argument(
+        "--surface",
+        choices=("pre_review", "review", "merge_ready", "closeout"),
+        default="merge_ready",
+        help="Gate surface whose carrier refresh drift policy should be evaluated",
+    )
     carrier.add_argument("--terminal-state", choices=tuple(sorted(TERMINAL_CLOSEOUT_STATES)), help="Terminal closeout state to write")
     carrier.add_argument("--issue", help="Issue locator or number bound to terminal closeout")
     carrier.add_argument("--pr", help="PR locator or number bound to terminal closeout")
@@ -821,7 +827,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     gate_freeze.add_argument("--compare-body-file", help="Optional repo-relative post-edit/readback PR body markdown to compare against --body-file")
     gate_freeze.add_argument(
         "--surface",
-        choices=("pre_review", "review", "merge_ready"),
+        choices=("pre_review", "review", "merge_ready", "closeout"),
         default="merge_ready",
         help="Gate surface whose PR metadata contract is consumed by the snapshot",
     )
@@ -14144,7 +14150,14 @@ def apply_shadow_evidence_actions(target_root: Path, actions: list[dict[str, Any
             write_json_file(path, payload)
 
 
-def carrier_refresh_payload(target_root: Path, output_relative: str, expected_item: str | None, *, dry_run: bool) -> dict[str, Any]:
+def carrier_refresh_payload(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    dry_run: bool,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
     runtime_state = runtime_state_payload(target_root)
     context, context_errors = load_context(target_root, output_relative, expected_item)
     idle_context = is_idle_context_errors(context_errors)
@@ -14196,7 +14209,13 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         assert context
         review_record, review_path, review_errors = load_review_record(target_root, context["item_id"], context["review_entry"])
         spec_review_path = default_spec_review_path(context["item_id"])
-        allowed_paths = allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+        terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+        allowed_paths = (
+            allowed_terminal_closeout_carrier_paths(context, review_path, spec_review_path)
+            if terminal_closeout_surface
+            else allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        )
         if review_errors or review_record is None:
             review_status = {"status": "missing", "path": review_path, "missing_inputs": review_errors or [f"missing review artifact: {review_path}"]}
         else:
@@ -14205,7 +14224,17 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
                 reviewed_head=str(review_record.get("reviewed_head", "")),
                 allowed_paths=allowed_paths,
             )
-            review_status = {"path": review_path, "head_binding": binding, "missing_inputs": binding_errors}
+            review_status = {
+                "path": review_path,
+                "head_binding": binding,
+                "missing_inputs": binding_errors,
+                "surface": surface,
+                "allowed_paths_policy": (
+                    "terminal closeout carrier paths only; requires terminal checkpoint"
+                    if terminal_closeout_surface
+                    else "post-review carrier paths only"
+                ),
+            }
             if binding.get("status") in {"implementation-drift-only", "stale"}:
                 review_status["status"] = "block"
                 missing_inputs.append("review artifact is stale because non-carrier drift is present")
@@ -14238,6 +14267,7 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         "missing_inputs": missing_inputs,
         "fallback_to": None if result == "pass" else "adoption",
         "dry_run": dry_run,
+        "surface": surface,
         "runtime_state": runtime_state,
         "actions": actions,
         "refresh_needed": refresh_needed,
@@ -15188,7 +15218,7 @@ def handle_carrier(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     if args.operation == "closeout-sync":
         return emit(carrier_closeout_sync_payload(target_root, args.output, args.item, args))
-    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run))
+    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run, surface=args.surface))
 
 
 def github_commit_pulls(root: Path, owner: str, repo_name: str, head_sha: str) -> tuple[list[dict[str, Any]], list[str]]:
@@ -17178,7 +17208,7 @@ def gate_freeze_command_surface(context: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None) -> dict[str, Any]:
+def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None, surface: str = "merge_ready") -> dict[str, Any]:
     review_entry = context.get("review_entry")
     review_relative = str(review_entry) if isinstance(review_entry, str) and review_entry else None
     review_record, review_path, review_errors = load_review_record(
@@ -17212,11 +17242,18 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
     binding["decision"] = review_record.get("decision")
     binding["kind"] = review_record.get("kind")
     binding["reviewed_head"] = review_record.get("reviewed_head")
+    normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+    terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+    allowed_paths = (
+        allowed_terminal_closeout_carrier_paths(context, review_path)
+        if terminal_closeout_surface
+        else allowed_post_review_carrier_paths(context, review_path)
+    )
     head_binding, head_errors = review_head_binding_for_head(
         context["target_root"],
         reviewed_head=review_record.get("reviewed_head") if isinstance(review_record.get("reviewed_head"), str) else None,
         target_head=head_sha or git_head_sha(context["target_root"]),
-        allowed_paths=allowed_post_review_carrier_paths(context, review_path),
+        allowed_paths=allowed_paths,
     )
     binding["head_binding"] = head_binding
     binding["current_head"] = head_binding.get("current_head")
@@ -17230,6 +17267,12 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
         current_validation_summary=context.get("latest_validation_summary"),
     )
     binding["semantic_review_disposition"] = disposition
+    binding["surface"] = surface
+    binding["allowed_paths_policy"] = (
+        "terminal closeout carrier paths only; requires terminal checkpoint"
+        if terminal_closeout_surface
+        else "post-review carrier paths only"
+    )
     binding["missing_inputs"] = [*head_errors, *disposition_errors]
     if review_record.get("decision") != "allow":
         binding["missing_inputs"].append("review artifact decision is not allow")
@@ -17384,8 +17427,17 @@ def gate_freeze_shadow_freshness_binding(target_root: Path, governance_surface: 
     }
 
 
-def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str, expected_item: str | None) -> dict[str, Any]:
-    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True)
+def gate_freeze_carrier_refresh_binding(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
+    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True, surface=surface)
+    refresh_command = "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+    if surface != "merge_ready":
+        refresh_command = f"{refresh_command} --surface {surface}"
     refresh_needed = [
         action for action in dry_run_payload.get("refresh_needed", []) if isinstance(action, dict)
     ]
@@ -17414,10 +17466,10 @@ def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str,
         "subject": "carrier_refresh",
         "why_blocking": "hosted admission cannot trust a frozen snapshot while carrier refresh dry-run reports pending updates.",
         "fallback_to": "carrier_refresh",
-        "refresh_suggestion": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "refresh_suggestion": refresh_command
         if refresh_needed
         else None,
-        "next_action": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "next_action": refresh_command
         if refresh_needed
         else dry_run_payload.get("fallback_to"),
     }
@@ -18408,9 +18460,9 @@ def gate_freeze_payload(args: argparse.Namespace, *, operation: str) -> dict[str
         "status_surface": status_binding,
         "pr_metadata": pr_metadata,
         "pr_body_pin": gate_freeze_pr_body_pin_binding(pr_metadata),
-        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha),
+        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha, surface=args.surface),
         "shadow_parity": gate_freeze_shadow_binding(target_root, governance_surface),
-        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"]),
+        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"], surface=args.surface),
         "shadow_freshness": gate_freeze_shadow_freshness_binding(target_root, governance_surface),
         "suite_validation": suite_validation,
         "suite_evidence_validation": suite_evidence_validation,
@@ -18591,7 +18643,7 @@ def hosted_freeze_admission_payload(
             "failure_classifier": failure_classifier_payload([]),
         }
 
-    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready"} else "merge_ready"
+    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready", "closeout"} else "merge_ready"
     freeze_args = argparse.Namespace(
         target=str(target_root),
         output=output_relative,

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
@@ -679,6 +679,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     carrier.add_argument("--dry-run", action="store_true", default=True, help="Preview refresh actions without writing files; this is the default")
     carrier.add_argument("--write", dest="dry_run", action="store_false", help="Write Loom-owned carrier metadata refreshes")
     carrier.add_argument("--apply", dest="dry_run", action="store_false", help="Apply explicit versioned carrier closeout metadata writes")
+    carrier.add_argument(
+        "--surface",
+        choices=("pre_review", "review", "merge_ready", "closeout"),
+        default="merge_ready",
+        help="Gate surface whose carrier refresh drift policy should be evaluated",
+    )
     carrier.add_argument("--terminal-state", choices=tuple(sorted(TERMINAL_CLOSEOUT_STATES)), help="Terminal closeout state to write")
     carrier.add_argument("--issue", help="Issue locator or number bound to terminal closeout")
     carrier.add_argument("--pr", help="PR locator or number bound to terminal closeout")
@@ -821,7 +827,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     gate_freeze.add_argument("--compare-body-file", help="Optional repo-relative post-edit/readback PR body markdown to compare against --body-file")
     gate_freeze.add_argument(
         "--surface",
-        choices=("pre_review", "review", "merge_ready"),
+        choices=("pre_review", "review", "merge_ready", "closeout"),
         default="merge_ready",
         help="Gate surface whose PR metadata contract is consumed by the snapshot",
     )
@@ -14144,7 +14150,14 @@ def apply_shadow_evidence_actions(target_root: Path, actions: list[dict[str, Any
             write_json_file(path, payload)
 
 
-def carrier_refresh_payload(target_root: Path, output_relative: str, expected_item: str | None, *, dry_run: bool) -> dict[str, Any]:
+def carrier_refresh_payload(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    dry_run: bool,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
     runtime_state = runtime_state_payload(target_root)
     context, context_errors = load_context(target_root, output_relative, expected_item)
     idle_context = is_idle_context_errors(context_errors)
@@ -14196,7 +14209,13 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         assert context
         review_record, review_path, review_errors = load_review_record(target_root, context["item_id"], context["review_entry"])
         spec_review_path = default_spec_review_path(context["item_id"])
-        allowed_paths = allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+        terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+        allowed_paths = (
+            allowed_terminal_closeout_carrier_paths(context, review_path, spec_review_path)
+            if terminal_closeout_surface
+            else allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        )
         if review_errors or review_record is None:
             review_status = {"status": "missing", "path": review_path, "missing_inputs": review_errors or [f"missing review artifact: {review_path}"]}
         else:
@@ -14205,7 +14224,17 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
                 reviewed_head=str(review_record.get("reviewed_head", "")),
                 allowed_paths=allowed_paths,
             )
-            review_status = {"path": review_path, "head_binding": binding, "missing_inputs": binding_errors}
+            review_status = {
+                "path": review_path,
+                "head_binding": binding,
+                "missing_inputs": binding_errors,
+                "surface": surface,
+                "allowed_paths_policy": (
+                    "terminal closeout carrier paths only; requires terminal checkpoint"
+                    if terminal_closeout_surface
+                    else "post-review carrier paths only"
+                ),
+            }
             if binding.get("status") in {"implementation-drift-only", "stale"}:
                 review_status["status"] = "block"
                 missing_inputs.append("review artifact is stale because non-carrier drift is present")
@@ -14238,6 +14267,7 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         "missing_inputs": missing_inputs,
         "fallback_to": None if result == "pass" else "adoption",
         "dry_run": dry_run,
+        "surface": surface,
         "runtime_state": runtime_state,
         "actions": actions,
         "refresh_needed": refresh_needed,
@@ -15188,7 +15218,7 @@ def handle_carrier(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     if args.operation == "closeout-sync":
         return emit(carrier_closeout_sync_payload(target_root, args.output, args.item, args))
-    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run))
+    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run, surface=args.surface))
 
 
 def github_commit_pulls(root: Path, owner: str, repo_name: str, head_sha: str) -> tuple[list[dict[str, Any]], list[str]]:
@@ -17178,7 +17208,7 @@ def gate_freeze_command_surface(context: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None) -> dict[str, Any]:
+def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None, surface: str = "merge_ready") -> dict[str, Any]:
     review_entry = context.get("review_entry")
     review_relative = str(review_entry) if isinstance(review_entry, str) and review_entry else None
     review_record, review_path, review_errors = load_review_record(
@@ -17212,11 +17242,18 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
     binding["decision"] = review_record.get("decision")
     binding["kind"] = review_record.get("kind")
     binding["reviewed_head"] = review_record.get("reviewed_head")
+    normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+    terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+    allowed_paths = (
+        allowed_terminal_closeout_carrier_paths(context, review_path)
+        if terminal_closeout_surface
+        else allowed_post_review_carrier_paths(context, review_path)
+    )
     head_binding, head_errors = review_head_binding_for_head(
         context["target_root"],
         reviewed_head=review_record.get("reviewed_head") if isinstance(review_record.get("reviewed_head"), str) else None,
         target_head=head_sha or git_head_sha(context["target_root"]),
-        allowed_paths=allowed_post_review_carrier_paths(context, review_path),
+        allowed_paths=allowed_paths,
     )
     binding["head_binding"] = head_binding
     binding["current_head"] = head_binding.get("current_head")
@@ -17230,6 +17267,12 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
         current_validation_summary=context.get("latest_validation_summary"),
     )
     binding["semantic_review_disposition"] = disposition
+    binding["surface"] = surface
+    binding["allowed_paths_policy"] = (
+        "terminal closeout carrier paths only; requires terminal checkpoint"
+        if terminal_closeout_surface
+        else "post-review carrier paths only"
+    )
     binding["missing_inputs"] = [*head_errors, *disposition_errors]
     if review_record.get("decision") != "allow":
         binding["missing_inputs"].append("review artifact decision is not allow")
@@ -17384,8 +17427,17 @@ def gate_freeze_shadow_freshness_binding(target_root: Path, governance_surface: 
     }
 
 
-def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str, expected_item: str | None) -> dict[str, Any]:
-    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True)
+def gate_freeze_carrier_refresh_binding(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
+    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True, surface=surface)
+    refresh_command = "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+    if surface != "merge_ready":
+        refresh_command = f"{refresh_command} --surface {surface}"
     refresh_needed = [
         action for action in dry_run_payload.get("refresh_needed", []) if isinstance(action, dict)
     ]
@@ -17414,10 +17466,10 @@ def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str,
         "subject": "carrier_refresh",
         "why_blocking": "hosted admission cannot trust a frozen snapshot while carrier refresh dry-run reports pending updates.",
         "fallback_to": "carrier_refresh",
-        "refresh_suggestion": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "refresh_suggestion": refresh_command
         if refresh_needed
         else None,
-        "next_action": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "next_action": refresh_command
         if refresh_needed
         else dry_run_payload.get("fallback_to"),
     }
@@ -18408,9 +18460,9 @@ def gate_freeze_payload(args: argparse.Namespace, *, operation: str) -> dict[str
         "status_surface": status_binding,
         "pr_metadata": pr_metadata,
         "pr_body_pin": gate_freeze_pr_body_pin_binding(pr_metadata),
-        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha),
+        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha, surface=args.surface),
         "shadow_parity": gate_freeze_shadow_binding(target_root, governance_surface),
-        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"]),
+        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"], surface=args.surface),
         "shadow_freshness": gate_freeze_shadow_freshness_binding(target_root, governance_surface),
         "suite_validation": suite_validation,
         "suite_evidence_validation": suite_evidence_validation,
@@ -18591,7 +18643,7 @@ def hosted_freeze_admission_payload(
             "failure_classifier": failure_classifier_payload([]),
         }
 
-    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready"} else "merge_ready"
+    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready", "closeout"} else "merge_ready"
     freeze_args = argparse.Namespace(
         target=str(target_root),
         output=output_relative,

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -679,6 +679,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     carrier.add_argument("--dry-run", action="store_true", default=True, help="Preview refresh actions without writing files; this is the default")
     carrier.add_argument("--write", dest="dry_run", action="store_false", help="Write Loom-owned carrier metadata refreshes")
     carrier.add_argument("--apply", dest="dry_run", action="store_false", help="Apply explicit versioned carrier closeout metadata writes")
+    carrier.add_argument(
+        "--surface",
+        choices=("pre_review", "review", "merge_ready", "closeout"),
+        default="merge_ready",
+        help="Gate surface whose carrier refresh drift policy should be evaluated",
+    )
     carrier.add_argument("--terminal-state", choices=tuple(sorted(TERMINAL_CLOSEOUT_STATES)), help="Terminal closeout state to write")
     carrier.add_argument("--issue", help="Issue locator or number bound to terminal closeout")
     carrier.add_argument("--pr", help="PR locator or number bound to terminal closeout")
@@ -821,7 +827,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     gate_freeze.add_argument("--compare-body-file", help="Optional repo-relative post-edit/readback PR body markdown to compare against --body-file")
     gate_freeze.add_argument(
         "--surface",
-        choices=("pre_review", "review", "merge_ready"),
+        choices=("pre_review", "review", "merge_ready", "closeout"),
         default="merge_ready",
         help="Gate surface whose PR metadata contract is consumed by the snapshot",
     )
@@ -14144,7 +14150,14 @@ def apply_shadow_evidence_actions(target_root: Path, actions: list[dict[str, Any
             write_json_file(path, payload)
 
 
-def carrier_refresh_payload(target_root: Path, output_relative: str, expected_item: str | None, *, dry_run: bool) -> dict[str, Any]:
+def carrier_refresh_payload(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    dry_run: bool,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
     runtime_state = runtime_state_payload(target_root)
     context, context_errors = load_context(target_root, output_relative, expected_item)
     idle_context = is_idle_context_errors(context_errors)
@@ -14196,7 +14209,13 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         assert context
         review_record, review_path, review_errors = load_review_record(target_root, context["item_id"], context["review_entry"])
         spec_review_path = default_spec_review_path(context["item_id"])
-        allowed_paths = allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+        terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+        allowed_paths = (
+            allowed_terminal_closeout_carrier_paths(context, review_path, spec_review_path)
+            if terminal_closeout_surface
+            else allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        )
         if review_errors or review_record is None:
             review_status = {"status": "missing", "path": review_path, "missing_inputs": review_errors or [f"missing review artifact: {review_path}"]}
         else:
@@ -14205,7 +14224,17 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
                 reviewed_head=str(review_record.get("reviewed_head", "")),
                 allowed_paths=allowed_paths,
             )
-            review_status = {"path": review_path, "head_binding": binding, "missing_inputs": binding_errors}
+            review_status = {
+                "path": review_path,
+                "head_binding": binding,
+                "missing_inputs": binding_errors,
+                "surface": surface,
+                "allowed_paths_policy": (
+                    "terminal closeout carrier paths only; requires terminal checkpoint"
+                    if terminal_closeout_surface
+                    else "post-review carrier paths only"
+                ),
+            }
             if binding.get("status") in {"implementation-drift-only", "stale"}:
                 review_status["status"] = "block"
                 missing_inputs.append("review artifact is stale because non-carrier drift is present")
@@ -14238,6 +14267,7 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         "missing_inputs": missing_inputs,
         "fallback_to": None if result == "pass" else "adoption",
         "dry_run": dry_run,
+        "surface": surface,
         "runtime_state": runtime_state,
         "actions": actions,
         "refresh_needed": refresh_needed,
@@ -15188,7 +15218,7 @@ def handle_carrier(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     if args.operation == "closeout-sync":
         return emit(carrier_closeout_sync_payload(target_root, args.output, args.item, args))
-    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run))
+    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run, surface=args.surface))
 
 
 def github_commit_pulls(root: Path, owner: str, repo_name: str, head_sha: str) -> tuple[list[dict[str, Any]], list[str]]:
@@ -17178,7 +17208,7 @@ def gate_freeze_command_surface(context: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None) -> dict[str, Any]:
+def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None, surface: str = "merge_ready") -> dict[str, Any]:
     review_entry = context.get("review_entry")
     review_relative = str(review_entry) if isinstance(review_entry, str) and review_entry else None
     review_record, review_path, review_errors = load_review_record(
@@ -17212,11 +17242,18 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
     binding["decision"] = review_record.get("decision")
     binding["kind"] = review_record.get("kind")
     binding["reviewed_head"] = review_record.get("reviewed_head")
+    normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+    terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+    allowed_paths = (
+        allowed_terminal_closeout_carrier_paths(context, review_path)
+        if terminal_closeout_surface
+        else allowed_post_review_carrier_paths(context, review_path)
+    )
     head_binding, head_errors = review_head_binding_for_head(
         context["target_root"],
         reviewed_head=review_record.get("reviewed_head") if isinstance(review_record.get("reviewed_head"), str) else None,
         target_head=head_sha or git_head_sha(context["target_root"]),
-        allowed_paths=allowed_post_review_carrier_paths(context, review_path),
+        allowed_paths=allowed_paths,
     )
     binding["head_binding"] = head_binding
     binding["current_head"] = head_binding.get("current_head")
@@ -17230,6 +17267,12 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
         current_validation_summary=context.get("latest_validation_summary"),
     )
     binding["semantic_review_disposition"] = disposition
+    binding["surface"] = surface
+    binding["allowed_paths_policy"] = (
+        "terminal closeout carrier paths only; requires terminal checkpoint"
+        if terminal_closeout_surface
+        else "post-review carrier paths only"
+    )
     binding["missing_inputs"] = [*head_errors, *disposition_errors]
     if review_record.get("decision") != "allow":
         binding["missing_inputs"].append("review artifact decision is not allow")
@@ -17384,8 +17427,17 @@ def gate_freeze_shadow_freshness_binding(target_root: Path, governance_surface: 
     }
 
 
-def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str, expected_item: str | None) -> dict[str, Any]:
-    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True)
+def gate_freeze_carrier_refresh_binding(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
+    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True, surface=surface)
+    refresh_command = "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+    if surface != "merge_ready":
+        refresh_command = f"{refresh_command} --surface {surface}"
     refresh_needed = [
         action for action in dry_run_payload.get("refresh_needed", []) if isinstance(action, dict)
     ]
@@ -17414,10 +17466,10 @@ def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str,
         "subject": "carrier_refresh",
         "why_blocking": "hosted admission cannot trust a frozen snapshot while carrier refresh dry-run reports pending updates.",
         "fallback_to": "carrier_refresh",
-        "refresh_suggestion": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "refresh_suggestion": refresh_command
         if refresh_needed
         else None,
-        "next_action": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "next_action": refresh_command
         if refresh_needed
         else dry_run_payload.get("fallback_to"),
     }
@@ -18408,9 +18460,9 @@ def gate_freeze_payload(args: argparse.Namespace, *, operation: str) -> dict[str
         "status_surface": status_binding,
         "pr_metadata": pr_metadata,
         "pr_body_pin": gate_freeze_pr_body_pin_binding(pr_metadata),
-        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha),
+        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha, surface=args.surface),
         "shadow_parity": gate_freeze_shadow_binding(target_root, governance_surface),
-        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"]),
+        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"], surface=args.surface),
         "shadow_freshness": gate_freeze_shadow_freshness_binding(target_root, governance_surface),
         "suite_validation": suite_validation,
         "suite_evidence_validation": suite_evidence_validation,
@@ -18591,7 +18643,7 @@ def hosted_freeze_admission_payload(
             "failure_classifier": failure_classifier_payload([]),
         }
 
-    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready"} else "merge_ready"
+    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready", "closeout"} else "merge_ready"
     freeze_args = argparse.Namespace(
         target=str(target_root),
         output=output_relative,

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -679,6 +679,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     carrier.add_argument("--dry-run", action="store_true", default=True, help="Preview refresh actions without writing files; this is the default")
     carrier.add_argument("--write", dest="dry_run", action="store_false", help="Write Loom-owned carrier metadata refreshes")
     carrier.add_argument("--apply", dest="dry_run", action="store_false", help="Apply explicit versioned carrier closeout metadata writes")
+    carrier.add_argument(
+        "--surface",
+        choices=("pre_review", "review", "merge_ready", "closeout"),
+        default="merge_ready",
+        help="Gate surface whose carrier refresh drift policy should be evaluated",
+    )
     carrier.add_argument("--terminal-state", choices=tuple(sorted(TERMINAL_CLOSEOUT_STATES)), help="Terminal closeout state to write")
     carrier.add_argument("--issue", help="Issue locator or number bound to terminal closeout")
     carrier.add_argument("--pr", help="PR locator or number bound to terminal closeout")
@@ -821,7 +827,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     gate_freeze.add_argument("--compare-body-file", help="Optional repo-relative post-edit/readback PR body markdown to compare against --body-file")
     gate_freeze.add_argument(
         "--surface",
-        choices=("pre_review", "review", "merge_ready"),
+        choices=("pre_review", "review", "merge_ready", "closeout"),
         default="merge_ready",
         help="Gate surface whose PR metadata contract is consumed by the snapshot",
     )
@@ -14144,7 +14150,14 @@ def apply_shadow_evidence_actions(target_root: Path, actions: list[dict[str, Any
             write_json_file(path, payload)
 
 
-def carrier_refresh_payload(target_root: Path, output_relative: str, expected_item: str | None, *, dry_run: bool) -> dict[str, Any]:
+def carrier_refresh_payload(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    dry_run: bool,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
     runtime_state = runtime_state_payload(target_root)
     context, context_errors = load_context(target_root, output_relative, expected_item)
     idle_context = is_idle_context_errors(context_errors)
@@ -14196,7 +14209,13 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         assert context
         review_record, review_path, review_errors = load_review_record(target_root, context["item_id"], context["review_entry"])
         spec_review_path = default_spec_review_path(context["item_id"])
-        allowed_paths = allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+        terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+        allowed_paths = (
+            allowed_terminal_closeout_carrier_paths(context, review_path, spec_review_path)
+            if terminal_closeout_surface
+            else allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        )
         if review_errors or review_record is None:
             review_status = {"status": "missing", "path": review_path, "missing_inputs": review_errors or [f"missing review artifact: {review_path}"]}
         else:
@@ -14205,7 +14224,17 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
                 reviewed_head=str(review_record.get("reviewed_head", "")),
                 allowed_paths=allowed_paths,
             )
-            review_status = {"path": review_path, "head_binding": binding, "missing_inputs": binding_errors}
+            review_status = {
+                "path": review_path,
+                "head_binding": binding,
+                "missing_inputs": binding_errors,
+                "surface": surface,
+                "allowed_paths_policy": (
+                    "terminal closeout carrier paths only; requires terminal checkpoint"
+                    if terminal_closeout_surface
+                    else "post-review carrier paths only"
+                ),
+            }
             if binding.get("status") in {"implementation-drift-only", "stale"}:
                 review_status["status"] = "block"
                 missing_inputs.append("review artifact is stale because non-carrier drift is present")
@@ -14238,6 +14267,7 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         "missing_inputs": missing_inputs,
         "fallback_to": None if result == "pass" else "adoption",
         "dry_run": dry_run,
+        "surface": surface,
         "runtime_state": runtime_state,
         "actions": actions,
         "refresh_needed": refresh_needed,
@@ -15188,7 +15218,7 @@ def handle_carrier(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     if args.operation == "closeout-sync":
         return emit(carrier_closeout_sync_payload(target_root, args.output, args.item, args))
-    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run))
+    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run, surface=args.surface))
 
 
 def github_commit_pulls(root: Path, owner: str, repo_name: str, head_sha: str) -> tuple[list[dict[str, Any]], list[str]]:
@@ -17178,7 +17208,7 @@ def gate_freeze_command_surface(context: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None) -> dict[str, Any]:
+def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None, surface: str = "merge_ready") -> dict[str, Any]:
     review_entry = context.get("review_entry")
     review_relative = str(review_entry) if isinstance(review_entry, str) and review_entry else None
     review_record, review_path, review_errors = load_review_record(
@@ -17212,11 +17242,18 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
     binding["decision"] = review_record.get("decision")
     binding["kind"] = review_record.get("kind")
     binding["reviewed_head"] = review_record.get("reviewed_head")
+    normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+    terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+    allowed_paths = (
+        allowed_terminal_closeout_carrier_paths(context, review_path)
+        if terminal_closeout_surface
+        else allowed_post_review_carrier_paths(context, review_path)
+    )
     head_binding, head_errors = review_head_binding_for_head(
         context["target_root"],
         reviewed_head=review_record.get("reviewed_head") if isinstance(review_record.get("reviewed_head"), str) else None,
         target_head=head_sha or git_head_sha(context["target_root"]),
-        allowed_paths=allowed_post_review_carrier_paths(context, review_path),
+        allowed_paths=allowed_paths,
     )
     binding["head_binding"] = head_binding
     binding["current_head"] = head_binding.get("current_head")
@@ -17230,6 +17267,12 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
         current_validation_summary=context.get("latest_validation_summary"),
     )
     binding["semantic_review_disposition"] = disposition
+    binding["surface"] = surface
+    binding["allowed_paths_policy"] = (
+        "terminal closeout carrier paths only; requires terminal checkpoint"
+        if terminal_closeout_surface
+        else "post-review carrier paths only"
+    )
     binding["missing_inputs"] = [*head_errors, *disposition_errors]
     if review_record.get("decision") != "allow":
         binding["missing_inputs"].append("review artifact decision is not allow")
@@ -17384,8 +17427,17 @@ def gate_freeze_shadow_freshness_binding(target_root: Path, governance_surface: 
     }
 
 
-def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str, expected_item: str | None) -> dict[str, Any]:
-    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True)
+def gate_freeze_carrier_refresh_binding(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
+    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True, surface=surface)
+    refresh_command = "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+    if surface != "merge_ready":
+        refresh_command = f"{refresh_command} --surface {surface}"
     refresh_needed = [
         action for action in dry_run_payload.get("refresh_needed", []) if isinstance(action, dict)
     ]
@@ -17414,10 +17466,10 @@ def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str,
         "subject": "carrier_refresh",
         "why_blocking": "hosted admission cannot trust a frozen snapshot while carrier refresh dry-run reports pending updates.",
         "fallback_to": "carrier_refresh",
-        "refresh_suggestion": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "refresh_suggestion": refresh_command
         if refresh_needed
         else None,
-        "next_action": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "next_action": refresh_command
         if refresh_needed
         else dry_run_payload.get("fallback_to"),
     }
@@ -18408,9 +18460,9 @@ def gate_freeze_payload(args: argparse.Namespace, *, operation: str) -> dict[str
         "status_surface": status_binding,
         "pr_metadata": pr_metadata,
         "pr_body_pin": gate_freeze_pr_body_pin_binding(pr_metadata),
-        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha),
+        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha, surface=args.surface),
         "shadow_parity": gate_freeze_shadow_binding(target_root, governance_surface),
-        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"]),
+        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"], surface=args.surface),
         "shadow_freshness": gate_freeze_shadow_freshness_binding(target_root, governance_surface),
         "suite_validation": suite_validation,
         "suite_evidence_validation": suite_evidence_validation,
@@ -18591,7 +18643,7 @@ def hosted_freeze_admission_payload(
             "failure_classifier": failure_classifier_payload([]),
         }
 
-    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready"} else "merge_ready"
+    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready", "closeout"} else "merge_ready"
     freeze_args = argparse.Namespace(
         target=str(target_root),
         output=output_relative,

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -679,6 +679,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     carrier.add_argument("--dry-run", action="store_true", default=True, help="Preview refresh actions without writing files; this is the default")
     carrier.add_argument("--write", dest="dry_run", action="store_false", help="Write Loom-owned carrier metadata refreshes")
     carrier.add_argument("--apply", dest="dry_run", action="store_false", help="Apply explicit versioned carrier closeout metadata writes")
+    carrier.add_argument(
+        "--surface",
+        choices=("pre_review", "review", "merge_ready", "closeout"),
+        default="merge_ready",
+        help="Gate surface whose carrier refresh drift policy should be evaluated",
+    )
     carrier.add_argument("--terminal-state", choices=tuple(sorted(TERMINAL_CLOSEOUT_STATES)), help="Terminal closeout state to write")
     carrier.add_argument("--issue", help="Issue locator or number bound to terminal closeout")
     carrier.add_argument("--pr", help="PR locator or number bound to terminal closeout")
@@ -821,7 +827,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     gate_freeze.add_argument("--compare-body-file", help="Optional repo-relative post-edit/readback PR body markdown to compare against --body-file")
     gate_freeze.add_argument(
         "--surface",
-        choices=("pre_review", "review", "merge_ready"),
+        choices=("pre_review", "review", "merge_ready", "closeout"),
         default="merge_ready",
         help="Gate surface whose PR metadata contract is consumed by the snapshot",
     )
@@ -14144,7 +14150,14 @@ def apply_shadow_evidence_actions(target_root: Path, actions: list[dict[str, Any
             write_json_file(path, payload)
 
 
-def carrier_refresh_payload(target_root: Path, output_relative: str, expected_item: str | None, *, dry_run: bool) -> dict[str, Any]:
+def carrier_refresh_payload(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    dry_run: bool,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
     runtime_state = runtime_state_payload(target_root)
     context, context_errors = load_context(target_root, output_relative, expected_item)
     idle_context = is_idle_context_errors(context_errors)
@@ -14196,7 +14209,13 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         assert context
         review_record, review_path, review_errors = load_review_record(target_root, context["item_id"], context["review_entry"])
         spec_review_path = default_spec_review_path(context["item_id"])
-        allowed_paths = allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+        terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+        allowed_paths = (
+            allowed_terminal_closeout_carrier_paths(context, review_path, spec_review_path)
+            if terminal_closeout_surface
+            else allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        )
         if review_errors or review_record is None:
             review_status = {"status": "missing", "path": review_path, "missing_inputs": review_errors or [f"missing review artifact: {review_path}"]}
         else:
@@ -14205,7 +14224,17 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
                 reviewed_head=str(review_record.get("reviewed_head", "")),
                 allowed_paths=allowed_paths,
             )
-            review_status = {"path": review_path, "head_binding": binding, "missing_inputs": binding_errors}
+            review_status = {
+                "path": review_path,
+                "head_binding": binding,
+                "missing_inputs": binding_errors,
+                "surface": surface,
+                "allowed_paths_policy": (
+                    "terminal closeout carrier paths only; requires terminal checkpoint"
+                    if terminal_closeout_surface
+                    else "post-review carrier paths only"
+                ),
+            }
             if binding.get("status") in {"implementation-drift-only", "stale"}:
                 review_status["status"] = "block"
                 missing_inputs.append("review artifact is stale because non-carrier drift is present")
@@ -14238,6 +14267,7 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         "missing_inputs": missing_inputs,
         "fallback_to": None if result == "pass" else "adoption",
         "dry_run": dry_run,
+        "surface": surface,
         "runtime_state": runtime_state,
         "actions": actions,
         "refresh_needed": refresh_needed,
@@ -15188,7 +15218,7 @@ def handle_carrier(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     if args.operation == "closeout-sync":
         return emit(carrier_closeout_sync_payload(target_root, args.output, args.item, args))
-    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run))
+    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run, surface=args.surface))
 
 
 def github_commit_pulls(root: Path, owner: str, repo_name: str, head_sha: str) -> tuple[list[dict[str, Any]], list[str]]:
@@ -17178,7 +17208,7 @@ def gate_freeze_command_surface(context: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None) -> dict[str, Any]:
+def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None, surface: str = "merge_ready") -> dict[str, Any]:
     review_entry = context.get("review_entry")
     review_relative = str(review_entry) if isinstance(review_entry, str) and review_entry else None
     review_record, review_path, review_errors = load_review_record(
@@ -17212,11 +17242,18 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
     binding["decision"] = review_record.get("decision")
     binding["kind"] = review_record.get("kind")
     binding["reviewed_head"] = review_record.get("reviewed_head")
+    normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+    terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+    allowed_paths = (
+        allowed_terminal_closeout_carrier_paths(context, review_path)
+        if terminal_closeout_surface
+        else allowed_post_review_carrier_paths(context, review_path)
+    )
     head_binding, head_errors = review_head_binding_for_head(
         context["target_root"],
         reviewed_head=review_record.get("reviewed_head") if isinstance(review_record.get("reviewed_head"), str) else None,
         target_head=head_sha or git_head_sha(context["target_root"]),
-        allowed_paths=allowed_post_review_carrier_paths(context, review_path),
+        allowed_paths=allowed_paths,
     )
     binding["head_binding"] = head_binding
     binding["current_head"] = head_binding.get("current_head")
@@ -17230,6 +17267,12 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
         current_validation_summary=context.get("latest_validation_summary"),
     )
     binding["semantic_review_disposition"] = disposition
+    binding["surface"] = surface
+    binding["allowed_paths_policy"] = (
+        "terminal closeout carrier paths only; requires terminal checkpoint"
+        if terminal_closeout_surface
+        else "post-review carrier paths only"
+    )
     binding["missing_inputs"] = [*head_errors, *disposition_errors]
     if review_record.get("decision") != "allow":
         binding["missing_inputs"].append("review artifact decision is not allow")
@@ -17384,8 +17427,17 @@ def gate_freeze_shadow_freshness_binding(target_root: Path, governance_surface: 
     }
 
 
-def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str, expected_item: str | None) -> dict[str, Any]:
-    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True)
+def gate_freeze_carrier_refresh_binding(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
+    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True, surface=surface)
+    refresh_command = "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+    if surface != "merge_ready":
+        refresh_command = f"{refresh_command} --surface {surface}"
     refresh_needed = [
         action for action in dry_run_payload.get("refresh_needed", []) if isinstance(action, dict)
     ]
@@ -17414,10 +17466,10 @@ def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str,
         "subject": "carrier_refresh",
         "why_blocking": "hosted admission cannot trust a frozen snapshot while carrier refresh dry-run reports pending updates.",
         "fallback_to": "carrier_refresh",
-        "refresh_suggestion": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "refresh_suggestion": refresh_command
         if refresh_needed
         else None,
-        "next_action": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "next_action": refresh_command
         if refresh_needed
         else dry_run_payload.get("fallback_to"),
     }
@@ -18408,9 +18460,9 @@ def gate_freeze_payload(args: argparse.Namespace, *, operation: str) -> dict[str
         "status_surface": status_binding,
         "pr_metadata": pr_metadata,
         "pr_body_pin": gate_freeze_pr_body_pin_binding(pr_metadata),
-        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha),
+        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha, surface=args.surface),
         "shadow_parity": gate_freeze_shadow_binding(target_root, governance_surface),
-        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"]),
+        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"], surface=args.surface),
         "shadow_freshness": gate_freeze_shadow_freshness_binding(target_root, governance_surface),
         "suite_validation": suite_validation,
         "suite_evidence_validation": suite_evidence_validation,
@@ -18591,7 +18643,7 @@ def hosted_freeze_admission_payload(
             "failure_classifier": failure_classifier_payload([]),
         }
 
-    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready"} else "merge_ready"
+    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready", "closeout"} else "merge_ready"
     freeze_args = argparse.Namespace(
         target=str(target_root),
         output=output_relative,

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -679,6 +679,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     carrier.add_argument("--dry-run", action="store_true", default=True, help="Preview refresh actions without writing files; this is the default")
     carrier.add_argument("--write", dest="dry_run", action="store_false", help="Write Loom-owned carrier metadata refreshes")
     carrier.add_argument("--apply", dest="dry_run", action="store_false", help="Apply explicit versioned carrier closeout metadata writes")
+    carrier.add_argument(
+        "--surface",
+        choices=("pre_review", "review", "merge_ready", "closeout"),
+        default="merge_ready",
+        help="Gate surface whose carrier refresh drift policy should be evaluated",
+    )
     carrier.add_argument("--terminal-state", choices=tuple(sorted(TERMINAL_CLOSEOUT_STATES)), help="Terminal closeout state to write")
     carrier.add_argument("--issue", help="Issue locator or number bound to terminal closeout")
     carrier.add_argument("--pr", help="PR locator or number bound to terminal closeout")
@@ -821,7 +827,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     gate_freeze.add_argument("--compare-body-file", help="Optional repo-relative post-edit/readback PR body markdown to compare against --body-file")
     gate_freeze.add_argument(
         "--surface",
-        choices=("pre_review", "review", "merge_ready"),
+        choices=("pre_review", "review", "merge_ready", "closeout"),
         default="merge_ready",
         help="Gate surface whose PR metadata contract is consumed by the snapshot",
     )
@@ -14144,7 +14150,14 @@ def apply_shadow_evidence_actions(target_root: Path, actions: list[dict[str, Any
             write_json_file(path, payload)
 
 
-def carrier_refresh_payload(target_root: Path, output_relative: str, expected_item: str | None, *, dry_run: bool) -> dict[str, Any]:
+def carrier_refresh_payload(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    dry_run: bool,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
     runtime_state = runtime_state_payload(target_root)
     context, context_errors = load_context(target_root, output_relative, expected_item)
     idle_context = is_idle_context_errors(context_errors)
@@ -14196,7 +14209,13 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         assert context
         review_record, review_path, review_errors = load_review_record(target_root, context["item_id"], context["review_entry"])
         spec_review_path = default_spec_review_path(context["item_id"])
-        allowed_paths = allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+        terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+        allowed_paths = (
+            allowed_terminal_closeout_carrier_paths(context, review_path, spec_review_path)
+            if terminal_closeout_surface
+            else allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        )
         if review_errors or review_record is None:
             review_status = {"status": "missing", "path": review_path, "missing_inputs": review_errors or [f"missing review artifact: {review_path}"]}
         else:
@@ -14205,7 +14224,17 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
                 reviewed_head=str(review_record.get("reviewed_head", "")),
                 allowed_paths=allowed_paths,
             )
-            review_status = {"path": review_path, "head_binding": binding, "missing_inputs": binding_errors}
+            review_status = {
+                "path": review_path,
+                "head_binding": binding,
+                "missing_inputs": binding_errors,
+                "surface": surface,
+                "allowed_paths_policy": (
+                    "terminal closeout carrier paths only; requires terminal checkpoint"
+                    if terminal_closeout_surface
+                    else "post-review carrier paths only"
+                ),
+            }
             if binding.get("status") in {"implementation-drift-only", "stale"}:
                 review_status["status"] = "block"
                 missing_inputs.append("review artifact is stale because non-carrier drift is present")
@@ -14238,6 +14267,7 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         "missing_inputs": missing_inputs,
         "fallback_to": None if result == "pass" else "adoption",
         "dry_run": dry_run,
+        "surface": surface,
         "runtime_state": runtime_state,
         "actions": actions,
         "refresh_needed": refresh_needed,
@@ -15188,7 +15218,7 @@ def handle_carrier(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     if args.operation == "closeout-sync":
         return emit(carrier_closeout_sync_payload(target_root, args.output, args.item, args))
-    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run))
+    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run, surface=args.surface))
 
 
 def github_commit_pulls(root: Path, owner: str, repo_name: str, head_sha: str) -> tuple[list[dict[str, Any]], list[str]]:
@@ -17178,7 +17208,7 @@ def gate_freeze_command_surface(context: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None) -> dict[str, Any]:
+def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None, surface: str = "merge_ready") -> dict[str, Any]:
     review_entry = context.get("review_entry")
     review_relative = str(review_entry) if isinstance(review_entry, str) and review_entry else None
     review_record, review_path, review_errors = load_review_record(
@@ -17212,11 +17242,18 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
     binding["decision"] = review_record.get("decision")
     binding["kind"] = review_record.get("kind")
     binding["reviewed_head"] = review_record.get("reviewed_head")
+    normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+    terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+    allowed_paths = (
+        allowed_terminal_closeout_carrier_paths(context, review_path)
+        if terminal_closeout_surface
+        else allowed_post_review_carrier_paths(context, review_path)
+    )
     head_binding, head_errors = review_head_binding_for_head(
         context["target_root"],
         reviewed_head=review_record.get("reviewed_head") if isinstance(review_record.get("reviewed_head"), str) else None,
         target_head=head_sha or git_head_sha(context["target_root"]),
-        allowed_paths=allowed_post_review_carrier_paths(context, review_path),
+        allowed_paths=allowed_paths,
     )
     binding["head_binding"] = head_binding
     binding["current_head"] = head_binding.get("current_head")
@@ -17230,6 +17267,12 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
         current_validation_summary=context.get("latest_validation_summary"),
     )
     binding["semantic_review_disposition"] = disposition
+    binding["surface"] = surface
+    binding["allowed_paths_policy"] = (
+        "terminal closeout carrier paths only; requires terminal checkpoint"
+        if terminal_closeout_surface
+        else "post-review carrier paths only"
+    )
     binding["missing_inputs"] = [*head_errors, *disposition_errors]
     if review_record.get("decision") != "allow":
         binding["missing_inputs"].append("review artifact decision is not allow")
@@ -17384,8 +17427,17 @@ def gate_freeze_shadow_freshness_binding(target_root: Path, governance_surface: 
     }
 
 
-def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str, expected_item: str | None) -> dict[str, Any]:
-    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True)
+def gate_freeze_carrier_refresh_binding(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
+    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True, surface=surface)
+    refresh_command = "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+    if surface != "merge_ready":
+        refresh_command = f"{refresh_command} --surface {surface}"
     refresh_needed = [
         action for action in dry_run_payload.get("refresh_needed", []) if isinstance(action, dict)
     ]
@@ -17414,10 +17466,10 @@ def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str,
         "subject": "carrier_refresh",
         "why_blocking": "hosted admission cannot trust a frozen snapshot while carrier refresh dry-run reports pending updates.",
         "fallback_to": "carrier_refresh",
-        "refresh_suggestion": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "refresh_suggestion": refresh_command
         if refresh_needed
         else None,
-        "next_action": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "next_action": refresh_command
         if refresh_needed
         else dry_run_payload.get("fallback_to"),
     }
@@ -18408,9 +18460,9 @@ def gate_freeze_payload(args: argparse.Namespace, *, operation: str) -> dict[str
         "status_surface": status_binding,
         "pr_metadata": pr_metadata,
         "pr_body_pin": gate_freeze_pr_body_pin_binding(pr_metadata),
-        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha),
+        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha, surface=args.surface),
         "shadow_parity": gate_freeze_shadow_binding(target_root, governance_surface),
-        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"]),
+        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"], surface=args.surface),
         "shadow_freshness": gate_freeze_shadow_freshness_binding(target_root, governance_surface),
         "suite_validation": suite_validation,
         "suite_evidence_validation": suite_evidence_validation,
@@ -18591,7 +18643,7 @@ def hosted_freeze_admission_payload(
             "failure_classifier": failure_classifier_payload([]),
         }
 
-    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready"} else "merge_ready"
+    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready", "closeout"} else "merge_ready"
     freeze_args = argparse.Namespace(
         target=str(target_root),
         output=output_relative,

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -679,6 +679,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     carrier.add_argument("--dry-run", action="store_true", default=True, help="Preview refresh actions without writing files; this is the default")
     carrier.add_argument("--write", dest="dry_run", action="store_false", help="Write Loom-owned carrier metadata refreshes")
     carrier.add_argument("--apply", dest="dry_run", action="store_false", help="Apply explicit versioned carrier closeout metadata writes")
+    carrier.add_argument(
+        "--surface",
+        choices=("pre_review", "review", "merge_ready", "closeout"),
+        default="merge_ready",
+        help="Gate surface whose carrier refresh drift policy should be evaluated",
+    )
     carrier.add_argument("--terminal-state", choices=tuple(sorted(TERMINAL_CLOSEOUT_STATES)), help="Terminal closeout state to write")
     carrier.add_argument("--issue", help="Issue locator or number bound to terminal closeout")
     carrier.add_argument("--pr", help="PR locator or number bound to terminal closeout")
@@ -821,7 +827,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     gate_freeze.add_argument("--compare-body-file", help="Optional repo-relative post-edit/readback PR body markdown to compare against --body-file")
     gate_freeze.add_argument(
         "--surface",
-        choices=("pre_review", "review", "merge_ready"),
+        choices=("pre_review", "review", "merge_ready", "closeout"),
         default="merge_ready",
         help="Gate surface whose PR metadata contract is consumed by the snapshot",
     )
@@ -14144,7 +14150,14 @@ def apply_shadow_evidence_actions(target_root: Path, actions: list[dict[str, Any
             write_json_file(path, payload)
 
 
-def carrier_refresh_payload(target_root: Path, output_relative: str, expected_item: str | None, *, dry_run: bool) -> dict[str, Any]:
+def carrier_refresh_payload(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    dry_run: bool,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
     runtime_state = runtime_state_payload(target_root)
     context, context_errors = load_context(target_root, output_relative, expected_item)
     idle_context = is_idle_context_errors(context_errors)
@@ -14196,7 +14209,13 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         assert context
         review_record, review_path, review_errors = load_review_record(target_root, context["item_id"], context["review_entry"])
         spec_review_path = default_spec_review_path(context["item_id"])
-        allowed_paths = allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+        terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+        allowed_paths = (
+            allowed_terminal_closeout_carrier_paths(context, review_path, spec_review_path)
+            if terminal_closeout_surface
+            else allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        )
         if review_errors or review_record is None:
             review_status = {"status": "missing", "path": review_path, "missing_inputs": review_errors or [f"missing review artifact: {review_path}"]}
         else:
@@ -14205,7 +14224,17 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
                 reviewed_head=str(review_record.get("reviewed_head", "")),
                 allowed_paths=allowed_paths,
             )
-            review_status = {"path": review_path, "head_binding": binding, "missing_inputs": binding_errors}
+            review_status = {
+                "path": review_path,
+                "head_binding": binding,
+                "missing_inputs": binding_errors,
+                "surface": surface,
+                "allowed_paths_policy": (
+                    "terminal closeout carrier paths only; requires terminal checkpoint"
+                    if terminal_closeout_surface
+                    else "post-review carrier paths only"
+                ),
+            }
             if binding.get("status") in {"implementation-drift-only", "stale"}:
                 review_status["status"] = "block"
                 missing_inputs.append("review artifact is stale because non-carrier drift is present")
@@ -14238,6 +14267,7 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         "missing_inputs": missing_inputs,
         "fallback_to": None if result == "pass" else "adoption",
         "dry_run": dry_run,
+        "surface": surface,
         "runtime_state": runtime_state,
         "actions": actions,
         "refresh_needed": refresh_needed,
@@ -15188,7 +15218,7 @@ def handle_carrier(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     if args.operation == "closeout-sync":
         return emit(carrier_closeout_sync_payload(target_root, args.output, args.item, args))
-    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run))
+    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run, surface=args.surface))
 
 
 def github_commit_pulls(root: Path, owner: str, repo_name: str, head_sha: str) -> tuple[list[dict[str, Any]], list[str]]:
@@ -17178,7 +17208,7 @@ def gate_freeze_command_surface(context: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None) -> dict[str, Any]:
+def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None, surface: str = "merge_ready") -> dict[str, Any]:
     review_entry = context.get("review_entry")
     review_relative = str(review_entry) if isinstance(review_entry, str) and review_entry else None
     review_record, review_path, review_errors = load_review_record(
@@ -17212,11 +17242,18 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
     binding["decision"] = review_record.get("decision")
     binding["kind"] = review_record.get("kind")
     binding["reviewed_head"] = review_record.get("reviewed_head")
+    normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+    terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+    allowed_paths = (
+        allowed_terminal_closeout_carrier_paths(context, review_path)
+        if terminal_closeout_surface
+        else allowed_post_review_carrier_paths(context, review_path)
+    )
     head_binding, head_errors = review_head_binding_for_head(
         context["target_root"],
         reviewed_head=review_record.get("reviewed_head") if isinstance(review_record.get("reviewed_head"), str) else None,
         target_head=head_sha or git_head_sha(context["target_root"]),
-        allowed_paths=allowed_post_review_carrier_paths(context, review_path),
+        allowed_paths=allowed_paths,
     )
     binding["head_binding"] = head_binding
     binding["current_head"] = head_binding.get("current_head")
@@ -17230,6 +17267,12 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
         current_validation_summary=context.get("latest_validation_summary"),
     )
     binding["semantic_review_disposition"] = disposition
+    binding["surface"] = surface
+    binding["allowed_paths_policy"] = (
+        "terminal closeout carrier paths only; requires terminal checkpoint"
+        if terminal_closeout_surface
+        else "post-review carrier paths only"
+    )
     binding["missing_inputs"] = [*head_errors, *disposition_errors]
     if review_record.get("decision") != "allow":
         binding["missing_inputs"].append("review artifact decision is not allow")
@@ -17384,8 +17427,17 @@ def gate_freeze_shadow_freshness_binding(target_root: Path, governance_surface: 
     }
 
 
-def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str, expected_item: str | None) -> dict[str, Any]:
-    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True)
+def gate_freeze_carrier_refresh_binding(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
+    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True, surface=surface)
+    refresh_command = "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+    if surface != "merge_ready":
+        refresh_command = f"{refresh_command} --surface {surface}"
     refresh_needed = [
         action for action in dry_run_payload.get("refresh_needed", []) if isinstance(action, dict)
     ]
@@ -17414,10 +17466,10 @@ def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str,
         "subject": "carrier_refresh",
         "why_blocking": "hosted admission cannot trust a frozen snapshot while carrier refresh dry-run reports pending updates.",
         "fallback_to": "carrier_refresh",
-        "refresh_suggestion": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "refresh_suggestion": refresh_command
         if refresh_needed
         else None,
-        "next_action": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "next_action": refresh_command
         if refresh_needed
         else dry_run_payload.get("fallback_to"),
     }
@@ -18408,9 +18460,9 @@ def gate_freeze_payload(args: argparse.Namespace, *, operation: str) -> dict[str
         "status_surface": status_binding,
         "pr_metadata": pr_metadata,
         "pr_body_pin": gate_freeze_pr_body_pin_binding(pr_metadata),
-        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha),
+        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha, surface=args.surface),
         "shadow_parity": gate_freeze_shadow_binding(target_root, governance_surface),
-        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"]),
+        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"], surface=args.surface),
         "shadow_freshness": gate_freeze_shadow_freshness_binding(target_root, governance_surface),
         "suite_validation": suite_validation,
         "suite_evidence_validation": suite_evidence_validation,
@@ -18591,7 +18643,7 @@ def hosted_freeze_admission_payload(
             "failure_classifier": failure_classifier_payload([]),
         }
 
-    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready"} else "merge_ready"
+    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready", "closeout"} else "merge_ready"
     freeze_args = argparse.Namespace(
         target=str(target_root),
         output=output_relative,

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -679,6 +679,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     carrier.add_argument("--dry-run", action="store_true", default=True, help="Preview refresh actions without writing files; this is the default")
     carrier.add_argument("--write", dest="dry_run", action="store_false", help="Write Loom-owned carrier metadata refreshes")
     carrier.add_argument("--apply", dest="dry_run", action="store_false", help="Apply explicit versioned carrier closeout metadata writes")
+    carrier.add_argument(
+        "--surface",
+        choices=("pre_review", "review", "merge_ready", "closeout"),
+        default="merge_ready",
+        help="Gate surface whose carrier refresh drift policy should be evaluated",
+    )
     carrier.add_argument("--terminal-state", choices=tuple(sorted(TERMINAL_CLOSEOUT_STATES)), help="Terminal closeout state to write")
     carrier.add_argument("--issue", help="Issue locator or number bound to terminal closeout")
     carrier.add_argument("--pr", help="PR locator or number bound to terminal closeout")
@@ -821,7 +827,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     gate_freeze.add_argument("--compare-body-file", help="Optional repo-relative post-edit/readback PR body markdown to compare against --body-file")
     gate_freeze.add_argument(
         "--surface",
-        choices=("pre_review", "review", "merge_ready"),
+        choices=("pre_review", "review", "merge_ready", "closeout"),
         default="merge_ready",
         help="Gate surface whose PR metadata contract is consumed by the snapshot",
     )
@@ -14144,7 +14150,14 @@ def apply_shadow_evidence_actions(target_root: Path, actions: list[dict[str, Any
             write_json_file(path, payload)
 
 
-def carrier_refresh_payload(target_root: Path, output_relative: str, expected_item: str | None, *, dry_run: bool) -> dict[str, Any]:
+def carrier_refresh_payload(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    dry_run: bool,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
     runtime_state = runtime_state_payload(target_root)
     context, context_errors = load_context(target_root, output_relative, expected_item)
     idle_context = is_idle_context_errors(context_errors)
@@ -14196,7 +14209,13 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         assert context
         review_record, review_path, review_errors = load_review_record(target_root, context["item_id"], context["review_entry"])
         spec_review_path = default_spec_review_path(context["item_id"])
-        allowed_paths = allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+        terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+        allowed_paths = (
+            allowed_terminal_closeout_carrier_paths(context, review_path, spec_review_path)
+            if terminal_closeout_surface
+            else allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        )
         if review_errors or review_record is None:
             review_status = {"status": "missing", "path": review_path, "missing_inputs": review_errors or [f"missing review artifact: {review_path}"]}
         else:
@@ -14205,7 +14224,17 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
                 reviewed_head=str(review_record.get("reviewed_head", "")),
                 allowed_paths=allowed_paths,
             )
-            review_status = {"path": review_path, "head_binding": binding, "missing_inputs": binding_errors}
+            review_status = {
+                "path": review_path,
+                "head_binding": binding,
+                "missing_inputs": binding_errors,
+                "surface": surface,
+                "allowed_paths_policy": (
+                    "terminal closeout carrier paths only; requires terminal checkpoint"
+                    if terminal_closeout_surface
+                    else "post-review carrier paths only"
+                ),
+            }
             if binding.get("status") in {"implementation-drift-only", "stale"}:
                 review_status["status"] = "block"
                 missing_inputs.append("review artifact is stale because non-carrier drift is present")
@@ -14238,6 +14267,7 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         "missing_inputs": missing_inputs,
         "fallback_to": None if result == "pass" else "adoption",
         "dry_run": dry_run,
+        "surface": surface,
         "runtime_state": runtime_state,
         "actions": actions,
         "refresh_needed": refresh_needed,
@@ -15188,7 +15218,7 @@ def handle_carrier(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     if args.operation == "closeout-sync":
         return emit(carrier_closeout_sync_payload(target_root, args.output, args.item, args))
-    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run))
+    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run, surface=args.surface))
 
 
 def github_commit_pulls(root: Path, owner: str, repo_name: str, head_sha: str) -> tuple[list[dict[str, Any]], list[str]]:
@@ -17178,7 +17208,7 @@ def gate_freeze_command_surface(context: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None) -> dict[str, Any]:
+def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None, surface: str = "merge_ready") -> dict[str, Any]:
     review_entry = context.get("review_entry")
     review_relative = str(review_entry) if isinstance(review_entry, str) and review_entry else None
     review_record, review_path, review_errors = load_review_record(
@@ -17212,11 +17242,18 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
     binding["decision"] = review_record.get("decision")
     binding["kind"] = review_record.get("kind")
     binding["reviewed_head"] = review_record.get("reviewed_head")
+    normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+    terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+    allowed_paths = (
+        allowed_terminal_closeout_carrier_paths(context, review_path)
+        if terminal_closeout_surface
+        else allowed_post_review_carrier_paths(context, review_path)
+    )
     head_binding, head_errors = review_head_binding_for_head(
         context["target_root"],
         reviewed_head=review_record.get("reviewed_head") if isinstance(review_record.get("reviewed_head"), str) else None,
         target_head=head_sha or git_head_sha(context["target_root"]),
-        allowed_paths=allowed_post_review_carrier_paths(context, review_path),
+        allowed_paths=allowed_paths,
     )
     binding["head_binding"] = head_binding
     binding["current_head"] = head_binding.get("current_head")
@@ -17230,6 +17267,12 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
         current_validation_summary=context.get("latest_validation_summary"),
     )
     binding["semantic_review_disposition"] = disposition
+    binding["surface"] = surface
+    binding["allowed_paths_policy"] = (
+        "terminal closeout carrier paths only; requires terminal checkpoint"
+        if terminal_closeout_surface
+        else "post-review carrier paths only"
+    )
     binding["missing_inputs"] = [*head_errors, *disposition_errors]
     if review_record.get("decision") != "allow":
         binding["missing_inputs"].append("review artifact decision is not allow")
@@ -17384,8 +17427,17 @@ def gate_freeze_shadow_freshness_binding(target_root: Path, governance_surface: 
     }
 
 
-def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str, expected_item: str | None) -> dict[str, Any]:
-    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True)
+def gate_freeze_carrier_refresh_binding(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
+    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True, surface=surface)
+    refresh_command = "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+    if surface != "merge_ready":
+        refresh_command = f"{refresh_command} --surface {surface}"
     refresh_needed = [
         action for action in dry_run_payload.get("refresh_needed", []) if isinstance(action, dict)
     ]
@@ -17414,10 +17466,10 @@ def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str,
         "subject": "carrier_refresh",
         "why_blocking": "hosted admission cannot trust a frozen snapshot while carrier refresh dry-run reports pending updates.",
         "fallback_to": "carrier_refresh",
-        "refresh_suggestion": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "refresh_suggestion": refresh_command
         if refresh_needed
         else None,
-        "next_action": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "next_action": refresh_command
         if refresh_needed
         else dry_run_payload.get("fallback_to"),
     }
@@ -18408,9 +18460,9 @@ def gate_freeze_payload(args: argparse.Namespace, *, operation: str) -> dict[str
         "status_surface": status_binding,
         "pr_metadata": pr_metadata,
         "pr_body_pin": gate_freeze_pr_body_pin_binding(pr_metadata),
-        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha),
+        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha, surface=args.surface),
         "shadow_parity": gate_freeze_shadow_binding(target_root, governance_surface),
-        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"]),
+        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"], surface=args.surface),
         "shadow_freshness": gate_freeze_shadow_freshness_binding(target_root, governance_surface),
         "suite_validation": suite_validation,
         "suite_evidence_validation": suite_evidence_validation,
@@ -18591,7 +18643,7 @@ def hosted_freeze_admission_payload(
             "failure_classifier": failure_classifier_payload([]),
         }
 
-    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready"} else "merge_ready"
+    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready", "closeout"} else "merge_ready"
     freeze_args = argparse.Namespace(
         target=str(target_root),
         output=output_relative,

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -679,6 +679,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     carrier.add_argument("--dry-run", action="store_true", default=True, help="Preview refresh actions without writing files; this is the default")
     carrier.add_argument("--write", dest="dry_run", action="store_false", help="Write Loom-owned carrier metadata refreshes")
     carrier.add_argument("--apply", dest="dry_run", action="store_false", help="Apply explicit versioned carrier closeout metadata writes")
+    carrier.add_argument(
+        "--surface",
+        choices=("pre_review", "review", "merge_ready", "closeout"),
+        default="merge_ready",
+        help="Gate surface whose carrier refresh drift policy should be evaluated",
+    )
     carrier.add_argument("--terminal-state", choices=tuple(sorted(TERMINAL_CLOSEOUT_STATES)), help="Terminal closeout state to write")
     carrier.add_argument("--issue", help="Issue locator or number bound to terminal closeout")
     carrier.add_argument("--pr", help="PR locator or number bound to terminal closeout")
@@ -821,7 +827,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     gate_freeze.add_argument("--compare-body-file", help="Optional repo-relative post-edit/readback PR body markdown to compare against --body-file")
     gate_freeze.add_argument(
         "--surface",
-        choices=("pre_review", "review", "merge_ready"),
+        choices=("pre_review", "review", "merge_ready", "closeout"),
         default="merge_ready",
         help="Gate surface whose PR metadata contract is consumed by the snapshot",
     )
@@ -14144,7 +14150,14 @@ def apply_shadow_evidence_actions(target_root: Path, actions: list[dict[str, Any
             write_json_file(path, payload)
 
 
-def carrier_refresh_payload(target_root: Path, output_relative: str, expected_item: str | None, *, dry_run: bool) -> dict[str, Any]:
+def carrier_refresh_payload(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    dry_run: bool,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
     runtime_state = runtime_state_payload(target_root)
     context, context_errors = load_context(target_root, output_relative, expected_item)
     idle_context = is_idle_context_errors(context_errors)
@@ -14196,7 +14209,13 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         assert context
         review_record, review_path, review_errors = load_review_record(target_root, context["item_id"], context["review_entry"])
         spec_review_path = default_spec_review_path(context["item_id"])
-        allowed_paths = allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+        terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+        allowed_paths = (
+            allowed_terminal_closeout_carrier_paths(context, review_path, spec_review_path)
+            if terminal_closeout_surface
+            else allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        )
         if review_errors or review_record is None:
             review_status = {"status": "missing", "path": review_path, "missing_inputs": review_errors or [f"missing review artifact: {review_path}"]}
         else:
@@ -14205,7 +14224,17 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
                 reviewed_head=str(review_record.get("reviewed_head", "")),
                 allowed_paths=allowed_paths,
             )
-            review_status = {"path": review_path, "head_binding": binding, "missing_inputs": binding_errors}
+            review_status = {
+                "path": review_path,
+                "head_binding": binding,
+                "missing_inputs": binding_errors,
+                "surface": surface,
+                "allowed_paths_policy": (
+                    "terminal closeout carrier paths only; requires terminal checkpoint"
+                    if terminal_closeout_surface
+                    else "post-review carrier paths only"
+                ),
+            }
             if binding.get("status") in {"implementation-drift-only", "stale"}:
                 review_status["status"] = "block"
                 missing_inputs.append("review artifact is stale because non-carrier drift is present")
@@ -14238,6 +14267,7 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         "missing_inputs": missing_inputs,
         "fallback_to": None if result == "pass" else "adoption",
         "dry_run": dry_run,
+        "surface": surface,
         "runtime_state": runtime_state,
         "actions": actions,
         "refresh_needed": refresh_needed,
@@ -15188,7 +15218,7 @@ def handle_carrier(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     if args.operation == "closeout-sync":
         return emit(carrier_closeout_sync_payload(target_root, args.output, args.item, args))
-    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run))
+    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run, surface=args.surface))
 
 
 def github_commit_pulls(root: Path, owner: str, repo_name: str, head_sha: str) -> tuple[list[dict[str, Any]], list[str]]:
@@ -17178,7 +17208,7 @@ def gate_freeze_command_surface(context: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None) -> dict[str, Any]:
+def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None, surface: str = "merge_ready") -> dict[str, Any]:
     review_entry = context.get("review_entry")
     review_relative = str(review_entry) if isinstance(review_entry, str) and review_entry else None
     review_record, review_path, review_errors = load_review_record(
@@ -17212,11 +17242,18 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
     binding["decision"] = review_record.get("decision")
     binding["kind"] = review_record.get("kind")
     binding["reviewed_head"] = review_record.get("reviewed_head")
+    normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+    terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+    allowed_paths = (
+        allowed_terminal_closeout_carrier_paths(context, review_path)
+        if terminal_closeout_surface
+        else allowed_post_review_carrier_paths(context, review_path)
+    )
     head_binding, head_errors = review_head_binding_for_head(
         context["target_root"],
         reviewed_head=review_record.get("reviewed_head") if isinstance(review_record.get("reviewed_head"), str) else None,
         target_head=head_sha or git_head_sha(context["target_root"]),
-        allowed_paths=allowed_post_review_carrier_paths(context, review_path),
+        allowed_paths=allowed_paths,
     )
     binding["head_binding"] = head_binding
     binding["current_head"] = head_binding.get("current_head")
@@ -17230,6 +17267,12 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
         current_validation_summary=context.get("latest_validation_summary"),
     )
     binding["semantic_review_disposition"] = disposition
+    binding["surface"] = surface
+    binding["allowed_paths_policy"] = (
+        "terminal closeout carrier paths only; requires terminal checkpoint"
+        if terminal_closeout_surface
+        else "post-review carrier paths only"
+    )
     binding["missing_inputs"] = [*head_errors, *disposition_errors]
     if review_record.get("decision") != "allow":
         binding["missing_inputs"].append("review artifact decision is not allow")
@@ -17384,8 +17427,17 @@ def gate_freeze_shadow_freshness_binding(target_root: Path, governance_surface: 
     }
 
 
-def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str, expected_item: str | None) -> dict[str, Any]:
-    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True)
+def gate_freeze_carrier_refresh_binding(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
+    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True, surface=surface)
+    refresh_command = "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+    if surface != "merge_ready":
+        refresh_command = f"{refresh_command} --surface {surface}"
     refresh_needed = [
         action for action in dry_run_payload.get("refresh_needed", []) if isinstance(action, dict)
     ]
@@ -17414,10 +17466,10 @@ def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str,
         "subject": "carrier_refresh",
         "why_blocking": "hosted admission cannot trust a frozen snapshot while carrier refresh dry-run reports pending updates.",
         "fallback_to": "carrier_refresh",
-        "refresh_suggestion": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "refresh_suggestion": refresh_command
         if refresh_needed
         else None,
-        "next_action": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "next_action": refresh_command
         if refresh_needed
         else dry_run_payload.get("fallback_to"),
     }
@@ -18408,9 +18460,9 @@ def gate_freeze_payload(args: argparse.Namespace, *, operation: str) -> dict[str
         "status_surface": status_binding,
         "pr_metadata": pr_metadata,
         "pr_body_pin": gate_freeze_pr_body_pin_binding(pr_metadata),
-        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha),
+        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha, surface=args.surface),
         "shadow_parity": gate_freeze_shadow_binding(target_root, governance_surface),
-        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"]),
+        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"], surface=args.surface),
         "shadow_freshness": gate_freeze_shadow_freshness_binding(target_root, governance_surface),
         "suite_validation": suite_validation,
         "suite_evidence_validation": suite_evidence_validation,
@@ -18591,7 +18643,7 @@ def hosted_freeze_admission_payload(
             "failure_classifier": failure_classifier_payload([]),
         }
 
-    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready"} else "merge_ready"
+    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready", "closeout"} else "merge_ready"
     freeze_args = argparse.Namespace(
         target=str(target_root),
         output=output_relative,

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -679,6 +679,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     carrier.add_argument("--dry-run", action="store_true", default=True, help="Preview refresh actions without writing files; this is the default")
     carrier.add_argument("--write", dest="dry_run", action="store_false", help="Write Loom-owned carrier metadata refreshes")
     carrier.add_argument("--apply", dest="dry_run", action="store_false", help="Apply explicit versioned carrier closeout metadata writes")
+    carrier.add_argument(
+        "--surface",
+        choices=("pre_review", "review", "merge_ready", "closeout"),
+        default="merge_ready",
+        help="Gate surface whose carrier refresh drift policy should be evaluated",
+    )
     carrier.add_argument("--terminal-state", choices=tuple(sorted(TERMINAL_CLOSEOUT_STATES)), help="Terminal closeout state to write")
     carrier.add_argument("--issue", help="Issue locator or number bound to terminal closeout")
     carrier.add_argument("--pr", help="PR locator or number bound to terminal closeout")
@@ -821,7 +827,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     gate_freeze.add_argument("--compare-body-file", help="Optional repo-relative post-edit/readback PR body markdown to compare against --body-file")
     gate_freeze.add_argument(
         "--surface",
-        choices=("pre_review", "review", "merge_ready"),
+        choices=("pre_review", "review", "merge_ready", "closeout"),
         default="merge_ready",
         help="Gate surface whose PR metadata contract is consumed by the snapshot",
     )
@@ -14144,7 +14150,14 @@ def apply_shadow_evidence_actions(target_root: Path, actions: list[dict[str, Any
             write_json_file(path, payload)
 
 
-def carrier_refresh_payload(target_root: Path, output_relative: str, expected_item: str | None, *, dry_run: bool) -> dict[str, Any]:
+def carrier_refresh_payload(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    dry_run: bool,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
     runtime_state = runtime_state_payload(target_root)
     context, context_errors = load_context(target_root, output_relative, expected_item)
     idle_context = is_idle_context_errors(context_errors)
@@ -14196,7 +14209,13 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         assert context
         review_record, review_path, review_errors = load_review_record(target_root, context["item_id"], context["review_entry"])
         spec_review_path = default_spec_review_path(context["item_id"])
-        allowed_paths = allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+        terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+        allowed_paths = (
+            allowed_terminal_closeout_carrier_paths(context, review_path, spec_review_path)
+            if terminal_closeout_surface
+            else allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        )
         if review_errors or review_record is None:
             review_status = {"status": "missing", "path": review_path, "missing_inputs": review_errors or [f"missing review artifact: {review_path}"]}
         else:
@@ -14205,7 +14224,17 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
                 reviewed_head=str(review_record.get("reviewed_head", "")),
                 allowed_paths=allowed_paths,
             )
-            review_status = {"path": review_path, "head_binding": binding, "missing_inputs": binding_errors}
+            review_status = {
+                "path": review_path,
+                "head_binding": binding,
+                "missing_inputs": binding_errors,
+                "surface": surface,
+                "allowed_paths_policy": (
+                    "terminal closeout carrier paths only; requires terminal checkpoint"
+                    if terminal_closeout_surface
+                    else "post-review carrier paths only"
+                ),
+            }
             if binding.get("status") in {"implementation-drift-only", "stale"}:
                 review_status["status"] = "block"
                 missing_inputs.append("review artifact is stale because non-carrier drift is present")
@@ -14238,6 +14267,7 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         "missing_inputs": missing_inputs,
         "fallback_to": None if result == "pass" else "adoption",
         "dry_run": dry_run,
+        "surface": surface,
         "runtime_state": runtime_state,
         "actions": actions,
         "refresh_needed": refresh_needed,
@@ -15188,7 +15218,7 @@ def handle_carrier(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     if args.operation == "closeout-sync":
         return emit(carrier_closeout_sync_payload(target_root, args.output, args.item, args))
-    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run))
+    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run, surface=args.surface))
 
 
 def github_commit_pulls(root: Path, owner: str, repo_name: str, head_sha: str) -> tuple[list[dict[str, Any]], list[str]]:
@@ -17178,7 +17208,7 @@ def gate_freeze_command_surface(context: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None) -> dict[str, Any]:
+def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None, surface: str = "merge_ready") -> dict[str, Any]:
     review_entry = context.get("review_entry")
     review_relative = str(review_entry) if isinstance(review_entry, str) and review_entry else None
     review_record, review_path, review_errors = load_review_record(
@@ -17212,11 +17242,18 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
     binding["decision"] = review_record.get("decision")
     binding["kind"] = review_record.get("kind")
     binding["reviewed_head"] = review_record.get("reviewed_head")
+    normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+    terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+    allowed_paths = (
+        allowed_terminal_closeout_carrier_paths(context, review_path)
+        if terminal_closeout_surface
+        else allowed_post_review_carrier_paths(context, review_path)
+    )
     head_binding, head_errors = review_head_binding_for_head(
         context["target_root"],
         reviewed_head=review_record.get("reviewed_head") if isinstance(review_record.get("reviewed_head"), str) else None,
         target_head=head_sha or git_head_sha(context["target_root"]),
-        allowed_paths=allowed_post_review_carrier_paths(context, review_path),
+        allowed_paths=allowed_paths,
     )
     binding["head_binding"] = head_binding
     binding["current_head"] = head_binding.get("current_head")
@@ -17230,6 +17267,12 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
         current_validation_summary=context.get("latest_validation_summary"),
     )
     binding["semantic_review_disposition"] = disposition
+    binding["surface"] = surface
+    binding["allowed_paths_policy"] = (
+        "terminal closeout carrier paths only; requires terminal checkpoint"
+        if terminal_closeout_surface
+        else "post-review carrier paths only"
+    )
     binding["missing_inputs"] = [*head_errors, *disposition_errors]
     if review_record.get("decision") != "allow":
         binding["missing_inputs"].append("review artifact decision is not allow")
@@ -17384,8 +17427,17 @@ def gate_freeze_shadow_freshness_binding(target_root: Path, governance_surface: 
     }
 
 
-def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str, expected_item: str | None) -> dict[str, Any]:
-    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True)
+def gate_freeze_carrier_refresh_binding(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
+    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True, surface=surface)
+    refresh_command = "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+    if surface != "merge_ready":
+        refresh_command = f"{refresh_command} --surface {surface}"
     refresh_needed = [
         action for action in dry_run_payload.get("refresh_needed", []) if isinstance(action, dict)
     ]
@@ -17414,10 +17466,10 @@ def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str,
         "subject": "carrier_refresh",
         "why_blocking": "hosted admission cannot trust a frozen snapshot while carrier refresh dry-run reports pending updates.",
         "fallback_to": "carrier_refresh",
-        "refresh_suggestion": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "refresh_suggestion": refresh_command
         if refresh_needed
         else None,
-        "next_action": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "next_action": refresh_command
         if refresh_needed
         else dry_run_payload.get("fallback_to"),
     }
@@ -18408,9 +18460,9 @@ def gate_freeze_payload(args: argparse.Namespace, *, operation: str) -> dict[str
         "status_surface": status_binding,
         "pr_metadata": pr_metadata,
         "pr_body_pin": gate_freeze_pr_body_pin_binding(pr_metadata),
-        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha),
+        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha, surface=args.surface),
         "shadow_parity": gate_freeze_shadow_binding(target_root, governance_surface),
-        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"]),
+        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"], surface=args.surface),
         "shadow_freshness": gate_freeze_shadow_freshness_binding(target_root, governance_surface),
         "suite_validation": suite_validation,
         "suite_evidence_validation": suite_evidence_validation,
@@ -18591,7 +18643,7 @@ def hosted_freeze_admission_payload(
             "failure_classifier": failure_classifier_payload([]),
         }
 
-    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready"} else "merge_ready"
+    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready", "closeout"} else "merge_ready"
     freeze_args = argparse.Namespace(
         target=str(target_root),
         output=output_relative,

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_flow.py
@@ -679,6 +679,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     carrier.add_argument("--dry-run", action="store_true", default=True, help="Preview refresh actions without writing files; this is the default")
     carrier.add_argument("--write", dest="dry_run", action="store_false", help="Write Loom-owned carrier metadata refreshes")
     carrier.add_argument("--apply", dest="dry_run", action="store_false", help="Apply explicit versioned carrier closeout metadata writes")
+    carrier.add_argument(
+        "--surface",
+        choices=("pre_review", "review", "merge_ready", "closeout"),
+        default="merge_ready",
+        help="Gate surface whose carrier refresh drift policy should be evaluated",
+    )
     carrier.add_argument("--terminal-state", choices=tuple(sorted(TERMINAL_CLOSEOUT_STATES)), help="Terminal closeout state to write")
     carrier.add_argument("--issue", help="Issue locator or number bound to terminal closeout")
     carrier.add_argument("--pr", help="PR locator or number bound to terminal closeout")
@@ -821,7 +827,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     gate_freeze.add_argument("--compare-body-file", help="Optional repo-relative post-edit/readback PR body markdown to compare against --body-file")
     gate_freeze.add_argument(
         "--surface",
-        choices=("pre_review", "review", "merge_ready"),
+        choices=("pre_review", "review", "merge_ready", "closeout"),
         default="merge_ready",
         help="Gate surface whose PR metadata contract is consumed by the snapshot",
     )
@@ -14144,7 +14150,14 @@ def apply_shadow_evidence_actions(target_root: Path, actions: list[dict[str, Any
             write_json_file(path, payload)
 
 
-def carrier_refresh_payload(target_root: Path, output_relative: str, expected_item: str | None, *, dry_run: bool) -> dict[str, Any]:
+def carrier_refresh_payload(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    dry_run: bool,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
     runtime_state = runtime_state_payload(target_root)
     context, context_errors = load_context(target_root, output_relative, expected_item)
     idle_context = is_idle_context_errors(context_errors)
@@ -14196,7 +14209,13 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         assert context
         review_record, review_path, review_errors = load_review_record(target_root, context["item_id"], context["review_entry"])
         spec_review_path = default_spec_review_path(context["item_id"])
-        allowed_paths = allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+        terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+        allowed_paths = (
+            allowed_terminal_closeout_carrier_paths(context, review_path, spec_review_path)
+            if terminal_closeout_surface
+            else allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        )
         if review_errors or review_record is None:
             review_status = {"status": "missing", "path": review_path, "missing_inputs": review_errors or [f"missing review artifact: {review_path}"]}
         else:
@@ -14205,7 +14224,17 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
                 reviewed_head=str(review_record.get("reviewed_head", "")),
                 allowed_paths=allowed_paths,
             )
-            review_status = {"path": review_path, "head_binding": binding, "missing_inputs": binding_errors}
+            review_status = {
+                "path": review_path,
+                "head_binding": binding,
+                "missing_inputs": binding_errors,
+                "surface": surface,
+                "allowed_paths_policy": (
+                    "terminal closeout carrier paths only; requires terminal checkpoint"
+                    if terminal_closeout_surface
+                    else "post-review carrier paths only"
+                ),
+            }
             if binding.get("status") in {"implementation-drift-only", "stale"}:
                 review_status["status"] = "block"
                 missing_inputs.append("review artifact is stale because non-carrier drift is present")
@@ -14238,6 +14267,7 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         "missing_inputs": missing_inputs,
         "fallback_to": None if result == "pass" else "adoption",
         "dry_run": dry_run,
+        "surface": surface,
         "runtime_state": runtime_state,
         "actions": actions,
         "refresh_needed": refresh_needed,
@@ -15188,7 +15218,7 @@ def handle_carrier(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     if args.operation == "closeout-sync":
         return emit(carrier_closeout_sync_payload(target_root, args.output, args.item, args))
-    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run))
+    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run, surface=args.surface))
 
 
 def github_commit_pulls(root: Path, owner: str, repo_name: str, head_sha: str) -> tuple[list[dict[str, Any]], list[str]]:
@@ -17178,7 +17208,7 @@ def gate_freeze_command_surface(context: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None) -> dict[str, Any]:
+def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None, surface: str = "merge_ready") -> dict[str, Any]:
     review_entry = context.get("review_entry")
     review_relative = str(review_entry) if isinstance(review_entry, str) and review_entry else None
     review_record, review_path, review_errors = load_review_record(
@@ -17212,11 +17242,18 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
     binding["decision"] = review_record.get("decision")
     binding["kind"] = review_record.get("kind")
     binding["reviewed_head"] = review_record.get("reviewed_head")
+    normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+    terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+    allowed_paths = (
+        allowed_terminal_closeout_carrier_paths(context, review_path)
+        if terminal_closeout_surface
+        else allowed_post_review_carrier_paths(context, review_path)
+    )
     head_binding, head_errors = review_head_binding_for_head(
         context["target_root"],
         reviewed_head=review_record.get("reviewed_head") if isinstance(review_record.get("reviewed_head"), str) else None,
         target_head=head_sha or git_head_sha(context["target_root"]),
-        allowed_paths=allowed_post_review_carrier_paths(context, review_path),
+        allowed_paths=allowed_paths,
     )
     binding["head_binding"] = head_binding
     binding["current_head"] = head_binding.get("current_head")
@@ -17230,6 +17267,12 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
         current_validation_summary=context.get("latest_validation_summary"),
     )
     binding["semantic_review_disposition"] = disposition
+    binding["surface"] = surface
+    binding["allowed_paths_policy"] = (
+        "terminal closeout carrier paths only; requires terminal checkpoint"
+        if terminal_closeout_surface
+        else "post-review carrier paths only"
+    )
     binding["missing_inputs"] = [*head_errors, *disposition_errors]
     if review_record.get("decision") != "allow":
         binding["missing_inputs"].append("review artifact decision is not allow")
@@ -17384,8 +17427,17 @@ def gate_freeze_shadow_freshness_binding(target_root: Path, governance_surface: 
     }
 
 
-def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str, expected_item: str | None) -> dict[str, Any]:
-    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True)
+def gate_freeze_carrier_refresh_binding(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
+    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True, surface=surface)
+    refresh_command = "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+    if surface != "merge_ready":
+        refresh_command = f"{refresh_command} --surface {surface}"
     refresh_needed = [
         action for action in dry_run_payload.get("refresh_needed", []) if isinstance(action, dict)
     ]
@@ -17414,10 +17466,10 @@ def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str,
         "subject": "carrier_refresh",
         "why_blocking": "hosted admission cannot trust a frozen snapshot while carrier refresh dry-run reports pending updates.",
         "fallback_to": "carrier_refresh",
-        "refresh_suggestion": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "refresh_suggestion": refresh_command
         if refresh_needed
         else None,
-        "next_action": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "next_action": refresh_command
         if refresh_needed
         else dry_run_payload.get("fallback_to"),
     }
@@ -18408,9 +18460,9 @@ def gate_freeze_payload(args: argparse.Namespace, *, operation: str) -> dict[str
         "status_surface": status_binding,
         "pr_metadata": pr_metadata,
         "pr_body_pin": gate_freeze_pr_body_pin_binding(pr_metadata),
-        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha),
+        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha, surface=args.surface),
         "shadow_parity": gate_freeze_shadow_binding(target_root, governance_surface),
-        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"]),
+        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"], surface=args.surface),
         "shadow_freshness": gate_freeze_shadow_freshness_binding(target_root, governance_surface),
         "suite_validation": suite_validation,
         "suite_evidence_validation": suite_evidence_validation,
@@ -18591,7 +18643,7 @@ def hosted_freeze_admission_payload(
             "failure_classifier": failure_classifier_payload([]),
         }
 
-    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready"} else "merge_ready"
+    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready", "closeout"} else "merge_ready"
     freeze_args = argparse.Namespace(
         target=str(target_root),
         output=output_relative,

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -679,6 +679,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     carrier.add_argument("--dry-run", action="store_true", default=True, help="Preview refresh actions without writing files; this is the default")
     carrier.add_argument("--write", dest="dry_run", action="store_false", help="Write Loom-owned carrier metadata refreshes")
     carrier.add_argument("--apply", dest="dry_run", action="store_false", help="Apply explicit versioned carrier closeout metadata writes")
+    carrier.add_argument(
+        "--surface",
+        choices=("pre_review", "review", "merge_ready", "closeout"),
+        default="merge_ready",
+        help="Gate surface whose carrier refresh drift policy should be evaluated",
+    )
     carrier.add_argument("--terminal-state", choices=tuple(sorted(TERMINAL_CLOSEOUT_STATES)), help="Terminal closeout state to write")
     carrier.add_argument("--issue", help="Issue locator or number bound to terminal closeout")
     carrier.add_argument("--pr", help="PR locator or number bound to terminal closeout")
@@ -821,7 +827,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     gate_freeze.add_argument("--compare-body-file", help="Optional repo-relative post-edit/readback PR body markdown to compare against --body-file")
     gate_freeze.add_argument(
         "--surface",
-        choices=("pre_review", "review", "merge_ready"),
+        choices=("pre_review", "review", "merge_ready", "closeout"),
         default="merge_ready",
         help="Gate surface whose PR metadata contract is consumed by the snapshot",
     )
@@ -14144,7 +14150,14 @@ def apply_shadow_evidence_actions(target_root: Path, actions: list[dict[str, Any
             write_json_file(path, payload)
 
 
-def carrier_refresh_payload(target_root: Path, output_relative: str, expected_item: str | None, *, dry_run: bool) -> dict[str, Any]:
+def carrier_refresh_payload(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    dry_run: bool,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
     runtime_state = runtime_state_payload(target_root)
     context, context_errors = load_context(target_root, output_relative, expected_item)
     idle_context = is_idle_context_errors(context_errors)
@@ -14196,7 +14209,13 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         assert context
         review_record, review_path, review_errors = load_review_record(target_root, context["item_id"], context["review_entry"])
         spec_review_path = default_spec_review_path(context["item_id"])
-        allowed_paths = allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+        terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+        allowed_paths = (
+            allowed_terminal_closeout_carrier_paths(context, review_path, spec_review_path)
+            if terminal_closeout_surface
+            else allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        )
         if review_errors or review_record is None:
             review_status = {"status": "missing", "path": review_path, "missing_inputs": review_errors or [f"missing review artifact: {review_path}"]}
         else:
@@ -14205,7 +14224,17 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
                 reviewed_head=str(review_record.get("reviewed_head", "")),
                 allowed_paths=allowed_paths,
             )
-            review_status = {"path": review_path, "head_binding": binding, "missing_inputs": binding_errors}
+            review_status = {
+                "path": review_path,
+                "head_binding": binding,
+                "missing_inputs": binding_errors,
+                "surface": surface,
+                "allowed_paths_policy": (
+                    "terminal closeout carrier paths only; requires terminal checkpoint"
+                    if terminal_closeout_surface
+                    else "post-review carrier paths only"
+                ),
+            }
             if binding.get("status") in {"implementation-drift-only", "stale"}:
                 review_status["status"] = "block"
                 missing_inputs.append("review artifact is stale because non-carrier drift is present")
@@ -14238,6 +14267,7 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         "missing_inputs": missing_inputs,
         "fallback_to": None if result == "pass" else "adoption",
         "dry_run": dry_run,
+        "surface": surface,
         "runtime_state": runtime_state,
         "actions": actions,
         "refresh_needed": refresh_needed,
@@ -15188,7 +15218,7 @@ def handle_carrier(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     if args.operation == "closeout-sync":
         return emit(carrier_closeout_sync_payload(target_root, args.output, args.item, args))
-    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run))
+    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run, surface=args.surface))
 
 
 def github_commit_pulls(root: Path, owner: str, repo_name: str, head_sha: str) -> tuple[list[dict[str, Any]], list[str]]:
@@ -17178,7 +17208,7 @@ def gate_freeze_command_surface(context: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None) -> dict[str, Any]:
+def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None, surface: str = "merge_ready") -> dict[str, Any]:
     review_entry = context.get("review_entry")
     review_relative = str(review_entry) if isinstance(review_entry, str) and review_entry else None
     review_record, review_path, review_errors = load_review_record(
@@ -17212,11 +17242,18 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
     binding["decision"] = review_record.get("decision")
     binding["kind"] = review_record.get("kind")
     binding["reviewed_head"] = review_record.get("reviewed_head")
+    normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+    terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+    allowed_paths = (
+        allowed_terminal_closeout_carrier_paths(context, review_path)
+        if terminal_closeout_surface
+        else allowed_post_review_carrier_paths(context, review_path)
+    )
     head_binding, head_errors = review_head_binding_for_head(
         context["target_root"],
         reviewed_head=review_record.get("reviewed_head") if isinstance(review_record.get("reviewed_head"), str) else None,
         target_head=head_sha or git_head_sha(context["target_root"]),
-        allowed_paths=allowed_post_review_carrier_paths(context, review_path),
+        allowed_paths=allowed_paths,
     )
     binding["head_binding"] = head_binding
     binding["current_head"] = head_binding.get("current_head")
@@ -17230,6 +17267,12 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
         current_validation_summary=context.get("latest_validation_summary"),
     )
     binding["semantic_review_disposition"] = disposition
+    binding["surface"] = surface
+    binding["allowed_paths_policy"] = (
+        "terminal closeout carrier paths only; requires terminal checkpoint"
+        if terminal_closeout_surface
+        else "post-review carrier paths only"
+    )
     binding["missing_inputs"] = [*head_errors, *disposition_errors]
     if review_record.get("decision") != "allow":
         binding["missing_inputs"].append("review artifact decision is not allow")
@@ -17384,8 +17427,17 @@ def gate_freeze_shadow_freshness_binding(target_root: Path, governance_surface: 
     }
 
 
-def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str, expected_item: str | None) -> dict[str, Any]:
-    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True)
+def gate_freeze_carrier_refresh_binding(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
+    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True, surface=surface)
+    refresh_command = "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+    if surface != "merge_ready":
+        refresh_command = f"{refresh_command} --surface {surface}"
     refresh_needed = [
         action for action in dry_run_payload.get("refresh_needed", []) if isinstance(action, dict)
     ]
@@ -17414,10 +17466,10 @@ def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str,
         "subject": "carrier_refresh",
         "why_blocking": "hosted admission cannot trust a frozen snapshot while carrier refresh dry-run reports pending updates.",
         "fallback_to": "carrier_refresh",
-        "refresh_suggestion": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "refresh_suggestion": refresh_command
         if refresh_needed
         else None,
-        "next_action": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "next_action": refresh_command
         if refresh_needed
         else dry_run_payload.get("fallback_to"),
     }
@@ -18408,9 +18460,9 @@ def gate_freeze_payload(args: argparse.Namespace, *, operation: str) -> dict[str
         "status_surface": status_binding,
         "pr_metadata": pr_metadata,
         "pr_body_pin": gate_freeze_pr_body_pin_binding(pr_metadata),
-        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha),
+        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha, surface=args.surface),
         "shadow_parity": gate_freeze_shadow_binding(target_root, governance_surface),
-        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"]),
+        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"], surface=args.surface),
         "shadow_freshness": gate_freeze_shadow_freshness_binding(target_root, governance_surface),
         "suite_validation": suite_validation,
         "suite_evidence_validation": suite_evidence_validation,
@@ -18591,7 +18643,7 @@ def hosted_freeze_admission_payload(
             "failure_classifier": failure_classifier_payload([]),
         }
 
-    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready"} else "merge_ready"
+    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready", "closeout"} else "merge_ready"
     freeze_args = argparse.Namespace(
         target=str(target_root),
         output=output_relative,

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -679,6 +679,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     carrier.add_argument("--dry-run", action="store_true", default=True, help="Preview refresh actions without writing files; this is the default")
     carrier.add_argument("--write", dest="dry_run", action="store_false", help="Write Loom-owned carrier metadata refreshes")
     carrier.add_argument("--apply", dest="dry_run", action="store_false", help="Apply explicit versioned carrier closeout metadata writes")
+    carrier.add_argument(
+        "--surface",
+        choices=("pre_review", "review", "merge_ready", "closeout"),
+        default="merge_ready",
+        help="Gate surface whose carrier refresh drift policy should be evaluated",
+    )
     carrier.add_argument("--terminal-state", choices=tuple(sorted(TERMINAL_CLOSEOUT_STATES)), help="Terminal closeout state to write")
     carrier.add_argument("--issue", help="Issue locator or number bound to terminal closeout")
     carrier.add_argument("--pr", help="PR locator or number bound to terminal closeout")
@@ -821,7 +827,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     gate_freeze.add_argument("--compare-body-file", help="Optional repo-relative post-edit/readback PR body markdown to compare against --body-file")
     gate_freeze.add_argument(
         "--surface",
-        choices=("pre_review", "review", "merge_ready"),
+        choices=("pre_review", "review", "merge_ready", "closeout"),
         default="merge_ready",
         help="Gate surface whose PR metadata contract is consumed by the snapshot",
     )
@@ -14144,7 +14150,14 @@ def apply_shadow_evidence_actions(target_root: Path, actions: list[dict[str, Any
             write_json_file(path, payload)
 
 
-def carrier_refresh_payload(target_root: Path, output_relative: str, expected_item: str | None, *, dry_run: bool) -> dict[str, Any]:
+def carrier_refresh_payload(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    dry_run: bool,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
     runtime_state = runtime_state_payload(target_root)
     context, context_errors = load_context(target_root, output_relative, expected_item)
     idle_context = is_idle_context_errors(context_errors)
@@ -14196,7 +14209,13 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         assert context
         review_record, review_path, review_errors = load_review_record(target_root, context["item_id"], context["review_entry"])
         spec_review_path = default_spec_review_path(context["item_id"])
-        allowed_paths = allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+        terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+        allowed_paths = (
+            allowed_terminal_closeout_carrier_paths(context, review_path, spec_review_path)
+            if terminal_closeout_surface
+            else allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        )
         if review_errors or review_record is None:
             review_status = {"status": "missing", "path": review_path, "missing_inputs": review_errors or [f"missing review artifact: {review_path}"]}
         else:
@@ -14205,7 +14224,17 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
                 reviewed_head=str(review_record.get("reviewed_head", "")),
                 allowed_paths=allowed_paths,
             )
-            review_status = {"path": review_path, "head_binding": binding, "missing_inputs": binding_errors}
+            review_status = {
+                "path": review_path,
+                "head_binding": binding,
+                "missing_inputs": binding_errors,
+                "surface": surface,
+                "allowed_paths_policy": (
+                    "terminal closeout carrier paths only; requires terminal checkpoint"
+                    if terminal_closeout_surface
+                    else "post-review carrier paths only"
+                ),
+            }
             if binding.get("status") in {"implementation-drift-only", "stale"}:
                 review_status["status"] = "block"
                 missing_inputs.append("review artifact is stale because non-carrier drift is present")
@@ -14238,6 +14267,7 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
         "missing_inputs": missing_inputs,
         "fallback_to": None if result == "pass" else "adoption",
         "dry_run": dry_run,
+        "surface": surface,
         "runtime_state": runtime_state,
         "actions": actions,
         "refresh_needed": refresh_needed,
@@ -15188,7 +15218,7 @@ def handle_carrier(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     if args.operation == "closeout-sync":
         return emit(carrier_closeout_sync_payload(target_root, args.output, args.item, args))
-    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run))
+    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run, surface=args.surface))
 
 
 def github_commit_pulls(root: Path, owner: str, repo_name: str, head_sha: str) -> tuple[list[dict[str, Any]], list[str]]:
@@ -17178,7 +17208,7 @@ def gate_freeze_command_surface(context: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None) -> dict[str, Any]:
+def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None, surface: str = "merge_ready") -> dict[str, Any]:
     review_entry = context.get("review_entry")
     review_relative = str(review_entry) if isinstance(review_entry, str) and review_entry else None
     review_record, review_path, review_errors = load_review_record(
@@ -17212,11 +17242,18 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
     binding["decision"] = review_record.get("decision")
     binding["kind"] = review_record.get("kind")
     binding["reviewed_head"] = review_record.get("reviewed_head")
+    normalized_checkpoint = normalize_checkpoint(str(context.get("current_checkpoint", "")))
+    terminal_closeout_surface = surface == "closeout" and normalized_checkpoint in TERMINAL_CHECKPOINTS
+    allowed_paths = (
+        allowed_terminal_closeout_carrier_paths(context, review_path)
+        if terminal_closeout_surface
+        else allowed_post_review_carrier_paths(context, review_path)
+    )
     head_binding, head_errors = review_head_binding_for_head(
         context["target_root"],
         reviewed_head=review_record.get("reviewed_head") if isinstance(review_record.get("reviewed_head"), str) else None,
         target_head=head_sha or git_head_sha(context["target_root"]),
-        allowed_paths=allowed_post_review_carrier_paths(context, review_path),
+        allowed_paths=allowed_paths,
     )
     binding["head_binding"] = head_binding
     binding["current_head"] = head_binding.get("current_head")
@@ -17230,6 +17267,12 @@ def gate_freeze_review_binding(context: dict[str, Any], *, head_sha: str | None)
         current_validation_summary=context.get("latest_validation_summary"),
     )
     binding["semantic_review_disposition"] = disposition
+    binding["surface"] = surface
+    binding["allowed_paths_policy"] = (
+        "terminal closeout carrier paths only; requires terminal checkpoint"
+        if terminal_closeout_surface
+        else "post-review carrier paths only"
+    )
     binding["missing_inputs"] = [*head_errors, *disposition_errors]
     if review_record.get("decision") != "allow":
         binding["missing_inputs"].append("review artifact decision is not allow")
@@ -17384,8 +17427,17 @@ def gate_freeze_shadow_freshness_binding(target_root: Path, governance_surface: 
     }
 
 
-def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str, expected_item: str | None) -> dict[str, Any]:
-    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True)
+def gate_freeze_carrier_refresh_binding(
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+    *,
+    surface: str = "merge_ready",
+) -> dict[str, Any]:
+    dry_run_payload = carrier_refresh_payload(target_root, output_relative, expected_item, dry_run=True, surface=surface)
+    refresh_command = "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+    if surface != "merge_ready":
+        refresh_command = f"{refresh_command} --surface {surface}"
     refresh_needed = [
         action for action in dry_run_payload.get("refresh_needed", []) if isinstance(action, dict)
     ]
@@ -17414,10 +17466,10 @@ def gate_freeze_carrier_refresh_binding(target_root: Path, output_relative: str,
         "subject": "carrier_refresh",
         "why_blocking": "hosted admission cannot trust a frozen snapshot while carrier refresh dry-run reports pending updates.",
         "fallback_to": "carrier_refresh",
-        "refresh_suggestion": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "refresh_suggestion": refresh_command
         if refresh_needed
         else None,
-        "next_action": "python3 .loom/bin/loom_flow.py carrier refresh --target <repo> --write"
+        "next_action": refresh_command
         if refresh_needed
         else dry_run_payload.get("fallback_to"),
     }
@@ -18408,9 +18460,9 @@ def gate_freeze_payload(args: argparse.Namespace, *, operation: str) -> dict[str
         "status_surface": status_binding,
         "pr_metadata": pr_metadata,
         "pr_body_pin": gate_freeze_pr_body_pin_binding(pr_metadata),
-        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha),
+        "review_binding": gate_freeze_review_binding(context, head_sha=head_sha, surface=args.surface),
         "shadow_parity": gate_freeze_shadow_binding(target_root, governance_surface),
-        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"]),
+        "carrier_refresh": gate_freeze_carrier_refresh_binding(target_root, args.output, context["item_id"], surface=args.surface),
         "shadow_freshness": gate_freeze_shadow_freshness_binding(target_root, governance_surface),
         "suite_validation": suite_validation,
         "suite_evidence_validation": suite_evidence_validation,
@@ -18591,7 +18643,7 @@ def hosted_freeze_admission_payload(
             "failure_classifier": failure_classifier_payload([]),
         }
 
-    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready"} else "merge_ready"
+    freeze_surface = surface if surface in {"pre_review", "review", "merge_ready", "closeout"} else "merge_ready"
     freeze_args = argparse.Namespace(
         target=str(target_root),
         output=output_relative,

--- a/tools/check_cli_contract.py
+++ b/tools/check_cli_contract.py
@@ -4059,6 +4059,7 @@ def append_governance_intensity_metadata_body(
     *,
     include_legacy_bindings: bool = True,
     fields_override: dict[str, Any] | None = None,
+    surface: str = "merge_ready",
 ) -> None:
     pr_path = target / fixture["pr_file"]
     payload = json.loads(pr_path.read_text(encoding="utf-8"))
@@ -4068,6 +4069,7 @@ def append_governance_intensity_metadata_body(
         head_sha=payload["headRefOid"],
         include_legacy_bindings=include_legacy_bindings,
         fields_override=fields_override,
+        surface=surface,
     )
     pr_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
@@ -4355,6 +4357,17 @@ def assert_terminal_closeout_pr_gate_fixture(tmp: Path) -> None:
     target.mkdir()
     fixture = write_semantic_review_pr_gate_fixture(target)
     item = fixture["item"]
+    write_hosted_freeze_admission_inputs(target)
+    subprocess.run(["git", "add", "."], cwd=target, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    subprocess.run(
+        ["git", "commit", "-m", "fixture terminal closeout hosted admission inputs"],
+        cwd=target,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    update_fixture_pr_head(target, fixture)
+    record_current_fixture_review(target, fixture)
     progress_path = target / ".loom" / "progress" / f"{item}.md"
     status_path = target / ".loom" / "status" / "current.md"
     task_carrier_path = target / ".loom" / "specs" / item / "task-carrier.md"
@@ -4395,7 +4408,7 @@ def assert_terminal_closeout_pr_gate_fixture(tmp: Path) -> None:
     commit_fixture_file(target, ".loom/status/current.md", "fixture terminal closeout status")
     commit_fixture_file(target, f".loom/specs/{item}/task-carrier.md", "fixture terminal closeout task carrier")
     update_fixture_pr_head(target, fixture)
-    append_pr_metadata_surface(target, fixture, surface="closeout")
+    append_governance_intensity_metadata_body(target, fixture, surface="closeout")
     closeout_payload = semantic_pr_gate_fixture_payload(target, fixture, surface="closeout")
     checkpoint_step = next(
         (
@@ -4421,6 +4434,84 @@ def assert_terminal_closeout_pr_gate_fixture(tmp: Path) -> None:
             "terminal closeout pr-gate fixture did not pass: "
             f"{closeout_payload.get('missing_inputs')}; steps={step_names}"
         )
+    pr_payload = json.loads((target / fixture["pr_file"]).read_text(encoding="utf-8"))
+    hosted_body_file = f".loom/fixtures/{item}/closeout-hosted-pr-body.md"
+    (target / hosted_body_file).write_text(pr_payload["body"], encoding="utf-8")
+    hosted_closeout_payload = semantic_pr_gate_fixture_payload(
+        target,
+        fixture,
+        surface="closeout",
+        body_file=hosted_body_file,
+        compare_body_file=hosted_body_file,
+    )
+    hosted_admission = hosted_closeout_payload.get("hosted_freeze_admission", {})
+    hosted_freeze_surface = (
+        hosted_admission.get("recomputed_freeze", {})
+        .get("snapshot_subject", {})
+        .get("surface")
+    )
+    hosted_carrier_refresh = (
+        hosted_admission.get("recomputed_freeze", {})
+        .get("input_bindings", {})
+        .get("carrier_refresh", {})
+    )
+    if (
+        hosted_closeout_payload.get("result") != "pass"
+        or hosted_admission.get("result") != "pass"
+        or hosted_freeze_surface != "closeout"
+        or hosted_carrier_refresh.get("result") != "pass"
+    ):
+        raise AssertionError(
+            "terminal closeout hosted admission did not preserve closeout surface: "
+            f"result={hosted_closeout_payload.get('result')}; "
+            f"admission={hosted_admission.get('result')}; "
+            f"freeze_surface={hosted_freeze_surface}; "
+            f"carrier_refresh={hosted_carrier_refresh.get('result')}; "
+            f"missing={hosted_closeout_payload.get('missing_inputs')}"
+        )
+    _, direct_carrier_refresh = run_flow_json(
+        [
+            "carrier",
+            "refresh",
+            "--target",
+            str(target),
+            "--item",
+            item,
+            "--surface",
+            "closeout",
+        ]
+    )
+    if direct_carrier_refresh.get("result") != "pass" or direct_carrier_refresh.get("surface") != "closeout":
+        raise AssertionError(
+            "carrier refresh --surface closeout did not consume terminal closeout carrier paths: "
+            f"{direct_carrier_refresh.get('missing_inputs')}"
+        )
+    _, direct_gate_freeze = run_flow_json(
+        [
+            "gate-freeze",
+            "check",
+            "--target",
+            str(target),
+            "--item",
+            item,
+            "--surface",
+            "closeout",
+            "--pr-payload-file",
+            fixture["pr_file"],
+            "--body-file",
+            hosted_body_file,
+            "--compare-body-file",
+            hosted_body_file,
+        ]
+    )
+    if (
+        direct_gate_freeze.get("result") != "pass"
+        or direct_gate_freeze.get("snapshot_subject", {}).get("surface") != "closeout"
+    ):
+        raise AssertionError(
+            "gate-freeze --surface closeout did not emit a hosted closeout freeze snapshot: "
+            f"{direct_gate_freeze.get('missing_inputs')}"
+        )
 
     spec_review_path = target / ".loom" / "reviews" / f"{item}.spec.json"
     spec_review = json.loads(spec_review_path.read_text(encoding="utf-8"))
@@ -4428,7 +4519,7 @@ def assert_terminal_closeout_pr_gate_fixture(tmp: Path) -> None:
     spec_review_path.write_text(json.dumps(spec_review, indent=2) + "\n", encoding="utf-8")
     commit_fixture_file(target, f".loom/reviews/{item}.spec.json", "fixture unreachable spec review head")
     update_fixture_pr_head(target, fixture)
-    append_pr_metadata_surface(target, fixture, surface="closeout")
+    append_governance_intensity_metadata_body(target, fixture, surface="closeout")
     unreachable_spec_head_payload = semantic_pr_gate_fixture_payload(target, fixture, surface="closeout")
     if (
         unreachable_spec_head_payload.get("result") != "pass"
@@ -4439,7 +4530,7 @@ def assert_terminal_closeout_pr_gate_fixture(tmp: Path) -> None:
             f"{unreachable_spec_head_payload.get('missing_inputs')}"
         )
 
-    append_pr_metadata_surface(target, fixture, surface="merge_ready")
+    append_governance_intensity_metadata_body(target, fixture, surface="merge_ready")
     merge_ready_payload = semantic_pr_gate_fixture_payload(target, fixture, surface="merge_ready")
     if merge_ready_payload.get("result") == "pass" or merge_ready_payload.get("terminal_closeout_consumption", {}).get("result") != "block":
         raise AssertionError("terminal closeout retained review bypassed a non-closeout PR metadata surface")


### PR DESCRIPTION
## Summary

- Problem: hosted closeout admission recomputed `surface=closeout` as merge-ready/default review freshness, so closeout-only carrier sync PRs could block after implementation merge.
- Scope: preserve closeout surface through hosted freeze recomputation, make review/carrier-refresh bindings surface-aware only for terminal closeout, expose `carrier refresh --surface closeout` / hosted `gate-freeze --surface closeout`, and refresh demo bootstrap fixtures for the generated runtime copy.

## Validation

- [x] Verified locally
- [ ] Verified by automation
- [ ] Not applicable

Validation details:
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile src/skills/shared/scripts/loom_flow.py skills/shared/scripts/loom_flow.py tools/check_cli_contract.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 tools/skills_surface.py check --surface generated-tree-drift`
- `make loom-demo-new-project-check`
- `make loom-check`
- targeted terminal closeout hosted fixture via `assert_terminal_closeout_pr_gate_fixture(Path(tmp))`
- `PYTHONDONTWRITEBYTECODE=1 python3 tools/check_cli_contract.py --surface pr-metadata`
- `PYTHONDONTWRITEBYTECODE=1 python3 tools/check_cli_contract.py --surface aggregate`

## Risks And Follow-ups

- Risks: closeout-specific allowlist is intentionally limited to `surface=closeout` plus terminal checkpoint; merge-ready/current-head review paths remain strict.
- Follow-ups: #1580 hosted gate should be rerun or refreshed after this lands so the closeout-only carrier sync can consume the corrected admission behavior. Current PR remains draft pending review/carrier truth alignment.

## Related Work

- Issue: #1512
- Loom Work Item:WI-1512
- Branch: work/1512-closeout-hosted-admission
- Head SHA: d5e2578bc7ac19128a1aabea1a964972ef1a61eb
- Spec / plan:

## PR Metadata Machine Carrier

If this repository declares repo-specific PR metadata in `.loom/companion/repo-interface.json`, preserve the declared machine block exactly. Prefer `loom pr metadata-update` for the end-to-end render/update/readback flow, or `loom pr metadata-render` when you need a repo-relative artifact without host mutation. Re-run `loom pr metadata-preflight --body-file <rendered> --compare-body-file <readback>` before review, merge-ready, or closeout.

<!-- loom:repo-pr-metadata
{
  "schema_version": "loom-repo-pr-metadata/v1",
  "metadata_contract_id": "loom-governance-intensity",
  "surface": "merge_ready",
  "fields": {
    "loom_work_item": "WI-1512",
    "branch": "work/1512-closeout-hosted-admission",
    "head_sha": "d5e2578bc7ac19128a1aabea1a964972ef1a61eb",
    "governance_intensity": "standard",
    "change_class": "contract",
    "suite_path": "minimal",
    "suite_not_applicable": null,
    "review_requirement": "current_head_review_required",
    "fact_chain_required": true,
    "pr_gate_required": true,
    "release_judgment": "no_release",
    "closeout_required": true,
    "upgrade_triggers": []
  },
  "source": {
    "rendered_hash": "renderer:loom-pr-metadata-render/v1"
  },
  "parser_version": "loom-pr-metadata-parser/v1"
}
-->
