### PR TITLE
fix(gate): 修正 reusable workflow YAML 描述

### DIFF
--- a/.github/workflows/loom-delivery-gate.yml
+++ b/.github/workflows/loom-delivery-gate.yml
@@ -24,7 +24,7 @@ on:
         required: true
         type: string
       enforcement:
-        description: Required delivery-gate mode: advisory records the result; enforce fails a non-passing terminal check.
+        description: "Required delivery-gate mode: advisory records the result; enforce fails a non-passing terminal check."
         required: true
         type: string
     outputs:

--- a/tools/check_delivery_gate.py
+++ b/tools/check_delivery_gate.py
@@ -321,7 +321,7 @@ def check_workflow() -> None:
         "default: make delivery-gate-check",
         "loom_ref:",
         "enforcement:",
-        "Required delivery-gate mode",
+        'description: "Required delivery-gate mode: advisory records the result; enforce fails a non-passing terminal check."',
         "required: true",
         "^[0-9a-f]{40}$",
         "loom-delivery-gate:",


### PR DESCRIPTION
## Summary

- 将 reusable `workflow_call` 的 enforcement description 改为引用 YAML scalar，避免 `:` 触发 GitHub 调用端编译失败。
- 增加合同断言，要求该 description 保持引用形式。

## Validation

- Ruby YAML 解析 `.github/workflows/loom-delivery-gate.yml`
- `make delivery-gate-check`
- `make py-compile`
- `git diff --check`

## Risks And Follow-ups

- Lode #260 将在此 PR 合入后更新为最终 SHA 并重新取得 enforce hosted evidence；不改 Lode protection/ruleset 或任何 carrier。

## Related Work

- Work Item: work_item:2007
- Parent FR: #1986

Closes #2007
