### PR TITLE
feat: 增加 FR/阶段关闭守卫

### DIFF
--- a/.github/workflows/loom-fr-phase-close-guard.yml
+++ b/.github/workflows/loom-fr-phase-close-guard.yml
@@ -1,0 +1,228 @@
+name: loom-fr-phase-close-guard
+
+# `issues` workflows are resolved from the default branch. The only checkout
+# below explicitly reads that trusted branch, never issue, branch, or PR code.
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: loom-fr-phase-close-guard-${{ github.repository }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  loom-fr-phase-close-guard:
+    name: loom-fr-phase-close-guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Read FR or Phase host facts
+        id: snapshot
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const subjectNumber = context.payload.issue?.number;
+            const eventLabels = context.payload.issue?.labels || [];
+            const typeLabels = new Set(eventLabels.map((label) => String(label?.name || label || "").trim().toLowerCase()));
+            if (!Number.isInteger(subjectNumber) || (!["fr", "phase"].some((label) => typeLabels.has(label)))) {
+              core.notice("closed issue is not an FR or Phase; close guard is not applicable");
+              core.setOutput("applicable", "false");
+              return;
+            }
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueQuery = `
+              query($owner:String!, $repo:String!, $number:Int!) {
+                repository(owner:$owner, name:$repo) {
+                  defaultBranchRef { name }
+                  issue(number:$number) {
+                    number state stateReason body
+                    labels(first:100) { pageInfo { hasNextPage } nodes { name } }
+                    subIssues(first:100) { pageInfo { hasNextPage } nodes { number } }
+                    blockedBy(first:100) { pageInfo { hasNextPage } nodes { number state } }
+                    closedByPullRequestsReferences(first:100) {
+                      pageInfo { hasNextPage }
+                      nodes {
+                        number merged baseRefName headRefOid mergeCommit { oid } reviewDecision
+                        commits(last:1) {
+                          nodes {
+                            commit {
+                              oid
+                              statusCheckRollup {
+                                state
+                                contexts(first:100) {
+                                  pageInfo { hasNextPage }
+                                  nodes {
+                                    __typename
+                                    ... on CheckRun { name status conclusion }
+                                    ... on StatusContext { context state }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+            const pageComplete = (connection) => Boolean(connection && Array.isArray(connection.nodes) && connection.pageInfo && connection.pageInfo.hasNextPage === false);
+            const fetchIssue = async (number) => {
+              const data = await github.graphql(issueQuery, { owner, repo, number });
+              const repository = data?.repository;
+              const issue = repository?.issue;
+              if (!issue || !repository?.defaultBranchRef?.name) throw new Error(`GitHub read for issue:${number} is incomplete`);
+              const connections = [issue.labels, issue.subIssues, issue.blockedBy, issue.closedByPullRequestsReferences];
+              const comments = number === subjectNumber
+                ? await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: number, per_page: 100 })
+                : [];
+              return {
+                default_branch: repository.defaultBranchRef.name,
+                issue: {
+                  number: issue.number,
+                  state: issue.state,
+                  state_reason: issue.stateReason,
+                  body: issue.body || "",
+                  labels: issue.labels?.nodes?.map((entry) => entry.name).filter(Boolean) || [],
+                  children: issue.subIssues?.nodes?.map((entry) => entry.number).filter(Number.isInteger) || [],
+                  blocked_by: issue.blockedBy?.nodes?.map((entry) => ({ number: entry.number, state: entry.state })) || [],
+                  merged_prs: issue.closedByPullRequestsReferences?.nodes?.map((entry) => {
+                    const commit = entry.commits?.nodes?.[0]?.commit;
+                    const rollup = commit?.statusCheckRollup;
+                    const contexts = rollup?.contexts;
+                    return {
+                      number: entry.number,
+                      merged: entry.merged,
+                      base_ref: entry.baseRefName,
+                      head_sha: entry.headRefOid,
+                      merge_commit: entry.mergeCommit?.oid,
+                      review_decision: entry.reviewDecision,
+                      check_rollup: {
+                        state: rollup?.state,
+                        contexts_complete: pageComplete(contexts),
+                        contexts: contexts?.nodes?.map((context) => ({
+                          type: context.__typename,
+                          name: context.name || context.context,
+                          status: context.status,
+                          conclusion: context.conclusion,
+                          state: context.state,
+                        })) || [],
+                      },
+                      commit_sha: commit?.oid,
+                    };
+                  }) || [],
+                  comment_bodies: comments.map((comment) => comment.body).filter((body) => typeof body === "string"),
+                  read_complete: connections.every(pageComplete),
+                  comments_complete: number === subjectNumber,
+                },
+              };
+            };
+            const snapshot = { subject: subjectNumber, default_branch: null, host_readable: true, issues: [] };
+            const byNumber = new Map();
+            try {
+              const queue = [subjectNumber];
+              while (queue.length) {
+                const number = queue.shift();
+                if (!Number.isInteger(number) || byNumber.has(number) || byNumber.size >= 100) {
+                  if (!Number.isInteger(number) || byNumber.size >= 100) snapshot.host_readable = false;
+                  continue;
+                }
+                const fetched = await fetchIssue(number);
+                snapshot.default_branch ||= fetched.default_branch;
+                if (snapshot.default_branch !== fetched.default_branch) snapshot.host_readable = false;
+                byNumber.set(number, fetched.issue);
+                queue.push(...fetched.issue.children);
+              }
+              snapshot.issues = [...byNumber.values()];
+            } catch (error) {
+              snapshot.host_readable = false;
+              core.warning(`closure guard host read failed: ${error.message}`);
+            }
+            const path = `${process.env.RUNNER_TEMP}/loom-fr-phase-close-guard-${subjectNumber}.json`;
+            fs.writeFileSync(path, JSON.stringify(snapshot));
+            core.setOutput("applicable", "true");
+            core.setOutput("subject", String(subjectNumber));
+            core.setOutput("snapshot", path);
+
+      - name: Checkout trusted default branch evaluator
+        if: steps.snapshot.outputs.applicable == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Evaluate closure facts
+        if: steps.snapshot.outputs.applicable == 'true'
+        env:
+          SNAPSHOT_PATH: ${{ steps.snapshot.outputs.snapshot }}
+          RESULT_PATH: ${{ runner.temp }}/loom-fr-phase-close-guard-result.json
+        run: python3 src/skills/shared/scripts/github_closure_guard.py --snapshot "$SNAPSHOT_PATH" --output "$RESULT_PATH"
+
+      - name: Reopen only evaluator-blocked closure
+        if: steps.snapshot.outputs.applicable == 'true'
+        uses: actions/github-script@v7
+        env:
+          GUARD_RESULT_PATH: ${{ runner.temp }}/loom-fr-phase-close-guard-result.json
+          SNAPSHOT_PATH: ${{ steps.snapshot.outputs.snapshot }}
+          SUBJECT_NUMBER: ${{ steps.snapshot.outputs.subject }}
+        with:
+          script: |
+            const fs = require("fs");
+            const subjectNumber = Number(process.env.SUBJECT_NUMBER);
+            let verdict;
+            let snapshot;
+            try {
+              verdict = JSON.parse(fs.readFileSync(process.env.GUARD_RESULT_PATH, "utf8"));
+              snapshot = JSON.parse(fs.readFileSync(process.env.SNAPSHOT_PATH, "utf8"));
+            } catch (error) {
+              core.setFailed(`cannot read closure evaluator snapshot or output: ${error.message}`);
+              return;
+            }
+            if (verdict?.verdict !== "reopen_required") {
+              core.notice(`closure guard allows ${verdict?.verdict || "unknown"}`);
+              return;
+            }
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const remediationMarker = `<!-- loom:fr-phase-close-guard issue:${subjectNumber} -->`;
+            const subject = Array.isArray(snapshot?.issues)
+              ? snapshot.issues.find((issue) => issue?.number === subjectNumber)
+              : null;
+            const snapshotComments = subject?.comment_bodies;
+            const hasSnapshotMarker = subject?.comments_complete === true && Array.isArray(snapshotComments)
+              && snapshotComments.some((body) => String(body).includes(remediationMarker));
+            await github.rest.issues.update({ owner, repo, issue_number: subjectNumber, state: "open" });
+            const { data: reopened } = await github.rest.issues.get({ owner, repo, issue_number: subjectNumber });
+            if (reopened.state !== "open") {
+              core.setFailed(`closure guard reopened issue:${subjectNumber} but host readback is ${reopened.state}`);
+              return;
+            }
+            if (hasSnapshotMarker) return;
+            let comments;
+            try {
+              comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: subjectNumber, per_page: 100 });
+            } catch (error) {
+              core.setFailed(`issue:${subjectNumber} reopened but remediation deduplication could not be completed: ${error.message}`);
+              return;
+            }
+            if (comments.some((comment) => String(comment.body || "").includes(remediationMarker))) return;
+            const details = Array.isArray(verdict.reasons)
+              ? verdict.reasons.map((entry) => `- \`${entry.code}\`: ${entry.message}`).join("\n")
+              : "- \`host_unreadable\`: the closure evaluator returned no structured reasons";
+            const { data: created } = await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: subjectNumber,
+              body: `${remediationMarker}\n\nLoom 已重新打开该 FR/Phase：它不能以 completed 关闭。\n\n${details}\n\n处理后再次关闭；不要通过补 current、carrier、shadow 或手写 head 字段绕过。`,
+            });
+            const { data: comment } = await github.rest.issues.getComment({ owner, repo, comment_id: created.id });
+            if (!String(comment.body || "").includes(remediationMarker)) {
+              core.setFailed(`issue:${subjectNumber} remediation comment readback is missing its stable marker`);
+            }

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
-.PHONY: loom-check check py-compile skills-check skills-doc-reference-sync-check skills-generated-tree-drift-check skills-package-metadata-check skills-cache-artifacts-check skills-launcher-smoke-check host-adapter-check pr-binding-workflow-check version-surface-check release-surface-check release-surface-doc-contract-check release-surface-workflow-contract-check release-surface-installer-sunset-guard-check release-surface-forbidden-patterns-check release-surface-installed-global-cli-smoke-check cli-contract-check npm-package-check npm-package-manifest-check npm-pack-payload-check loom-check-runtime-regression loom-check-runtime-locking loom-check-runtime-single-flight-locking loom-check-runtime-worktree-local-lock-paths loom-check-runtime-subprocess-env-purity loom-check-runtime-installer-regression-lock-output loom-check-runtime-demo-fixture-cleanliness loom-check-runtime-temp-dir-cleanup loom-demo-new-project loom-demo-new-project-check loom-demo-new-project-generation-check loom-demo-new-project-canonicalization-check loom-demo-new-project-fixture-drift-check loom-demo-new-project-cleanliness-check loom-demo-new-project-sync loom-self-plugin-check daily-execution-cli-fast daily-execution-cli-full
+.PHONY: loom-check check py-compile skills-check skills-doc-reference-sync-check skills-generated-tree-drift-check skills-package-metadata-check skills-cache-artifacts-check skills-launcher-smoke-check host-adapter-check pr-binding-workflow-check fr-phase-close-guard-check version-surface-check release-surface-check release-surface-doc-contract-check release-surface-workflow-contract-check release-surface-installer-sunset-guard-check release-surface-forbidden-patterns-check release-surface-installed-global-cli-smoke-check cli-contract-check npm-package-check npm-package-manifest-check npm-pack-payload-check loom-check-runtime-regression loom-check-runtime-locking loom-check-runtime-single-flight-locking loom-check-runtime-worktree-local-lock-paths loom-check-runtime-subprocess-env-purity loom-check-runtime-installer-regression-lock-output loom-check-runtime-demo-fixture-cleanliness loom-check-runtime-temp-dir-cleanup loom-demo-new-project loom-demo-new-project-check loom-demo-new-project-generation-check loom-demo-new-project-canonicalization-check loom-demo-new-project-fixture-drift-check loom-demo-new-project-cleanliness-check loom-demo-new-project-sync loom-self-plugin-check daily-execution-cli-fast daily-execution-cli-full
 .PHONY: repo-local-cli-fast repo-local-cli-full repo-local-cli-setup-demo-bootstrap repo-local-cli-init-runtime repo-local-cli-fact-chain repo-local-cli-flow-gates repo-local-cli-workspace-locate repo-local-cli-purity-check repo-local-cli-runtime-state-scene-conflict-negative
 
 REPO_LOCAL_CLI_GROUPS := setup-demo-bootstrap init-runtime fact-chain flow-gates workspace-locate purity-check runtime-state-scene-conflict-negative
 
