### PR TITLE
fix: 接入真实收口命令与证据工件

### DIFF
--- a/.github/workflows/host-attestation-evidence.yml
+++ b/.github/workflows/host-attestation-evidence.yml
@@ -1,0 +1,34 @@
+name: loom-host-attestation-evidence
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  host-attestation-evidence:
+    name: host-attestation-evidence
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Write host-generated evidence locator
+        shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          printf '{"schema_version":"loom-host-attestation-evidence/v1","pr_number":%s,"head_sha":"%s","base_ref":"%s"}\n' "$PR_NUMBER" "$HEAD_SHA" "$BASE_REF" > "$RUNNER_TEMP/host-attestation.json"
+      - name: Upload host attestation evidence
+        id: artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: loom-host-attestation-${{ github.event.pull_request.number }}
+          path: ${{ runner.temp }}/host-attestation.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.loom/bin/github_host.py
+++ b/.loom/bin/github_host.py
@@ -31,6 +31,7 @@ HOST_API_NEXT_ACTIONS = {
     ),
 }
 SHA256_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+HOST_ATTESTATION_WORKFLOW_PATH = ".github/workflows/host-attestation-evidence.yml"
 
 
 def run_process(
@@ -376,17 +377,15 @@ def github_pr_attestation_readback(
         return None, run_errors or ["GitHub Actions workflow run read returned no object"]
     pull_requests = run.get("pull_requests")
     run_pr_numbers = {row.get("number") for row in pull_requests if isinstance(row, dict)} if isinstance(pull_requests, list) else set()
-    expected_path = f"@refs/heads/{base_ref}"
     if (
         run.get("head_sha") != head_sha
-        or run.get("event") != "pull_request"
+        or run.get("event") != "pull_request_target"
         or str(run.get("status") or "").lower() != "completed"
         or str(run.get("conclusion") or "").lower() != "success"
-        or pr_number not in run_pr_numbers
-        or not isinstance(run.get("path"), str)
-        or not str(run.get("path")).endswith(expected_path)
+        or run.get("path") != HOST_ATTESTATION_WORKFLOW_PATH
+        or (run_pr_numbers and pr_number not in run_pr_numbers)
     ):
-        return None, ["GitHub Actions workflow run is not a completed successful base-branch pull_request run for this PR head"]
+        return None, ["GitHub Actions workflow run is not the completed successful host-attestation pull_request_target run for this PR head"]
     return {
         "source": "github",
         "read_complete": True,

--- a/.loom/bootstrap/manifest.json
+++ b/.loom/bootstrap/manifest.json
@@ -174,7 +174,7 @@
       "path": ".loom/bin/github_host.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/github_host.py",
-      "sha256": "902b5dc2651eef3e519844c2dea558fbc9101f674a5a8c67e828785c63c7a290"
+      "sha256": "94594ccbba49fd213d62371d74ed8d99b1babc6e97b00bf5d6398afed77e1821"
     },
     {
       "path": ".loom/bin/loom_flow.py",

--- a/examples/new-project/.loom/bin/github_host.py
+++ b/examples/new-project/.loom/bin/github_host.py
@@ -31,6 +31,7 @@ HOST_API_NEXT_ACTIONS = {
     ),
 }
 SHA256_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+HOST_ATTESTATION_WORKFLOW_PATH = ".github/workflows/host-attestation-evidence.yml"
 
 
 def run_process(
@@ -376,17 +377,15 @@ def github_pr_attestation_readback(
         return None, run_errors or ["GitHub Actions workflow run read returned no object"]
     pull_requests = run.get("pull_requests")
     run_pr_numbers = {row.get("number") for row in pull_requests if isinstance(row, dict)} if isinstance(pull_requests, list) else set()
-    expected_path = f"@refs/heads/{base_ref}"
     if (
         run.get("head_sha") != head_sha
-        or run.get("event") != "pull_request"
+        or run.get("event") != "pull_request_target"
         or str(run.get("status") or "").lower() != "completed"
         or str(run.get("conclusion") or "").lower() != "success"
-        or pr_number not in run_pr_numbers
-        or not isinstance(run.get("path"), str)
-        or not str(run.get("path")).endswith(expected_path)
+        or run.get("path") != HOST_ATTESTATION_WORKFLOW_PATH
+        or (run_pr_numbers and pr_number not in run_pr_numbers)
     ):
-        return None, ["GitHub Actions workflow run is not a completed successful base-branch pull_request run for this PR head"]
+        return None, ["GitHub Actions workflow run is not the completed successful host-attestation pull_request_target run for this PR head"]
     return {
         "source": "github",
         "read_complete": True,

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -510,7 +510,7 @@
       "path": ".loom/bin/github_host.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/github_host.py",
-      "sha256": "902b5dc2651eef3e519844c2dea558fbc9101f674a5a8c67e828785c63c7a290"
+      "sha256": "94594ccbba49fd213d62371d74ed8d99b1babc6e97b00bf5d6398afed77e1821"
     },
     {
       "path": ".loom/bin/loom_flow.py",
@@ -1348,7 +1348,7 @@
           "branch": {
             "status": "present",
             "locator": "${CURRENT_BRANCH}",
-            "authority": "bootstrap host binding"
+            "authority": "git"
           },
           "worktree": {
             "status": "present",
@@ -1513,7 +1513,7 @@
               "id": "host_binding.branch",
               "status": "present",
               "locator": "${CURRENT_BRANCH}",
-              "authority": "bootstrap host binding"
+              "authority": "git"
             },
             {
               "id": "host_binding.worktree",

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -174,7 +174,7 @@
       "path": ".loom/bin/github_host.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/github_host.py",
-      "sha256": "902b5dc2651eef3e519844c2dea558fbc9101f674a5a8c67e828785c63c7a290"
+      "sha256": "94594ccbba49fd213d62371d74ed8d99b1babc6e97b00bf5d6398afed77e1821"
     },
     {
       "path": ".loom/bin/loom_flow.py",

--- a/plugins/loom/.codex-plugin/plugin.json
+++ b/plugins/loom/.codex-plugin/plugin.json
@@ -23,7 +23,7 @@
     "source_git_sha": "unreleased",
     "source_git_sha_status": "pending_release_commit",
     "plugin_payload_version": "0.28.1",
-    "plugin_payload_hash": "f8a45bf810d4fbbd896981ad07550c3448de7f78aac20b939de1a8e896503b61",
+    "plugin_payload_hash": "f8a2dd95dd79fb9bff1edcec33d8483f1a0506f27051da19bfbb4914e2d3fdfa",
     "repository_payload": false
   },
   "keywords": [

--- a/plugins/loom/skills/shared/scripts/github_host.py
+++ b/plugins/loom/skills/shared/scripts/github_host.py
@@ -31,6 +31,7 @@ HOST_API_NEXT_ACTIONS = {
     ),
 }
 SHA256_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+HOST_ATTESTATION_WORKFLOW_PATH = ".github/workflows/host-attestation-evidence.yml"
 
 
 def run_process(
@@ -376,17 +377,15 @@ def github_pr_attestation_readback(
         return None, run_errors or ["GitHub Actions workflow run read returned no object"]
     pull_requests = run.get("pull_requests")
     run_pr_numbers = {row.get("number") for row in pull_requests if isinstance(row, dict)} if isinstance(pull_requests, list) else set()
-    expected_path = f"@refs/heads/{base_ref}"
     if (
         run.get("head_sha") != head_sha
-        or run.get("event") != "pull_request"
+        or run.get("event") != "pull_request_target"
         or str(run.get("status") or "").lower() != "completed"
         or str(run.get("conclusion") or "").lower() != "success"
-        or pr_number not in run_pr_numbers
-        or not isinstance(run.get("path"), str)
-        or not str(run.get("path")).endswith(expected_path)
+        or run.get("path") != HOST_ATTESTATION_WORKFLOW_PATH
+        or (run_pr_numbers and pr_number not in run_pr_numbers)
     ):
-        return None, ["GitHub Actions workflow run is not a completed successful base-branch pull_request run for this PR head"]
+        return None, ["GitHub Actions workflow run is not the completed successful host-attestation pull_request_target run for this PR head"]
     return {
         "source": "github",
         "read_complete": True,

--- a/skills/shared/scripts/github_host.py
+++ b/skills/shared/scripts/github_host.py
@@ -31,6 +31,7 @@ HOST_API_NEXT_ACTIONS = {
     ),
 }
 SHA256_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+HOST_ATTESTATION_WORKFLOW_PATH = ".github/workflows/host-attestation-evidence.yml"
 
 
 def run_process(
@@ -376,17 +377,15 @@ def github_pr_attestation_readback(
         return None, run_errors or ["GitHub Actions workflow run read returned no object"]
     pull_requests = run.get("pull_requests")
     run_pr_numbers = {row.get("number") for row in pull_requests if isinstance(row, dict)} if isinstance(pull_requests, list) else set()
-    expected_path = f"@refs/heads/{base_ref}"
     if (
         run.get("head_sha") != head_sha
-        or run.get("event") != "pull_request"
+        or run.get("event") != "pull_request_target"
         or str(run.get("status") or "").lower() != "completed"
         or str(run.get("conclusion") or "").lower() != "success"
-        or pr_number not in run_pr_numbers
-        or not isinstance(run.get("path"), str)
-        or not str(run.get("path")).endswith(expected_path)
+        or run.get("path") != HOST_ATTESTATION_WORKFLOW_PATH
+        or (run_pr_numbers and pr_number not in run_pr_numbers)
     ):
-        return None, ["GitHub Actions workflow run is not a completed successful base-branch pull_request run for this PR head"]
+        return None, ["GitHub Actions workflow run is not the completed successful host-attestation pull_request_target run for this PR head"]
     return {
         "source": "github",
         "read_complete": True,

--- a/src/skills/shared/scripts/github_host.py
+++ b/src/skills/shared/scripts/github_host.py
@@ -31,6 +31,7 @@ HOST_API_NEXT_ACTIONS = {
     ),
 }
 SHA256_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+HOST_ATTESTATION_WORKFLOW_PATH = ".github/workflows/host-attestation-evidence.yml"
 
 
 def run_process(
@@ -376,17 +377,15 @@ def github_pr_attestation_readback(
         return None, run_errors or ["GitHub Actions workflow run read returned no object"]
     pull_requests = run.get("pull_requests")
     run_pr_numbers = {row.get("number") for row in pull_requests if isinstance(row, dict)} if isinstance(pull_requests, list) else set()
-    expected_path = f"@refs/heads/{base_ref}"
     if (
         run.get("head_sha") != head_sha
-        or run.get("event") != "pull_request"
+        or run.get("event") != "pull_request_target"
         or str(run.get("status") or "").lower() != "completed"
         or str(run.get("conclusion") or "").lower() != "success"
-        or pr_number not in run_pr_numbers
-        or not isinstance(run.get("path"), str)
-        or not str(run.get("path")).endswith(expected_path)
+        or run.get("path") != HOST_ATTESTATION_WORKFLOW_PATH
+        or (run_pr_numbers and pr_number not in run_pr_numbers)
     ):
-        return None, ["GitHub Actions workflow run is not a completed successful base-branch pull_request run for this PR head"]
+        return None, ["GitHub Actions workflow run is not the completed successful host-attestation pull_request_target run for this PR head"]
     return {
         "source": "github",
         "read_complete": True,

--- a/tools/check_host_attestation.py
+++ b/tools/check_host_attestation.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / "src/skills/shared/scripts"
+WORKFLOW = ROOT / ".github" / "workflows" / "host-attestation-evidence.yml"
 sys.path.insert(0, str(SCRIPTS))
 
 import github_host
@@ -17,6 +18,11 @@ spec = importlib.util.spec_from_file_location("host_attestation", SCRIPTS / "hos
 module = importlib.util.module_from_spec(spec)
 assert spec and spec.loader
 spec.loader.exec_module(module)
+
+cli_spec = importlib.util.spec_from_file_location("loom_cli", ROOT / "tools" / "loom.py")
+cli = importlib.util.module_from_spec(cli_spec)
+assert cli_spec and cli_spec.loader
+cli_spec.loader.exec_module(cli)
 
 HEAD, MERGE = "a" * 40, "b" * 40
 
@@ -33,7 +39,7 @@ def facts(*, merged: bool = False, issue_completed: bool = True, compare_status:
         "repos/o/r/git/trees/tree-head?recursive=1": {"truncated": truncated, "tree": [{"path": "src/a.py", "sha": "c" * 40, "mode": "100644", "type": "blob"}]},
         "repos/o/r": {"default_branch": "main"},
         "repos/o/r/actions/artifacts/7": {"id": 7, "digest": "sha256:" + "d" * 64, "expired": False, "name": "review", "workflow_run": {"id": 9}},
-        "repos/o/r/actions/runs/9": {"id": 9, "event": "pull_request", "status": "completed", "conclusion": "success", "head_sha": run_head, "workflow_id": 3, "path": ".github/workflows/loom.yml@refs/heads/main", "pull_requests": [{"number": 1}]},
+        "repos/o/r/actions/runs/9": {"id": 9, "event": "pull_request_target", "status": "completed", "conclusion": "success", "head_sha": run_head, "workflow_id": 3, "path": ".github/workflows/host-attestation-evidence.yml", "pull_requests": [{"number": 1}]},
     }
     if merged:
         trees.update({
@@ -117,5 +123,47 @@ with tempfile.TemporaryDirectory() as directory:
         pass
     else:
         raise AssertionError("locally asserted digest must be rejected")
+
+forwarded: list[str] = []
+original_attestation_main = cli.host_attestation_main
+cli.host_attestation_main = lambda argv: forwarded.extend(argv) or 17
+try:
+    status = cli.main(
+        [
+            "loom",
+            "attestation",
+            "closeout",
+            "--repo",
+            "o/r",
+            "--pr",
+            "1",
+            "--work-item",
+            "2025",
+            "--artifact-input",
+            "artifact.json",
+            "--json",
+        ]
+    )
+finally:
+    cli.host_attestation_main = original_attestation_main
+assert status == 17
+assert forwarded == [
+    "closeout",
+    "--repo",
+    "o/r",
+    "--pr",
+    "1",
+    "--work-item",
+    "2025",
+    "--artifact-input",
+    "artifact.json",
+    "--json",
+]
+
+workflow = WORKFLOW.read_text(encoding="utf-8")
+for required in ("pull_request_target:", "host-attestation-evidence", "actions/upload-artifact@v4", "contents: read", "retention-days: 14"):
+    assert required in workflow, f"host-attestation workflow is missing {required}"
+for forbidden in ("actions/checkout", "github.event.pull_request.title", "github.event.pull_request.body", "secrets."):
+    assert forbidden not in workflow, f"host-attestation workflow must not consume {forbidden}"
 
 print("host attestation checks passed")

--- a/tools/loom.py
+++ b/tools/loom.py
@@ -65,6 +65,7 @@ for shared_scripts_root in reversed(SHARED_SCRIPT_CANDIDATES):
     if shared_scripts_root.is_dir() and str(shared_scripts_root) not in sys.path:
         sys.path.insert(0, str(shared_scripts_root))
 from runtime_paths import global_runtime_path, is_global_runtime_locator
+from host_attestation import main as host_attestation_main
 from product_acceptance import main as product_acceptance_main
 
 LOOM_BOOTSTRAP_START = "<!-- LOOM_BOOTSTRAP_START -->"
@@ -15172,6 +15173,9 @@ def main(argv: list[str]) -> int:
     if command == "acceptance" or command.startswith("acceptance "):
         acceptance_args = command.split()[1:] + forwarded if command.startswith("acceptance ") else forwarded
         return product_acceptance_main(acceptance_args)
+    if command == "attestation" or command.startswith("attestation "):
+        attestation_args = command.split()[1:] + forwarded if command.startswith("attestation ") else forwarded
+        return host_attestation_main(attestation_args)
     if command == "init":
         return handle_init(forwarded)
     if command == "adopt" or command.startswith("adopt "):


### PR DESCRIPTION
## 摘要

- 将 `loom attestation readback/closeout` 接入顶层 CLI。
- 新增不 checkout PR head 的 `pull_request_target` evidence workflow，仅上传 GitHub 生成的 PR/head/base locator。
- attestation readback 仅接受该受信 workflow 的 artifact；保留 GitHub host readback、semantic tree、approval 和原生 Work Item 关闭关系。

## 验证

- `python3 tools/check_host_attestation.py`
- `python3 tools/skills_surface.py check`
- `python3 tools/check_npm_package.py --surface aggregate`
- `make py-compile`
- `python3 tools/check_cli_contract.py`（23/23 surface passed；本次 dispatch 改动前复验）

## Related Work

- Work Item: work_item:2025
- Closes #2025