-loom-check: pr-binding-workflow-check loom-self-plugin-check loom-demo-new-project-check loom-check-runtime-regression
+loom-check: pr-binding-workflow-check fr-phase-close-guard-check loom-self-plugin-check loom-demo-new-project-check loom-check-runtime-regression
 	python3 tools/loom_check.py
 
 py-compile:
-	python3 tools/py_compile_clean.py tools/loom.py tools/runtime_wrapper.py tools/loom_init.py tools/loom_flow.py tools/loom_check.py tools/loom_status.py tools/py_compile_clean.py tools/check_cli_contract.py tools/check_npm_package.py tools/check_release_surface.py tools/check_pr_binding_workflow.py tools/check_demo_bootstrap_fixture.py tools/check_loom_check_runtime_regressions.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py skills/loom-init/scripts/*.py skills/loom-adopt/scripts/*.py skills/loom-resume/scripts/*.py skills/loom-pre-review/scripts/*.py skills/loom-review/scripts/*.py skills/loom-spec-review/scripts/*.py skills/loom-handoff/scripts/*.py skills/loom-retire/scripts/*.py skills/loom-merge-ready/scripts/*.py skills/loom-build/scripts/*.py skills/loom-story/scripts/*.py
+	python3 tools/py_compile_clean.py tools/loom.py tools/runtime_wrapper.py tools/loom_init.py tools/loom_flow.py tools/loom_check.py tools/loom_status.py tools/py_compile_clean.py tools/check_cli_contract.py tools/check_npm_package.py tools/check_release_surface.py tools/check_pr_binding_workflow.py tools/check_fr_phase_close_guard.py tools/check_fr_phase_close_guard_workflow.py tools/check_demo_bootstrap_fixture.py tools/check_loom_check_runtime_regressions.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py skills/loom-init/scripts/*.py skills/loom-adopt/scripts/*.py skills/loom-resume/scripts/*.py skills/loom-pre-review/scripts/*.py skills/loom-review/scripts/*.py skills/loom-spec-review/scripts/*.py skills/loom-handoff/scripts/*.py skills/loom-retire/scripts/*.py skills/loom-merge-ready/scripts/*.py skills/loom-build/scripts/*.py skills/loom-story/scripts/*.py
 
 skills-check:
 	python3 tools/skills_surface.py check
@@ -32,6 +32,10 @@ host-adapter-check:
 
 pr-binding-workflow-check:
 	python3 tools/check_pr_binding_workflow.py
+
+fr-phase-close-guard-check:
+	python3 tools/check_fr_phase_close_guard.py
+	python3 tools/check_fr_phase_close_guard_workflow.py
 
 version-surface-check:
 	python3 tools/version_surface_check.py

--- a/docs/adoption/github-profile.md
+++ b/docs/adoption/github-profile.md
@@ -100,6 +100,14 @@ FR 在规划态可以没有 Work Item；只有它要进入 branch、build、PR�
 - 未拆分 FR 的执行意图返回 `needs_breakdown`；`duplicate`、`invalid`、`cancelled`、`superseded`、`deferred` 与 `not planned` 只能表示非完成例外，不能伪装为 completed。
 - PR binding 与 FR/Phase close guard 是后续消费者：implementation PR 的 primary issue 必须是 `work_item`，而不是 FR 或 Phase。
 
+### FR/Phase host-native close guard
+
+`issues.closed` guard 只读取 GitHub default-branch 所定义的 workflow 与宿主 API；它只 checkout default branch 的 evaluator，不 checkout 或执行 issue、branch 或 PR 内容，也不读取或修补 `.loom` carrier。
+
+- 只有 `completed` 的 FR/Phase 才需证明完整 `Phase -> FR -> Work Item` native tree、已关闭 native blockers，以及每个 Work Item 的 default-branch merged PR、GitHub `reviewDecision: APPROVED` 与完整成功的 `statusCheckRollup`。issue comment 只能补充说明，不能单独成为 completed 证据。
+- `not planned`、`duplicate`、`invalid`、`cancelled`、`superseded` 是非完成关闭；不会被当作 completed。`deferred` 还必须有非空 `Activation Policy` 与 `Successor: phase|fr|work_item:<number>`，否则自动 reopen。
+- 分页、权限或任何 host read 不完整也自动 reopen。每个 issue 的 guard 串行执行；先用 snapshot 中完整读取的 comment marker 去重，再 reopen/readback，必要时再次完整分页读取 comments 后写入一条带稳定 marker 的 remediation。若去重读取失败，workflow 明确失败而不静默跳过 remediation。
+
 GitHub task carrier 边界：
 
 - GitHub issue / sub-issue 可以作为 execution breakdown unit 的 `github_issue` carrier，但只有被明确 author 为 `Work Item` 的 issue 才能进入正式执行。

--- a/plugins/loom/.codex-plugin/plugin.json
+++ b/plugins/loom/.codex-plugin/plugin.json
@@ -23,7 +23,7 @@
     "source_git_sha": "unreleased",
     "source_git_sha_status": "pending_release_commit",
     "plugin_payload_version": "0.28.0",
-    "plugin_payload_hash": "7976b239a4de0c1728ec3066ca94cea90d3684ae225c47c49de2818c842d1fc0",
+    "plugin_payload_hash": "46e389b3a14e3d0ab73eba50c305fc9300a331405a31d042e37de7a5f56ef729",
     "repository_payload": false
   },
   "keywords": [

--- a/plugins/loom/skills/shared/scripts/github_closure_guard.py
+++ b/plugins/loom/skills/shared/scripts/github_closure_guard.py
@@ -1,0 +1,206 @@
+"""Host-native guard for completed FR and Phase closures.
+
+The evaluator consumes a complete GitHub snapshot.  It owns neither a
+repository carrier nor a host write: the ``issues.closed`` workflow owns the
+small reopen/comment recovery when this module returns ``reopen_required``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "loom-fr-phase-close-guard/v1"
+NON_COMPLETION_LABELS = {"duplicate", "invalid", "cancelled", "canceled", "superseded"}
+TYPE_LABELS = {"fr": "fr", "phase": "phase", "work-item": "work_item"}
+DEFERRED_LABEL = "deferred"
+EXPECTED_CHILD_TYPE = {"phase": "fr", "fr": "work_item"}
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip().casefold().replace("-", "_").replace(" ", "_")
+
+
+def _labels(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    return {_text(label) for label in labels if isinstance(label, str)} if isinstance(labels, list) else set()
+
+
+def _type(issue: dict[str, Any]) -> str:
+    declared = _text(issue.get("type"))
+    if declared in {"fr", "phase", "work_item"}:
+        return declared
+    inferred = {TYPE_LABELS[label.replace("_", "-")] for label in _labels(issue) if label.replace("_", "-") in TYPE_LABELS}
+    return inferred.pop() if len(inferred) == 1 else "unknown"
+
+
+def _reason(code: str, locator: str, message: str) -> dict[str, str]:
+    return {"code": code, "locator": locator, "message": message}
+
+
+def _payload(subject: int, verdict: str, summary: str, reasons: list[dict[str, str]], *, completed: bool) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA,
+        "result": "block" if verdict == "reopen_required" else "pass",
+        "verdict": verdict,
+        "summary": summary,
+        "subject": {"number": subject, "locator": f"issue:{subject}"},
+        "completed": completed,
+        "reasons": reasons,
+        "remediation": "reconcile native children, dependencies, merged PR reviews, and check evidence before closing again"
+        if verdict == "reopen_required"
+        else None,
+    }
+
+
+def _deferred_ready(issue: dict[str, Any]) -> list[dict[str, str]]:
+    body = str(issue.get("body") or "")
+    number = issue.get("number", "unknown")
+    reasons: list[dict[str, str]] = []
+    if not re.search(r"(?im)^#{1,6}\s*activation\s+policy\s*$\n\s*\S", body):
+        reasons.append(_reason("deferred_missing_activation_policy", f"issue:{number}", "deferred closure requires a non-empty Activation Policy section"))
+    if not re.search(r"(?im)^\s*(?:-\s*)?successor:\s*`?(?:phase|fr|work_item):\d+`?\s*$", body):
+        reasons.append(_reason("deferred_missing_typed_successor", f"issue:{number}", "deferred closure requires `Successor: phase|fr|work_item:<number>`"))
+    return reasons
+
+
+def _successful_check_rollup(pr: dict[str, Any]) -> bool:
+    rollup = pr.get("check_rollup")
+    if not isinstance(rollup, dict) or _text(rollup.get("state")) != "success" or rollup.get("contexts_complete") is not True:
+        return False
+    contexts = rollup.get("contexts")
+    return isinstance(contexts, list) and bool(contexts)
+
+
+def _approved_green_merged_pr(issue: dict[str, Any], default_branch: str) -> bool:
+    prs = issue.get("merged_prs")
+    if not isinstance(prs, list):
+        return False
+    for pr in prs:
+        if not isinstance(pr, dict) or pr.get("merged") is not True or pr.get("base_ref") != default_branch:
+            continue
+        pr_number, head_sha, merge_commit, commit_sha = pr.get("number"), pr.get("head_sha"), pr.get("merge_commit"), pr.get("commit_sha")
+        if not isinstance(pr_number, int) or not all(isinstance(value, str) and value for value in (head_sha, merge_commit, commit_sha)) or commit_sha != head_sha:
+            continue
+        if _text(pr.get("review_decision")) == "approved" and _successful_check_rollup(pr):
+            return True
+    return False
+
+
+def _validate_completed(
+    issue: dict[str, Any],
+    issues: dict[int, dict[str, Any]],
+    default_branch: str,
+    reasons: list[dict[str, str]],
+    visiting: set[int],
+) -> None:
+    number = issue.get("number")
+    locator = f"issue:{number}" if isinstance(number, int) else "issue:unknown"
+    if issue.get("read_complete") is not True:
+        reasons.append(_reason("host_unreadable", locator, "GitHub child, dependency, PR, or comment read is incomplete"))
+        return
+    if _text(issue.get("state")) != "closed" or _text(issue.get("state_reason")) != "completed":
+        reasons.append(_reason("child_not_completed", locator, "a completed parent requires every native child to be closed as completed"))
+        return
+    if not isinstance(number, int):
+        reasons.append(_reason("host_unreadable", locator, "GitHub issue number is unreadable"))
+        return
+    if number in visiting:
+        reasons.append(_reason("native_tree_cycle", locator, "native sub-issue tree must be acyclic"))
+        return
+    blockers = issue.get("blocked_by")
+    if not isinstance(blockers, list):
+        reasons.append(_reason("host_unreadable", locator, "native dependency read is incomplete"))
+        return
+    for blocker in blockers:
+        if not isinstance(blocker, dict) or _text(blocker.get("state")) != "closed":
+            reasons.append(_reason("open_native_blocker", locator, "completed closure cannot retain an open or unreadable native blocker"))
+    kind = _type(issue)
+    if kind == "work_item":
+        if not _approved_green_merged_pr(issue, default_branch):
+            reasons.append(_reason("missing_approved_merged_pr_or_green_check", locator, "Work Item needs a default-branch merged PR with an approved review and successful host check rollup"))
+        return
+    expected = EXPECTED_CHILD_TYPE.get(kind)
+    children = issue.get("children")
+    if expected is None or not isinstance(children, list) or not children:
+        reasons.append(_reason("missing_native_child", locator, "completed FR/Phase requires its native child tree"))
+        return
+    next_visiting = {*visiting, number}
+    for child_number in children:
+        child = issues.get(child_number) if isinstance(child_number, int) else None
+        if not isinstance(child, dict):
+            reasons.append(_reason("host_unreadable", locator, "a native child cannot be read from GitHub"))
+            continue
+        if _type(child) != expected:
+            reasons.append(_reason("invalid_native_child_type", f"issue:{child_number}", f"{kind} requires native {expected} children"))
+            continue
+        _validate_completed(child, issues, default_branch, reasons, next_visiting)
+
+
+def evaluate_closure(snapshot: object) -> dict[str, Any]:
+    """Decide whether a closed FR/Phase may remain closed from host facts only."""
+    if not isinstance(snapshot, dict):
+        return _payload(0, "reopen_required", "GitHub closure snapshot is unreadable.", [_reason("host_unreadable", "issue:unknown", "closure snapshot must be an object")], completed=False)
+    subject = snapshot.get("subject")
+    issue_rows = snapshot.get("issues")
+    default_branch = snapshot.get("default_branch")
+    issues = {
+        row.get("number"): row
+        for row in issue_rows
+        if isinstance(row, dict) and isinstance(row.get("number"), int)
+    } if isinstance(issue_rows, list) else {}
+    subject_issue = issues.get(subject) if isinstance(subject, int) else None
+    if snapshot.get("host_readable", True) is not True or not isinstance(subject_issue, dict) or not isinstance(default_branch, str) or not default_branch:
+        return _payload(int(subject) if isinstance(subject, int) else 0, "reopen_required", "GitHub closure facts are unreadable.", [_reason("host_unreadable", f"issue:{subject or 'unknown'}", "subject, default branch, or native tree read is missing")], completed=False)
+    kind = _type(subject_issue)
+    labels = _labels(subject_issue)
+    if kind not in {"fr", "phase"}:
+        typed_labels = labels.intersection({"fr", "phase", "work_item"})
+        if typed_labels:
+            return _payload(subject, "reopen_required", "FR/Phase type labels are ambiguous.", [_reason("ambiguous_issue_type", f"issue:{subject}", "FR/Phase closure requires exactly one native type label")], completed=False)
+        return _payload(subject, "not_applicable", "Closed issue is not a uniquely typed FR or Phase.", [], completed=False)
+    if subject_issue.get("read_complete") is not True:
+        return _payload(subject, "reopen_required", "GitHub closure facts are incomplete.", [_reason("host_unreadable", f"issue:{subject}", "GitHub read pagination or a host request was incomplete")], completed=False)
+    state_reason = _text(subject_issue.get("state_reason"))
+    if DEFERRED_LABEL in labels:
+        if state_reason != "not_planned":
+            return _payload(subject, "reopen_required", "Deferred closure must use not planned semantics.", [_reason("deferred_requires_not_planned", f"issue:{subject}", "deferred closure cannot use completed semantics")], completed=False)
+        reasons = _deferred_ready(subject_issue)
+        return _payload(subject, "reopen_required", "Deferred closure lacks its recovery contract.", reasons, completed=False) if reasons else _payload(subject, "allow_non_completion_close", "Deferred item remains closed as deferred, not completed.", [], completed=False)
+    if state_reason == "not_planned":
+        return _payload(subject, "allow_non_completion_close", "Explicit non-completion closure is not counted as completed.", [], completed=False)
+    if labels.intersection(NON_COMPLETION_LABELS):
+        return _payload(subject, "reopen_required", "Non-completion labels must use not planned semantics.", [_reason("non_completion_requires_not_planned", f"issue:{subject}", "non-completion labels cannot use completed semantics")], completed=False)
+    reasons: list[dict[str, str]] = []
+    _validate_completed(subject_issue, issues, default_branch, reasons, set())
+    if reasons:
+        return _payload(subject, "reopen_required", "Completed FR/Phase closure is missing required host facts.", reasons, completed=False)
+    return _payload(subject, "allow_completed_close", "Native children, dependencies, merged PR reviews, and check evidence permit completed closure.", [], completed=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Evaluate one host snapshot without making a GitHub write."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--snapshot", type=Path, required=True, help="GitHub host snapshot JSON")
+    parser.add_argument("--output", type=Path, help="write the verdict JSON to this path")
+    args = parser.parse_args(argv)
+    try:
+        snapshot = json.loads(args.snapshot.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        verdict = _payload(0, "reopen_required", "GitHub closure snapshot is unreadable.", [_reason("host_unreadable", "issue:unknown", str(exc))], completed=False)
+    else:
+        verdict = evaluate_closure(snapshot)
+    rendered = json.dumps(verdict, ensure_ascii=False, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/shared/scripts/github_closure_guard.py
+++ b/skills/shared/scripts/github_closure_guard.py
@@ -1,0 +1,206 @@
+"""Host-native guard for completed FR and Phase closures.
+
+The evaluator consumes a complete GitHub snapshot.  It owns neither a
+repository carrier nor a host write: the ``issues.closed`` workflow owns the
+small reopen/comment recovery when this module returns ``reopen_required``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "loom-fr-phase-close-guard/v1"
+NON_COMPLETION_LABELS = {"duplicate", "invalid", "cancelled", "canceled", "superseded"}
+TYPE_LABELS = {"fr": "fr", "phase": "phase", "work-item": "work_item"}
+DEFERRED_LABEL = "deferred"
+EXPECTED_CHILD_TYPE = {"phase": "fr", "fr": "work_item"}
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip().casefold().replace("-", "_").replace(" ", "_")
+
+
+def _labels(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    return {_text(label) for label in labels if isinstance(label, str)} if isinstance(labels, list) else set()
+
+
+def _type(issue: dict[str, Any]) -> str:
+    declared = _text(issue.get("type"))
+    if declared in {"fr", "phase", "work_item"}:
+        return declared
+    inferred = {TYPE_LABELS[label.replace("_", "-")] for label in _labels(issue) if label.replace("_", "-") in TYPE_LABELS}
+    return inferred.pop() if len(inferred) == 1 else "unknown"
+
+
+def _reason(code: str, locator: str, message: str) -> dict[str, str]:
+    return {"code": code, "locator": locator, "message": message}
+
+
+def _payload(subject: int, verdict: str, summary: str, reasons: list[dict[str, str]], *, completed: bool) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA,
+        "result": "block" if verdict == "reopen_required" else "pass",
+        "verdict": verdict,
+        "summary": summary,
+        "subject": {"number": subject, "locator": f"issue:{subject}"},
+        "completed": completed,
+        "reasons": reasons,
+        "remediation": "reconcile native children, dependencies, merged PR reviews, and check evidence before closing again"
+        if verdict == "reopen_required"
+        else None,
+    }
+
+
+def _deferred_ready(issue: dict[str, Any]) -> list[dict[str, str]]:
+    body = str(issue.get("body") or "")
+    number = issue.get("number", "unknown")
+    reasons: list[dict[str, str]] = []
+    if not re.search(r"(?im)^#{1,6}\s*activation\s+policy\s*$\n\s*\S", body):
+        reasons.append(_reason("deferred_missing_activation_policy", f"issue:{number}", "deferred closure requires a non-empty Activation Policy section"))
+    if not re.search(r"(?im)^\s*(?:-\s*)?successor:\s*`?(?:phase|fr|work_item):\d+`?\s*$", body):
+        reasons.append(_reason("deferred_missing_typed_successor", f"issue:{number}", "deferred closure requires `Successor: phase|fr|work_item:<number>`"))
+    return reasons
+
+
+def _successful_check_rollup(pr: dict[str, Any]) -> bool:
+    rollup = pr.get("check_rollup")
+    if not isinstance(rollup, dict) or _text(rollup.get("state")) != "success" or rollup.get("contexts_complete") is not True:
+        return False
+    contexts = rollup.get("contexts")
+    return isinstance(contexts, list) and bool(contexts)
+
+
+def _approved_green_merged_pr(issue: dict[str, Any], default_branch: str) -> bool:
+    prs = issue.get("merged_prs")
+    if not isinstance(prs, list):
+        return False
+    for pr in prs:
+        if not isinstance(pr, dict) or pr.get("merged") is not True or pr.get("base_ref") != default_branch:
+            continue
+        pr_number, head_sha, merge_commit, commit_sha = pr.get("number"), pr.get("head_sha"), pr.get("merge_commit"), pr.get("commit_sha")
+        if not isinstance(pr_number, int) or not all(isinstance(value, str) and value for value in (head_sha, merge_commit, commit_sha)) or commit_sha != head_sha:
+            continue
+        if _text(pr.get("review_decision")) == "approved" and _successful_check_rollup(pr):
+            return True
+    return False
+
+
+def _validate_completed(
+    issue: dict[str, Any],
+    issues: dict[int, dict[str, Any]],
+    default_branch: str,
+    reasons: list[dict[str, str]],
+    visiting: set[int],
+) -> None:
+    number = issue.get("number")
+    locator = f"issue:{number}" if isinstance(number, int) else "issue:unknown"
+    if issue.get("read_complete") is not True:
+        reasons.append(_reason("host_unreadable", locator, "GitHub child, dependency, PR, or comment read is incomplete"))
+        return
+    if _text(issue.get("state")) != "closed" or _text(issue.get("state_reason")) != "completed":
+        reasons.append(_reason("child_not_completed", locator, "a completed parent requires every native child to be closed as completed"))
+        return
+    if not isinstance(number, int):
+        reasons.append(_reason("host_unreadable", locator, "GitHub issue number is unreadable"))
+        return
+    if number in visiting:
+        reasons.append(_reason("native_tree_cycle", locator, "native sub-issue tree must be acyclic"))
+        return
+    blockers = issue.get("blocked_by")
+    if not isinstance(blockers, list):
+        reasons.append(_reason("host_unreadable", locator, "native dependency read is incomplete"))
+        return
+    for blocker in blockers:
+        if not isinstance(blocker, dict) or _text(blocker.get("state")) != "closed":
+            reasons.append(_reason("open_native_blocker", locator, "completed closure cannot retain an open or unreadable native blocker"))
+    kind = _type(issue)
+    if kind == "work_item":
+        if not _approved_green_merged_pr(issue, default_branch):
+            reasons.append(_reason("missing_approved_merged_pr_or_green_check", locator, "Work Item needs a default-branch merged PR with an approved review and successful host check rollup"))
+        return
+    expected = EXPECTED_CHILD_TYPE.get(kind)
+    children = issue.get("children")
+    if expected is None or not isinstance(children, list) or not children:
+        reasons.append(_reason("missing_native_child", locator, "completed FR/Phase requires its native child tree"))
+        return
+    next_visiting = {*visiting, number}
+    for child_number in children:
+        child = issues.get(child_number) if isinstance(child_number, int) else None
+        if not isinstance(child, dict):
+            reasons.append(_reason("host_unreadable", locator, "a native child cannot be read from GitHub"))
+            continue
+        if _type(child) != expected:
+            reasons.append(_reason("invalid_native_child_type", f"issue:{child_number}", f"{kind} requires native {expected} children"))
+            continue
+        _validate_completed(child, issues, default_branch, reasons, next_visiting)
+
+
+def evaluate_closure(snapshot: object) -> dict[str, Any]:
+    """Decide whether a closed FR/Phase may remain closed from host facts only."""
+    if not isinstance(snapshot, dict):
+        return _payload(0, "reopen_required", "GitHub closure snapshot is unreadable.", [_reason("host_unreadable", "issue:unknown", "closure snapshot must be an object")], completed=False)
+    subject = snapshot.get("subject")
+    issue_rows = snapshot.get("issues")
+    default_branch = snapshot.get("default_branch")
+    issues = {
+        row.get("number"): row
+        for row in issue_rows
+        if isinstance(row, dict) and isinstance(row.get("number"), int)
+    } if isinstance(issue_rows, list) else {}
+    subject_issue = issues.get(subject) if isinstance(subject, int) else None
+    if snapshot.get("host_readable", True) is not True or not isinstance(subject_issue, dict) or not isinstance(default_branch, str) or not default_branch:
+        return _payload(int(subject) if isinstance(subject, int) else 0, "reopen_required", "GitHub closure facts are unreadable.", [_reason("host_unreadable", f"issue:{subject or 'unknown'}", "subject, default branch, or native tree read is missing")], completed=False)
+    kind = _type(subject_issue)
+    labels = _labels(subject_issue)
+    if kind not in {"fr", "phase"}:
+        typed_labels = labels.intersection({"fr", "phase", "work_item"})
+        if typed_labels:
+            return _payload(subject, "reopen_required", "FR/Phase type labels are ambiguous.", [_reason("ambiguous_issue_type", f"issue:{subject}", "FR/Phase closure requires exactly one native type label")], completed=False)
+        return _payload(subject, "not_applicable", "Closed issue is not a uniquely typed FR or Phase.", [], completed=False)
+    if subject_issue.get("read_complete") is not True:
+        return _payload(subject, "reopen_required", "GitHub closure facts are incomplete.", [_reason("host_unreadable", f"issue:{subject}", "GitHub read pagination or a host request was incomplete")], completed=False)
+    state_reason = _text(subject_issue.get("state_reason"))
+    if DEFERRED_LABEL in labels:
+        if state_reason != "not_planned":
+            return _payload(subject, "reopen_required", "Deferred closure must use not planned semantics.", [_reason("deferred_requires_not_planned", f"issue:{subject}", "deferred closure cannot use completed semantics")], completed=False)
+        reasons = _deferred_ready(subject_issue)
+        return _payload(subject, "reopen_required", "Deferred closure lacks its recovery contract.", reasons, completed=False) if reasons else _payload(subject, "allow_non_completion_close", "Deferred item remains closed as deferred, not completed.", [], completed=False)
+    if state_reason == "not_planned":
+        return _payload(subject, "allow_non_completion_close", "Explicit non-completion closure is not counted as completed.", [], completed=False)
+    if labels.intersection(NON_COMPLETION_LABELS):
+        return _payload(subject, "reopen_required", "Non-completion labels must use not planned semantics.", [_reason("non_completion_requires_not_planned", f"issue:{subject}", "non-completion labels cannot use completed semantics")], completed=False)
+    reasons: list[dict[str, str]] = []
+    _validate_completed(subject_issue, issues, default_branch, reasons, set())
+    if reasons:
+        return _payload(subject, "reopen_required", "Completed FR/Phase closure is missing required host facts.", reasons, completed=False)
+    return _payload(subject, "allow_completed_close", "Native children, dependencies, merged PR reviews, and check evidence permit completed closure.", [], completed=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Evaluate one host snapshot without making a GitHub write."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--snapshot", type=Path, required=True, help="GitHub host snapshot JSON")
+    parser.add_argument("--output", type=Path, help="write the verdict JSON to this path")
+    args = parser.parse_args(argv)
+    try:
+        snapshot = json.loads(args.snapshot.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        verdict = _payload(0, "reopen_required", "GitHub closure snapshot is unreadable.", [_reason("host_unreadable", "issue:unknown", str(exc))], completed=False)
+    else:
+        verdict = evaluate_closure(snapshot)
+    rendered = json.dumps(verdict, ensure_ascii=False, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/skills/shared/scripts/github_closure_guard.py
+++ b/src/skills/shared/scripts/github_closure_guard.py
@@ -1,0 +1,206 @@
+"""Host-native guard for completed FR and Phase closures.
+
+The evaluator consumes a complete GitHub snapshot.  It owns neither a
+repository carrier nor a host write: the ``issues.closed`` workflow owns the
+small reopen/comment recovery when this module returns ``reopen_required``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "loom-fr-phase-close-guard/v1"
+NON_COMPLETION_LABELS = {"duplicate", "invalid", "cancelled", "canceled", "superseded"}
+TYPE_LABELS = {"fr": "fr", "phase": "phase", "work-item": "work_item"}
+DEFERRED_LABEL = "deferred"
+EXPECTED_CHILD_TYPE = {"phase": "fr", "fr": "work_item"}
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip().casefold().replace("-", "_").replace(" ", "_")
+
+
+def _labels(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    return {_text(label) for label in labels if isinstance(label, str)} if isinstance(labels, list) else set()
+
+
+def _type(issue: dict[str, Any]) -> str:
+    declared = _text(issue.get("type"))
+    if declared in {"fr", "phase", "work_item"}:
+        return declared
+    inferred = {TYPE_LABELS[label.replace("_", "-")] for label in _labels(issue) if label.replace("_", "-") in TYPE_LABELS}
+    return inferred.pop() if len(inferred) == 1 else "unknown"
+
+
+def _reason(code: str, locator: str, message: str) -> dict[str, str]:
+    return {"code": code, "locator": locator, "message": message}
+
+
+def _payload(subject: int, verdict: str, summary: str, reasons: list[dict[str, str]], *, completed: bool) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA,
+        "result": "block" if verdict == "reopen_required" else "pass",
+        "verdict": verdict,
+        "summary": summary,
+        "subject": {"number": subject, "locator": f"issue:{subject}"},
+        "completed": completed,
+        "reasons": reasons,
+        "remediation": "reconcile native children, dependencies, merged PR reviews, and check evidence before closing again"
+        if verdict == "reopen_required"
+        else None,
+    }
+
+
+def _deferred_ready(issue: dict[str, Any]) -> list[dict[str, str]]:
+    body = str(issue.get("body") or "")
+    number = issue.get("number", "unknown")
+    reasons: list[dict[str, str]] = []
+    if not re.search(r"(?im)^#{1,6}\s*activation\s+policy\s*$\n\s*\S", body):
+        reasons.append(_reason("deferred_missing_activation_policy", f"issue:{number}", "deferred closure requires a non-empty Activation Policy section"))
+    if not re.search(r"(?im)^\s*(?:-\s*)?successor:\s*`?(?:phase|fr|work_item):\d+`?\s*$", body):
+        reasons.append(_reason("deferred_missing_typed_successor", f"issue:{number}", "deferred closure requires `Successor: phase|fr|work_item:<number>`"))
+    return reasons
+
+
+def _successful_check_rollup(pr: dict[str, Any]) -> bool:
+    rollup = pr.get("check_rollup")
+    if not isinstance(rollup, dict) or _text(rollup.get("state")) != "success" or rollup.get("contexts_complete") is not True:
+        return False
+    contexts = rollup.get("contexts")
+    return isinstance(contexts, list) and bool(contexts)
+
+
+def _approved_green_merged_pr(issue: dict[str, Any], default_branch: str) -> bool:
+    prs = issue.get("merged_prs")
+    if not isinstance(prs, list):
+        return False
+    for pr in prs:
+        if not isinstance(pr, dict) or pr.get("merged") is not True or pr.get("base_ref") != default_branch:
+            continue
+        pr_number, head_sha, merge_commit, commit_sha = pr.get("number"), pr.get("head_sha"), pr.get("merge_commit"), pr.get("commit_sha")
+        if not isinstance(pr_number, int) or not all(isinstance(value, str) and value for value in (head_sha, merge_commit, commit_sha)) or commit_sha != head_sha:
+            continue
+        if _text(pr.get("review_decision")) == "approved" and _successful_check_rollup(pr):
+            return True
+    return False
+
+
+def _validate_completed(
+    issue: dict[str, Any],
+    issues: dict[int, dict[str, Any]],
+    default_branch: str,
+    reasons: list[dict[str, str]],
+    visiting: set[int],
+) -> None:
+    number = issue.get("number")
+    locator = f"issue:{number}" if isinstance(number, int) else "issue:unknown"
+    if issue.get("read_complete") is not True:
+        reasons.append(_reason("host_unreadable", locator, "GitHub child, dependency, PR, or comment read is incomplete"))
+        return
+    if _text(issue.get("state")) != "closed" or _text(issue.get("state_reason")) != "completed":
+        reasons.append(_reason("child_not_completed", locator, "a completed parent requires every native child to be closed as completed"))
+        return
+    if not isinstance(number, int):
+        reasons.append(_reason("host_unreadable", locator, "GitHub issue number is unreadable"))
+        return
+    if number in visiting:
+        reasons.append(_reason("native_tree_cycle", locator, "native sub-issue tree must be acyclic"))
+        return
+    blockers = issue.get("blocked_by")
+    if not isinstance(blockers, list):
+        reasons.append(_reason("host_unreadable", locator, "native dependency read is incomplete"))
+        return
+    for blocker in blockers:
+        if not isinstance(blocker, dict) or _text(blocker.get("state")) != "closed":
+            reasons.append(_reason("open_native_blocker", locator, "completed closure cannot retain an open or unreadable native blocker"))
+    kind = _type(issue)
+    if kind == "work_item":
+        if not _approved_green_merged_pr(issue, default_branch):
+            reasons.append(_reason("missing_approved_merged_pr_or_green_check", locator, "Work Item needs a default-branch merged PR with an approved review and successful host check rollup"))
+        return
+    expected = EXPECTED_CHILD_TYPE.get(kind)
+    children = issue.get("children")
+    if expected is None or not isinstance(children, list) or not children:
+        reasons.append(_reason("missing_native_child", locator, "completed FR/Phase requires its native child tree"))
+        return
+    next_visiting = {*visiting, number}
+    for child_number in children:
+        child = issues.get(child_number) if isinstance(child_number, int) else None
+        if not isinstance(child, dict):
+            reasons.append(_reason("host_unreadable", locator, "a native child cannot be read from GitHub"))
+            continue
+        if _type(child) != expected:
+            reasons.append(_reason("invalid_native_child_type", f"issue:{child_number}", f"{kind} requires native {expected} children"))
+            continue
+        _validate_completed(child, issues, default_branch, reasons, next_visiting)
+
+
+def evaluate_closure(snapshot: object) -> dict[str, Any]:
+    """Decide whether a closed FR/Phase may remain closed from host facts only."""
+    if not isinstance(snapshot, dict):
+        return _payload(0, "reopen_required", "GitHub closure snapshot is unreadable.", [_reason("host_unreadable", "issue:unknown", "closure snapshot must be an object")], completed=False)
+    subject = snapshot.get("subject")
+    issue_rows = snapshot.get("issues")
+    default_branch = snapshot.get("default_branch")
+    issues = {
+        row.get("number"): row
+        for row in issue_rows
+        if isinstance(row, dict) and isinstance(row.get("number"), int)
+    } if isinstance(issue_rows, list) else {}
+    subject_issue = issues.get(subject) if isinstance(subject, int) else None
+    if snapshot.get("host_readable", True) is not True or not isinstance(subject_issue, dict) or not isinstance(default_branch, str) or not default_branch:
+        return _payload(int(subject) if isinstance(subject, int) else 0, "reopen_required", "GitHub closure facts are unreadable.", [_reason("host_unreadable", f"issue:{subject or 'unknown'}", "subject, default branch, or native tree read is missing")], completed=False)
+    kind = _type(subject_issue)
+    labels = _labels(subject_issue)
+    if kind not in {"fr", "phase"}:
+        typed_labels = labels.intersection({"fr", "phase", "work_item"})
+        if typed_labels:
+            return _payload(subject, "reopen_required", "FR/Phase type labels are ambiguous.", [_reason("ambiguous_issue_type", f"issue:{subject}", "FR/Phase closure requires exactly one native type label")], completed=False)
+        return _payload(subject, "not_applicable", "Closed issue is not a uniquely typed FR or Phase.", [], completed=False)
+    if subject_issue.get("read_complete") is not True:
+        return _payload(subject, "reopen_required", "GitHub closure facts are incomplete.", [_reason("host_unreadable", f"issue:{subject}", "GitHub read pagination or a host request was incomplete")], completed=False)
+    state_reason = _text(subject_issue.get("state_reason"))
+    if DEFERRED_LABEL in labels:
+        if state_reason != "not_planned":
+            return _payload(subject, "reopen_required", "Deferred closure must use not planned semantics.", [_reason("deferred_requires_not_planned", f"issue:{subject}", "deferred closure cannot use completed semantics")], completed=False)
+        reasons = _deferred_ready(subject_issue)
+        return _payload(subject, "reopen_required", "Deferred closure lacks its recovery contract.", reasons, completed=False) if reasons else _payload(subject, "allow_non_completion_close", "Deferred item remains closed as deferred, not completed.", [], completed=False)
+    if state_reason == "not_planned":
+        return _payload(subject, "allow_non_completion_close", "Explicit non-completion closure is not counted as completed.", [], completed=False)
+    if labels.intersection(NON_COMPLETION_LABELS):
+        return _payload(subject, "reopen_required", "Non-completion labels must use not planned semantics.", [_reason("non_completion_requires_not_planned", f"issue:{subject}", "non-completion labels cannot use completed semantics")], completed=False)
+    reasons: list[dict[str, str]] = []
+    _validate_completed(subject_issue, issues, default_branch, reasons, set())
+    if reasons:
+        return _payload(subject, "reopen_required", "Completed FR/Phase closure is missing required host facts.", reasons, completed=False)
+    return _payload(subject, "allow_completed_close", "Native children, dependencies, merged PR reviews, and check evidence permit completed closure.", [], completed=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Evaluate one host snapshot without making a GitHub write."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--snapshot", type=Path, required=True, help="GitHub host snapshot JSON")
+    parser.add_argument("--output", type=Path, help="write the verdict JSON to this path")
+    args = parser.parse_args(argv)
+    try:
+        snapshot = json.loads(args.snapshot.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        verdict = _payload(0, "reopen_required", "GitHub closure snapshot is unreadable.", [_reason("host_unreadable", "issue:unknown", str(exc))], completed=False)
+    else:
+        verdict = evaluate_closure(snapshot)
+    rendered = json.dumps(verdict, ensure_ascii=False, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_fr_phase_close_guard.py
+++ b/tools/check_fr_phase_close_guard.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Focused contract checks for the host-native FR/Phase closure evaluator."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "src" / "skills" / "shared" / "scripts" / "github_closure_guard.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("github_closure_guard", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise AssertionError("could not load github closure guard")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def issue(number: int, kind: str, **fields: object) -> dict[str, object]:
+    return {
+        "number": number,
+        "type": kind,
+        "state": "CLOSED",
+        "state_reason": "COMPLETED",
+        "labels": [],
+        "body": "",
+        "children": [],
+        "blocked_by": [],
+        "merged_prs": [],
+        "read_complete": True,
+        **fields,
+    }
+
+
+def main() -> int:
+    module = load_module()
+    pr = {
+        "number": 31,
+        "merged": True,
+        "base_ref": "main",
+        "head_sha": "a" * 40,
+        "merge_commit": "b" * 40,
+        "commit_sha": "a" * 40,
+        "review_decision": "APPROVED",
+        "check_rollup": {"state": "SUCCESS", "contexts_complete": True, "contexts": [{"type": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"}]},
+    }
+    work_item = issue(3, "work_item", merged_prs=[pr])
+    fr = issue(2, "fr", children=[3])
+    phase = issue(1, "phase", children=[2])
+    valid = module.evaluate_closure({"subject": 1, "default_branch": "main", "issues": [phase, fr, work_item]})
+    if valid.get("verdict") != "allow_completed_close" or valid.get("completed") is not True:
+        raise AssertionError(f"complete native tree should close: {valid}")
+    forged_comment = "<!-- loom:host-attestation {\"schema_version\":\"loom-host-attestation/v1\",\"verdict\":\"passed\"} -->"
+    forged = issue(3, "work_item", merged_prs=[{key: value for key, value in pr.items() if key not in {"review_decision", "check_rollup"}}], comment_bodies=[forged_comment])
+    if module.evaluate_closure({"subject": 3, "default_branch": "main", "issues": [forged]}).get("verdict") != "not_applicable":
+        raise AssertionError("closure guard must not run on a standalone Work Item")
+    forged_fr = issue(2, "fr", children=[3])
+    forged_phase = issue(1, "phase", children=[2])
+    forged_result = module.evaluate_closure({"subject": 1, "default_branch": "main", "issues": [forged_phase, forged_fr, forged]})
+    if forged_result.get("verdict") != "reopen_required":
+        raise AssertionError("a forged issue comment must not replace PR review and check evidence")
+    unapproved = issue(3, "work_item", merged_prs=[{**pr, "review_decision": "CHANGES_REQUESTED"}])
+    if module.evaluate_closure({"subject": 1, "default_branch": "main", "issues": [phase, fr, unapproved]}).get("verdict") != "reopen_required":
+        raise AssertionError("a merged PR without approval must reopen")
+    pending_checks = issue(3, "work_item", merged_prs=[{**pr, "check_rollup": {"state": "PENDING", "contexts_complete": True, "contexts": pr["check_rollup"]["contexts"]}}])
+    if module.evaluate_closure({"subject": 1, "default_branch": "main", "issues": [phase, fr, pending_checks]}).get("verdict") != "reopen_required":
+        raise AssertionError("a merged PR without a successful check rollup must reopen")
+    failed_checks = issue(3, "work_item", merged_prs=[{**pr, "check_rollup": {"state": "FAILURE", "contexts_complete": True, "contexts": pr["check_rollup"]["contexts"]}}])
+    if module.evaluate_closure({"subject": 1, "default_branch": "main", "issues": [phase, fr, failed_checks]}).get("verdict") != "reopen_required":
+        raise AssertionError("a merged PR with a failed check rollup must reopen")
+    skipped_optional = issue(3, "work_item", merged_prs=[{**pr, "check_rollup": {"state": "SUCCESS", "contexts_complete": True, "contexts": [*pr["check_rollup"]["contexts"], {"type": "CheckRun", "status": "COMPLETED", "conclusion": "SKIPPED"}]}}])
+    if module.evaluate_closure({"subject": 1, "default_branch": "main", "issues": [phase, fr, skipped_optional]}).get("verdict") != "allow_completed_close":
+        raise AssertionError("a successful aggregate rollup must allow intentionally skipped optional checks")
+    missing_child = module.evaluate_closure({"subject": 2, "default_branch": "main", "issues": [issue(2, "fr")]})
+    if missing_child.get("verdict") != "reopen_required" or not any(reason.get("code") == "missing_native_child" for reason in missing_child.get("reasons", [])):
+        raise AssertionError(f"FR without a Work Item must reopen: {missing_child}")
+    deferred = issue(4, "fr", labels=["deferred"], state_reason="NOT_PLANNED")
+    blocked_deferred = module.evaluate_closure({"subject": 4, "default_branch": "main", "issues": [deferred]})
+    if blocked_deferred.get("verdict") != "reopen_required" or len(blocked_deferred.get("reasons", [])) != 2:
+        raise AssertionError(f"deferred item without recovery contract must reopen: {blocked_deferred}")
+    deferred["body"] = "## Activation Policy\n\nResume after provider approval.\n\nSuccessor: work_item:5\n"
+    allowed_deferred = module.evaluate_closure({"subject": 4, "default_branch": "main", "issues": [deferred]})
+    if allowed_deferred.get("verdict") != "allow_non_completion_close" or allowed_deferred.get("completed") is not False:
+        raise AssertionError(f"deferred item must not be counted completed: {allowed_deferred}")
+    deferred_completed = issue(4, "fr", labels=["deferred"], state_reason="COMPLETED", body=deferred["body"])
+    if module.evaluate_closure({"subject": 4, "default_branch": "main", "issues": [deferred_completed]}).get("verdict") != "reopen_required":
+        raise AssertionError("deferred closure must not use completed semantics")
+    duplicate_completed = issue(5, "fr", labels=["duplicate"])
+    if module.evaluate_closure({"subject": 5, "default_branch": "main", "issues": [duplicate_completed]}).get("verdict") != "reopen_required":
+        raise AssertionError("non-completion label must not use completed semantics")
+    ambiguous = issue(6, "unknown", labels=["fr", "phase"])
+    if module.evaluate_closure({"subject": 6, "default_branch": "main", "issues": [ambiguous]}).get("verdict") != "reopen_required":
+        raise AssertionError("ambiguous FR/Phase type must not bypass the guard")
+    unreadable = module.evaluate_closure({"subject": 2, "default_branch": "main", "issues": [issue(2, "fr", read_complete=False)]})
+    if unreadable.get("verdict") != "reopen_required" or unreadable.get("reasons", [{}])[0].get("code") != "host_unreadable":
+        raise AssertionError(f"unreadable host facts must fail closed: {unreadable}")
+    print("fr/phase closure guard contract: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_fr_phase_close_guard_workflow.py
+++ b/tools/check_fr_phase_close_guard_workflow.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Keep the FR/Phase close guard on the trusted issues.closed boundary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "loom-fr-phase-close-guard.yml"
+
+
+def main() -> int:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    required = (
+        "name: loom-fr-phase-close-guard",
+        "issues:",
+        "types: [closed]",
+        "contents: read",
+        "issues: write",
+        "pull-requests: read",
+        "concurrency:",
+        "loom-fr-phase-close-guard-${{ github.repository }}-${{ github.event.issue.number }}",
+        "cancel-in-progress: false",
+        "actions/github-script@v7",
+        "github.graphql",
+        "github.paginate",
+        "github_closure_guard.py",
+        "--snapshot",
+        "--output",
+        "Checkout trusted default branch evaluator",
+        "ref: ${{ github.event.repository.default_branch }}",
+        "github.rest.issues.update",
+        "github.rest.issues.get",
+        "github.rest.issues.createComment",
+        "github.rest.issues.getComment",
+        "comment_id: created.id",
+        "reopen_required",
+        "defaultBranchRef",
+        "closedByPullRequestsReferences",
+        "reviewDecision",
+        "statusCheckRollup",
+        "comment_bodies",
+        "hasSnapshotMarker",
+        "remediationMarker",
+    )
+    forbidden = (
+        "pull_request:",
+        "pull_request_target:",
+        "tools/loom_flow.py",
+        "current.md",
+        "head.sha",
+        "const evaluate",
+        "validateCompleted",
+    )
+    missing = [needle for needle in required if needle not in text]
+    present = [needle for needle in forbidden if needle in text]
+    if missing or present:
+        details = [*(f"missing `{needle}`" for needle in missing), *(f"forbidden `{needle}`" for needle in present)]
+        raise SystemExit("FR/Phase close guard workflow contract failed: " + "; ".join(details))
+    print("FR/Phase close guard workflow contract: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- `issues.closed` 只读取 GitHub 原生 sub-issue、依赖、default-branch merged PR、approved review 与完整 successful check rollup；FR/Phase 的 completed 关闭缺任一证据时自动恢复。
- 唯一 Python evaluator 覆盖 completed、not planned/deferred、分页/权限不完整与类型歧义；issue comment 仅能补充说明，不能单独通过验证。aggregate rollup 为 GitHub 对 required/optional checks 的权威结果，允许 intentional skipped/neutral optional checks。
- 每个 issue guard 串行执行；仅 checkout default branch 的 evaluator，并且只在 `reopen_required` 时 reopen、host readback 后以稳定 marker 至多写一条 remediation；创建 comment 后再次 host readback marker。

## Validation

- [x] `make py-compile`
- [x] `make fr-phase-close-guard-check`（含伪造 comment、无 approved、aggregate PENDING/FAILURE、skipped optional 与有效 host PR evidence）
- [x] `make loom-check`（45 个 source/distribution surfaces；初始提交）
- [x] `python3 tools/skills_surface.py check --surface generated-tree-drift`
- [x] `python3 tools/check_npm_package.py --surface runtime-copy-parity`
- [x] `make release-surface-check`
- [x] GitHub Script JavaScript syntax check

## Related Work

- Issue: #1989
- Work Item: `work_item:1989`
- Spec / plan: not applicable；本 PR 仅实现已冻结的 host-native close guard，验证来自 focused contract、workflow contract、完整 source self-check 与 generated distribution proof。

Closes #1989
