### PR TITLE
feat(delivery): 强制 light carrier 门禁

### DIFF
--- a/.github/workflows/loom-delivery-gate.yml
+++ b/.github/workflows/loom-delivery-gate.yml
@@ -156,7 +156,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Evaluate advisory delivery facts
+      - name: Evaluate delivery facts
         id: evaluate
         if: ${{ always() }}
         continue-on-error: true
@@ -165,10 +165,11 @@ jobs:
           HOST_FACTS_PATH: ${{ runner.temp }}/loom-delivery-host-facts.json
           DELIVERY_GATE_PLAN_PATH: ${{ runner.temp }}/loom-delivery-gate-plan.json
           LOOM_SOURCE_PATH: ${{ inputs.loom_ref != '' && 'loom' || '.' }}
-          DELIVERY_GATE_ENFORCEMENT: ${{ inputs.loom_ref != '' && inputs.enforcement || 'advisory' }}
+          CANDIDATE_PATH: ${{ inputs.loom_ref != '' && 'candidate' || '.' }}
+          DELIVERY_GATE_ENFORCEMENT: ${{ inputs.loom_ref != '' && inputs.enforcement || 'enforce' }}
         run: |
           set -u
-          python3 "$LOOM_SOURCE_PATH/src/skills/shared/scripts/delivery_gate.py" --host-facts-file "$HOST_FACTS_PATH" --enforcement "$DELIVERY_GATE_ENFORCEMENT" --output "$DELIVERY_GATE_PLAN_PATH"
+          python3 "$LOOM_SOURCE_PATH/src/skills/shared/scripts/delivery_gate.py" --host-facts-file "$HOST_FACTS_PATH" --candidate-path "$CANDIDATE_PATH" --enforcement "$DELIVERY_GATE_ENFORCEMENT" --output "$DELIVERY_GATE_PLAN_PATH"
           COMMAND="$(python3 - "$DELIVERY_GATE_PLAN_PATH" <<'PY'
           import json
           import sys
@@ -218,12 +219,14 @@ jobs:
           VALIDATION_RESULT_PATH: ${{ runner.temp }}/loom-delivery-native-validation.json
           DELIVERY_GATE_PATH: ${{ runner.temp }}/loom-delivery-gate.json
           LOOM_SOURCE_PATH: ${{ inputs.loom_ref != '' && 'loom' || '.' }}
-          DELIVERY_GATE_ENFORCEMENT: ${{ inputs.loom_ref != '' && inputs.enforcement || 'advisory' }}
+          CANDIDATE_PATH: ${{ inputs.loom_ref != '' && 'candidate' || '.' }}
+          DELIVERY_GATE_ENFORCEMENT: ${{ inputs.loom_ref != '' && inputs.enforcement || 'enforce' }}
         run: |
           set -u
           python3 "$LOOM_SOURCE_PATH/src/skills/shared/scripts/delivery_gate.py" \
             --host-facts-file "$HOST_FACTS_PATH" \
             --validation-result-file "$VALIDATION_RESULT_PATH" \
+            --candidate-path "$CANDIDATE_PATH" \
             --enforcement "$DELIVERY_GATE_ENFORCEMENT" \
             --output "$DELIVERY_GATE_PATH"
 
@@ -233,7 +236,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           DELIVERY_GATE_PATH: ${{ runner.temp }}/loom-delivery-gate.json
-          DELIVERY_GATE_ENFORCEMENT: ${{ inputs.loom_ref != '' && inputs.enforcement || 'advisory' }}
+          DELIVERY_GATE_ENFORCEMENT: ${{ inputs.loom_ref != '' && inputs.enforcement || 'enforce' }}
         with:
           script: |
             const fs = require("fs");

--- a/docs/adoption/ci-required-checks-bootstrap.md
+++ b/docs/adoption/ci-required-checks-bootstrap.md
@@ -47,7 +47,9 @@ Loom 不把 workflow 文件存在解释为宿主强制门禁。强制能力仍�
 
 ## Delivery Gate Enforcement 与身份 readback
 
-`loom-delivery-gate` 的 direct Loom PR 固定以 `advisory` 运行：它总会写出一个 primary cause，但不会因为该 cause 失败。reusable caller 必须显式声明 `enforcement: advisory|enforce`；`enforce` 只会在 primary cause 不是 `passed` 时让同名 terminal check 失败。无论模式为何，`product_acceptance: not_evaluated` 都不构成 delivery failure。
+`loom-delivery-gate` 的 direct `pull_request` 与 `merge_group` 固定以 `enforce` 运行；primary cause 不是 `passed` 时，同名 terminal check 必须失败。gate 从 candidate tree 的 `loom-installed-state/v2` 读取 repository adoption profile；既有 execution-control 仓库可由 `loom-repo-interface/v2` companion 兼容识别。light adoption 无需在 direct-event facts 中手工声明 `profile`，其 forbidden carrier invariant 仍会被强制消费。candidate profile 不可读、installed-state 被删除，或 caller profile 低于 candidate state 时均 fail closed。
+
+reusable caller 必须显式声明 `enforcement: advisory|enforce`。caller 的 `profile` 只能显式提升本次验证强度，不能降级 candidate repository profile，也不能覆盖 candidate adoption authority。无论模式为何，`product_acceptance: not_evaluated` 都不构成 delivery failure。
 
 caller 的 `enforcement` input 可以随 PR workflow 改写，因而它只能选择本次执行模式，不能证明下游仓库已经把该检查设为 required。迁移保护面时必须采用增量顺序：先在现有保护面中追加 `loom-delivery-gate`，再执行只读 host readback，最后才移除旧 required checks。不能提交 registry、caller YAML、PR body 或 workflow 文件作为这种证明。
 

--- a/plugins/loom/.codex-plugin/plugin.json
+++ b/plugins/loom/.codex-plugin/plugin.json
@@ -23,7 +23,7 @@
     "source_git_sha": "unreleased",
     "source_git_sha_status": "pending_release_commit",
     "plugin_payload_version": "0.29.1",
-    "plugin_payload_hash": "c7389da1fa4de1b9e56028802f1c7ddf53772588ead2f3997439a5e797cf60aa",
+    "plugin_payload_hash": "546c63bb29ff443302b885fc01030b84a3a1a82d3dc6027daf44f543bf0dab70",
     "repository_payload": false
   },
   "keywords": [

--- a/plugins/loom/.codex-plugin/plugin.json
+++ b/plugins/loom/.codex-plugin/plugin.json
@@ -23,7 +23,7 @@
     "source_git_sha": "unreleased",
     "source_git_sha_status": "pending_release_commit",
     "plugin_payload_version": "0.29.1",
-    "plugin_payload_hash": "c0969068162dca2acdbb880512815a50e13711f37ce556c30c69957d5dc89e77",
+    "plugin_payload_hash": "c7389da1fa4de1b9e56028802f1c7ddf53772588ead2f3997439a5e797cf60aa",
     "repository_payload": false
   },
   "keywords": [

--- a/plugins/loom/skills/shared/scripts/delivery_gate.py
+++ b/plugins/loom/skills/shared/scripts/delivery_gate.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from failure_envelope import envelope, primary_cause
-from light_profile import plan_payload as evaluate_light_profile
+from light_profile import LIGHT_PROFILES, STATE_FILENAMES, installed_state, plan_payload as evaluate_light_profile, read_json
 
 
 SCHEMA = "loom-delivery-gate/v1"
@@ -18,6 +18,13 @@ REQUIRED_CHECK_IDENTITY_SCHEMA = "loom-delivery-gate-required-check-identity/v3"
 REQUIRED_CHECK_IDENTITY_READINESS_SCHEMA = "loom-delivery-gate-required-check-readiness/v3"
 SUPPORTED_EVENTS = {"pull_request", "merge_group", "workflow_call"}
 PROFILES = {"light", "standard", "reinforced"}
+PROFILE_ORDER = {"light": 0, "standard": 1, "reinforced": 2}
+ADOPTION_PROFILES = {
+    "attach-only": "light",
+    "light-governance": "light",
+    "execution-control": "standard",
+    "strong-governance": "reinforced",
+}
 ENFORCEMENTS = {"advisory", "enforce"}
 LIGHT_PATH_PREFIXES = ("docs/",)
 LIGHT_PATHS = {"README.md", "README.zh-CN.md"}
@@ -40,6 +47,24 @@ CAUSES = {
         "owner": "repository",
         "retryable": False,
         "remediation_command": "set host_facts.profile to light, standard, or reinforced",
+    },
+    "candidate_profile_unreadable": {
+        "failure_domain": "governance_metadata",
+        "code": "unreadable",
+        "locator": "candidate_tree:repository_profile",
+        "summary": "The candidate repository profile metadata is unreadable or unsupported.",
+        "owner": "repository",
+        "retryable": False,
+        "remediation_command": "restore valid installed-state or companion repository profile metadata",
+    },
+    "profile_state_mismatch": {
+        "failure_domain": "governance_metadata",
+        "code": "mismatch",
+        "locator": "delivery_profile:candidate_state_mismatch",
+        "summary": "The requested delivery profile would downgrade the candidate repository profile.",
+        "owner": "repository",
+        "retryable": False,
+        "remediation_command": "remove the profile override or select a profile at least as strong as candidate state",
     },
     "invalid_change_set": {
         "failure_domain": "governance_metadata",
@@ -186,10 +211,53 @@ def _paths(value: object) -> tuple[list[str], list[str]]:
     return paths, list(dict.fromkeys(errors))
 
 
-def _profile(facts: dict[str, Any], paths: list[str]) -> tuple[str, str]:
+def _candidate_profile(candidate_path: Path | None, paths: list[str]) -> tuple[str | None, dict[str, Any], list[str]]:
+    profile = {"status": "not_declared", "profile": None, "adoption_mode": None, "authority": None}
+    if candidate_path is None:
+        return None, profile, []
+    if candidate_path.is_symlink() or not candidate_path.is_dir():
+        profile["status"] = "unreadable"
+        return None, profile, ["candidate tree is unavailable"]
+    existing_state = next((locator for locator in STATE_FILENAMES if (candidate_path / locator).exists() or (candidate_path / locator).is_symlink()), None)
+    if existing_state is not None:
+        locator, state, state_error = installed_state(candidate_path)
+        repo_payload = state.get("repo_payload") if isinstance(state, dict) else None
+        adoption_mode = repo_payload.get("adoption_mode") if isinstance(repo_payload, dict) else None
+        if state_error or adoption_mode not in ADOPTION_PROFILES:
+            profile.update({"status": "unreadable", "adoption_mode": adoption_mode, "authority": locator})
+            return None, profile, [state_error or "installed-state adoption_mode is unsupported"]
+        if adoption_mode in LIGHT_PROFILES and repo_payload.get("mode") != "metadata-only":
+            profile.update({"status": "unreadable", "adoption_mode": adoption_mode, "authority": locator})
+            return None, profile, [f"{adoption_mode} installed-state must use metadata-only repository payload"]
+        resolved = ADOPTION_PROFILES[adoption_mode]
+        profile.update({"status": "valid", "profile": resolved, "adoption_mode": adoption_mode, "authority": locator})
+        return resolved, profile, []
+    if any(path in STATE_FILENAMES for path in paths):
+        profile["status"] = "unreadable"
+        return None, profile, ["candidate change set removed installed-state profile authority"]
+    companion_locator = ".loom/companion/repo-interface.json"
+    companion_path = candidate_path / companion_locator
+    if companion_path.exists() or companion_path.is_symlink():
+        if companion_path.is_symlink() or not companion_path.is_file():
+            profile.update({"status": "unreadable", "authority": companion_locator})
+            return None, profile, ["repo companion profile authority must be a regular file"]
+        companion = read_json(companion_path)
+        if companion is None or companion.get("schema_version") != "loom-repo-interface/v2":
+            profile.update({"status": "unreadable", "authority": companion_locator})
+            return None, profile, ["repo companion profile authority is unreadable"]
+        adoption_mode = "attach-only" if isinstance(companion.get("host_truth_locators"), list) and companion["host_truth_locators"] else "execution-control"
+        resolved = ADOPTION_PROFILES[adoption_mode]
+        profile.update({"status": "valid", "profile": resolved, "adoption_mode": adoption_mode, "authority": companion_locator})
+        return resolved, profile, []
+    return None, profile, []
+
+
+def _profile(facts: dict[str, Any], paths: list[str], candidate_profile: str | None) -> tuple[str, str]:
     requested = facts.get("profile")
     if isinstance(requested, str) and requested in PROFILES:
         return requested, "host_facts"
+    if candidate_profile is not None:
+        return candidate_profile, "candidate_state"
     if paths and all(path in LIGHT_PATHS or path.startswith(LIGHT_PATH_PREFIXES) for path in paths):
         return "light", "changed_paths"
     return "standard", "default"
@@ -222,8 +290,13 @@ def _result(enforcement: str, cause_id: str) -> str:
     return "passed" if enforcement == "enforce" and cause_id == "passed" else "blocked"
 
 
-def _light_invariant(profile: str, profile_source: str, candidate_path: Path | None) -> tuple[dict[str, Any], str]:
-    if profile != "light" or profile_source != "host_facts":
+def _light_invariant(
+    candidate_profile: str | None,
+    profile: str,
+    profile_source: str,
+    candidate_path: Path | None,
+) -> tuple[dict[str, Any], str]:
+    if candidate_profile != "light" and not (candidate_profile is None and profile == "light" and profile_source == "host_facts"):
         return {"status": "not_evaluated", "applicable": False, "source": "delivery_profile"}, "passed"
     if candidate_path is None:
         return {"status": "blocked", "applicable": True, "source": "candidate_tree", "violations": []}, "light_profile_tree_unreadable"
@@ -232,6 +305,8 @@ def _light_invariant(profile: str, profile_source: str, candidate_path: Path | N
     except (OSError, ValueError):
         return {"status": "blocked", "applicable": True, "source": "candidate_tree", "violations": []}, "light_profile_tree_unreadable"
     cause_id = evaluated.get("primary_cause", {}).get("id")
+    if evaluated.get("result") == "pass" and evaluated.get("applicable") is False:
+        return {"status": "blocked", "applicable": False, "source": "candidate_tree", "violations": []}, "profile_state_mismatch"
     if evaluated.get("result") == "pass":
         return {"status": "passed", "applicable": bool(evaluated.get("applicable")), "source": "candidate_tree", "violations": []}, "passed"
     if cause_id not in {"light_profile_forbidden_carrier", "light_profile_state_unreadable", "light_profile_tree_unreadable"}:
@@ -268,8 +343,12 @@ def evaluate_host_facts(
         host_errors.append("repository.owner and repository.name are required")
         repository = {}
     paths, path_errors = _paths(facts.get("changed_paths"))
+    candidate_profile, candidate_profile_evidence, candidate_profile_errors = _candidate_profile(candidate_path, paths)
     profile_errors = ["profile must be light, standard, or reinforced when supplied"] if "profile" in facts and facts.get("profile") not in PROFILES else []
-    profile, profile_source = _profile(facts, paths)
+    requested_profile = facts.get("profile")
+    if isinstance(requested_profile, str) and requested_profile in PROFILES and candidate_profile in PROFILES and PROFILE_ORDER[requested_profile] < PROFILE_ORDER[candidate_profile]:
+        profile_errors.append("requested profile cannot downgrade candidate repository state")
+    profile, profile_source = _profile(facts, paths, candidate_profile)
     validation_command, validation_command_errors = _validation_command(facts)
     enforcement_mode, enforcement_errors = _enforcement(enforcement)
     light_invariant = {"status": "not_evaluated", "applicable": False, "source": "delivery_profile"}
@@ -278,13 +357,15 @@ def evaluate_host_facts(
     elif enforcement_errors:
         cause_id = "enforcement_unsupported"
     elif profile_errors:
-        cause_id = "profile_unsupported"
+        cause_id = "profile_state_mismatch" if "requested profile cannot downgrade candidate repository state" in profile_errors else "profile_unsupported"
     elif path_errors:
         cause_id = "invalid_change_set"
+    elif candidate_profile_errors:
+        cause_id = "candidate_profile_unreadable"
     elif validation_command_errors:
         cause_id = "validation_command_missing"
     else:
-        light_invariant, cause_id = _light_invariant(profile, profile_source, candidate_path)
+        light_invariant, cause_id = _light_invariant(candidate_profile, profile, profile_source, candidate_path)
 
     primary = _cause(cause_id)
     return {
@@ -307,6 +388,8 @@ def evaluate_host_facts(
             "changed_paths": paths,
             "profile_errors": profile_errors,
             "change_set_errors": path_errors,
+            "candidate_profile": candidate_profile_evidence,
+            "candidate_profile_errors": candidate_profile_errors,
         },
         "native_validation": {
             "command": validation_command,

--- a/plugins/loom/skills/shared/scripts/delivery_gate.py
+++ b/plugins/loom/skills/shared/scripts/delivery_gate.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from failure_envelope import envelope, primary_cause
+from light_profile import plan_payload as evaluate_light_profile
 
 
 SCHEMA = "loom-delivery-gate/v1"
@@ -66,6 +67,33 @@ CAUSES = {
         "owner": "repository",
         "retryable": True,
         "remediation_command": "fix the reported native validation failure, then rerun loom-delivery-gate",
+    },
+    "light_profile_forbidden_carrier": {
+        "failure_domain": "governance_metadata",
+        "code": "forbidden_carrier",
+        "locator": "candidate_tree:forbidden_carrier",
+        "summary": "The candidate tree contains carriers forbidden by the declared light profile.",
+        "owner": "repository",
+        "retryable": False,
+        "remediation_command": "remove forbidden light-profile carriers from the candidate tree",
+    },
+    "light_profile_state_unreadable": {
+        "failure_domain": "governance_metadata",
+        "code": "unreadable",
+        "locator": "candidate_tree:installed_state",
+        "summary": "The candidate tree does not expose readable light-profile installed state.",
+        "owner": "repository",
+        "retryable": False,
+        "remediation_command": "restore valid metadata-only light-profile installed state",
+    },
+    "light_profile_tree_unreadable": {
+        "failure_domain": "toolchain",
+        "code": "unreadable",
+        "locator": "candidate_tree:unreadable",
+        "summary": "The declared light-profile candidate tree could not be evaluated.",
+        "owner": "github",
+        "retryable": True,
+        "remediation_command": "rerun loom-delivery-gate after the candidate checkout is readable",
     },
     "enforcement_unsupported": {
         "failure_domain": "governance_metadata",
@@ -194,7 +222,34 @@ def _result(enforcement: str, cause_id: str) -> str:
     return "passed" if enforcement == "enforce" and cause_id == "passed" else "blocked"
 
 
-def evaluate_host_facts(host_facts: object, enforcement: object = "advisory") -> dict[str, Any]:
+def _light_invariant(profile: str, profile_source: str, candidate_path: Path | None) -> tuple[dict[str, Any], str]:
+    if profile != "light" or profile_source != "host_facts":
+        return {"status": "not_evaluated", "applicable": False, "source": "delivery_profile"}, "passed"
+    if candidate_path is None:
+        return {"status": "blocked", "applicable": True, "source": "candidate_tree", "violations": []}, "light_profile_tree_unreadable"
+    try:
+        evaluated = evaluate_light_profile(candidate_path)
+    except (OSError, ValueError):
+        return {"status": "blocked", "applicable": True, "source": "candidate_tree", "violations": []}, "light_profile_tree_unreadable"
+    cause_id = evaluated.get("primary_cause", {}).get("id")
+    if evaluated.get("result") == "pass":
+        return {"status": "passed", "applicable": bool(evaluated.get("applicable")), "source": "candidate_tree", "violations": []}, "passed"
+    if cause_id not in {"light_profile_forbidden_carrier", "light_profile_state_unreadable", "light_profile_tree_unreadable"}:
+        cause_id = "light_profile_tree_unreadable"
+    violations = evaluated.get("violations")
+    return {
+        "status": "blocked",
+        "applicable": True,
+        "source": "candidate_tree",
+        "violations": violations if isinstance(violations, list) else [],
+    }, cause_id
+
+
+def evaluate_host_facts(
+    host_facts: object,
+    enforcement: object = "advisory",
+    candidate_path: Path | None = None,
+) -> dict[str, Any]:
     """Evaluate host facts before the selected native validation runs."""
 
     host_errors: list[str] = []
@@ -217,6 +272,7 @@ def evaluate_host_facts(host_facts: object, enforcement: object = "advisory") ->
     profile, profile_source = _profile(facts, paths)
     validation_command, validation_command_errors = _validation_command(facts)
     enforcement_mode, enforcement_errors = _enforcement(enforcement)
+    light_invariant = {"status": "not_evaluated", "applicable": False, "source": "delivery_profile"}
     if host_errors:
         cause_id = "host_facts_unreadable"
     elif enforcement_errors:
@@ -228,7 +284,7 @@ def evaluate_host_facts(host_facts: object, enforcement: object = "advisory") ->
     elif validation_command_errors:
         cause_id = "validation_command_missing"
     else:
-        cause_id = "passed"
+        light_invariant, cause_id = _light_invariant(profile, profile_source, candidate_path)
 
     primary = _cause(cause_id)
     return {
@@ -258,14 +314,20 @@ def evaluate_host_facts(host_facts: object, enforcement: object = "advisory") ->
             "status": "pending",
             "security_boundary": "untrusted_execution_read_token_only",
         },
+        "light_invariant": light_invariant,
         "enforcement_errors": enforcement_errors,
     }
 
 
-def finalize_delivery_gate(host_facts: object, validation_result: object, enforcement: object = "advisory") -> dict[str, Any]:
+def finalize_delivery_gate(
+    host_facts: object,
+    validation_result: object,
+    enforcement: object = "advisory",
+    candidate_path: Path | None = None,
+) -> dict[str, Any]:
     """Apply the fixed delivery-cause priority after native validation."""
 
-    payload = evaluate_host_facts(host_facts, enforcement)
+    payload = evaluate_host_facts(host_facts, enforcement, candidate_path)
     result = validation_result if isinstance(validation_result, dict) else {}
     status = result.get("status")
     payload["native_validation"]["status"] = status if isinstance(status, str) else "command_missing"
@@ -491,14 +553,15 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--host-facts-file", type=Path, required=True)
     parser.add_argument("--validation-result-file", type=Path)
+    parser.add_argument("--candidate-path", type=Path)
     parser.add_argument("--enforcement", default="advisory")
     parser.add_argument("--output", type=Path)
     args = parser.parse_args()
     host_facts = _read_host_facts(args.host_facts_file)
     payload = (
-        finalize_delivery_gate(host_facts, _read_host_facts(args.validation_result_file), args.enforcement)
+        finalize_delivery_gate(host_facts, _read_host_facts(args.validation_result_file), args.enforcement, args.candidate_path)
         if args.validation_result_file
-        else evaluate_host_facts(host_facts, args.enforcement)
+        else evaluate_host_facts(host_facts, args.enforcement, args.candidate_path)
     )
     encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
     if args.output:

--- a/plugins/loom/skills/shared/scripts/delivery_gate.py
+++ b/plugins/loom/skills/shared/scripts/delivery_gate.py
@@ -245,7 +245,7 @@ def _candidate_profile(candidate_path: Path | None, paths: list[str]) -> tuple[s
         if companion is None or companion.get("schema_version") != "loom-repo-interface/v2":
             profile.update({"status": "unreadable", "authority": companion_locator})
             return None, profile, ["repo companion profile authority is unreadable"]
-        adoption_mode = "attach-only" if isinstance(companion.get("host_truth_locators"), list) and companion["host_truth_locators"] else "execution-control"
+        adoption_mode = "execution-control"
         resolved = ADOPTION_PROFILES[adoption_mode]
         profile.update({"status": "valid", "profile": resolved, "adoption_mode": adoption_mode, "authority": companion_locator})
         return resolved, profile, []

--- a/skills/shared/scripts/delivery_gate.py
+++ b/skills/shared/scripts/delivery_gate.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from failure_envelope import envelope, primary_cause
-from light_profile import plan_payload as evaluate_light_profile
+from light_profile import LIGHT_PROFILES, STATE_FILENAMES, installed_state, plan_payload as evaluate_light_profile, read_json
 
 
 SCHEMA = "loom-delivery-gate/v1"
@@ -18,6 +18,13 @@ REQUIRED_CHECK_IDENTITY_SCHEMA = "loom-delivery-gate-required-check-identity/v3"
 REQUIRED_CHECK_IDENTITY_READINESS_SCHEMA = "loom-delivery-gate-required-check-readiness/v3"
 SUPPORTED_EVENTS = {"pull_request", "merge_group", "workflow_call"}
 PROFILES = {"light", "standard", "reinforced"}
+PROFILE_ORDER = {"light": 0, "standard": 1, "reinforced": 2}
+ADOPTION_PROFILES = {
+    "attach-only": "light",
+    "light-governance": "light",
+    "execution-control": "standard",
+    "strong-governance": "reinforced",
+}
 ENFORCEMENTS = {"advisory", "enforce"}
 LIGHT_PATH_PREFIXES = ("docs/",)
 LIGHT_PATHS = {"README.md", "README.zh-CN.md"}
@@ -40,6 +47,24 @@ CAUSES = {
         "owner": "repository",
         "retryable": False,
         "remediation_command": "set host_facts.profile to light, standard, or reinforced",
+    },
+    "candidate_profile_unreadable": {
+        "failure_domain": "governance_metadata",
+        "code": "unreadable",
+        "locator": "candidate_tree:repository_profile",
+        "summary": "The candidate repository profile metadata is unreadable or unsupported.",
+        "owner": "repository",
+        "retryable": False,
+        "remediation_command": "restore valid installed-state or companion repository profile metadata",
+    },
+    "profile_state_mismatch": {
+        "failure_domain": "governance_metadata",
+        "code": "mismatch",
+        "locator": "delivery_profile:candidate_state_mismatch",
+        "summary": "The requested delivery profile would downgrade the candidate repository profile.",
+        "owner": "repository",
+        "retryable": False,
+        "remediation_command": "remove the profile override or select a profile at least as strong as candidate state",
     },
     "invalid_change_set": {
         "failure_domain": "governance_metadata",
@@ -186,10 +211,53 @@ def _paths(value: object) -> tuple[list[str], list[str]]:
     return paths, list(dict.fromkeys(errors))
 
 
-def _profile(facts: dict[str, Any], paths: list[str]) -> tuple[str, str]:
+def _candidate_profile(candidate_path: Path | None, paths: list[str]) -> tuple[str | None, dict[str, Any], list[str]]:
+    profile = {"status": "not_declared", "profile": None, "adoption_mode": None, "authority": None}
+    if candidate_path is None:
+        return None, profile, []
+    if candidate_path.is_symlink() or not candidate_path.is_dir():
+        profile["status"] = "unreadable"
+        return None, profile, ["candidate tree is unavailable"]
+    existing_state = next((locator for locator in STATE_FILENAMES if (candidate_path / locator).exists() or (candidate_path / locator).is_symlink()), None)
+    if existing_state is not None:
+        locator, state, state_error = installed_state(candidate_path)
+        repo_payload = state.get("repo_payload") if isinstance(state, dict) else None
+        adoption_mode = repo_payload.get("adoption_mode") if isinstance(repo_payload, dict) else None
+        if state_error or adoption_mode not in ADOPTION_PROFILES:
+            profile.update({"status": "unreadable", "adoption_mode": adoption_mode, "authority": locator})
+            return None, profile, [state_error or "installed-state adoption_mode is unsupported"]
+        if adoption_mode in LIGHT_PROFILES and repo_payload.get("mode") != "metadata-only":
+            profile.update({"status": "unreadable", "adoption_mode": adoption_mode, "authority": locator})
+            return None, profile, [f"{adoption_mode} installed-state must use metadata-only repository payload"]
+        resolved = ADOPTION_PROFILES[adoption_mode]
+        profile.update({"status": "valid", "profile": resolved, "adoption_mode": adoption_mode, "authority": locator})
+        return resolved, profile, []
+    if any(path in STATE_FILENAMES for path in paths):
+        profile["status"] = "unreadable"
+        return None, profile, ["candidate change set removed installed-state profile authority"]
+    companion_locator = ".loom/companion/repo-interface.json"
+    companion_path = candidate_path / companion_locator
+    if companion_path.exists() or companion_path.is_symlink():
+        if companion_path.is_symlink() or not companion_path.is_file():
+            profile.update({"status": "unreadable", "authority": companion_locator})
+            return None, profile, ["repo companion profile authority must be a regular file"]
+        companion = read_json(companion_path)
+        if companion is None or companion.get("schema_version") != "loom-repo-interface/v2":
+            profile.update({"status": "unreadable", "authority": companion_locator})
+            return None, profile, ["repo companion profile authority is unreadable"]
+        adoption_mode = "attach-only" if isinstance(companion.get("host_truth_locators"), list) and companion["host_truth_locators"] else "execution-control"
+        resolved = ADOPTION_PROFILES[adoption_mode]
+        profile.update({"status": "valid", "profile": resolved, "adoption_mode": adoption_mode, "authority": companion_locator})
+        return resolved, profile, []
+    return None, profile, []
+
+
+def _profile(facts: dict[str, Any], paths: list[str], candidate_profile: str | None) -> tuple[str, str]:
     requested = facts.get("profile")
     if isinstance(requested, str) and requested in PROFILES:
         return requested, "host_facts"
+    if candidate_profile is not None:
+        return candidate_profile, "candidate_state"
     if paths and all(path in LIGHT_PATHS or path.startswith(LIGHT_PATH_PREFIXES) for path in paths):
         return "light", "changed_paths"
     return "standard", "default"
@@ -222,8 +290,13 @@ def _result(enforcement: str, cause_id: str) -> str:
     return "passed" if enforcement == "enforce" and cause_id == "passed" else "blocked"
 
 
-def _light_invariant(profile: str, profile_source: str, candidate_path: Path | None) -> tuple[dict[str, Any], str]:
-    if profile != "light" or profile_source != "host_facts":
+def _light_invariant(
+    candidate_profile: str | None,
+    profile: str,
+    profile_source: str,
+    candidate_path: Path | None,
+) -> tuple[dict[str, Any], str]:
+    if candidate_profile != "light" and not (candidate_profile is None and profile == "light" and profile_source == "host_facts"):
         return {"status": "not_evaluated", "applicable": False, "source": "delivery_profile"}, "passed"
     if candidate_path is None:
         return {"status": "blocked", "applicable": True, "source": "candidate_tree", "violations": []}, "light_profile_tree_unreadable"
@@ -232,6 +305,8 @@ def _light_invariant(profile: str, profile_source: str, candidate_path: Path | N
     except (OSError, ValueError):
         return {"status": "blocked", "applicable": True, "source": "candidate_tree", "violations": []}, "light_profile_tree_unreadable"
     cause_id = evaluated.get("primary_cause", {}).get("id")
+    if evaluated.get("result") == "pass" and evaluated.get("applicable") is False:
+        return {"status": "blocked", "applicable": False, "source": "candidate_tree", "violations": []}, "profile_state_mismatch"
     if evaluated.get("result") == "pass":
         return {"status": "passed", "applicable": bool(evaluated.get("applicable")), "source": "candidate_tree", "violations": []}, "passed"
     if cause_id not in {"light_profile_forbidden_carrier", "light_profile_state_unreadable", "light_profile_tree_unreadable"}:
@@ -268,8 +343,12 @@ def evaluate_host_facts(
         host_errors.append("repository.owner and repository.name are required")
         repository = {}
     paths, path_errors = _paths(facts.get("changed_paths"))
+    candidate_profile, candidate_profile_evidence, candidate_profile_errors = _candidate_profile(candidate_path, paths)
     profile_errors = ["profile must be light, standard, or reinforced when supplied"] if "profile" in facts and facts.get("profile") not in PROFILES else []
-    profile, profile_source = _profile(facts, paths)
+    requested_profile = facts.get("profile")
+    if isinstance(requested_profile, str) and requested_profile in PROFILES and candidate_profile in PROFILES and PROFILE_ORDER[requested_profile] < PROFILE_ORDER[candidate_profile]:
+        profile_errors.append("requested profile cannot downgrade candidate repository state")
+    profile, profile_source = _profile(facts, paths, candidate_profile)
     validation_command, validation_command_errors = _validation_command(facts)
     enforcement_mode, enforcement_errors = _enforcement(enforcement)
     light_invariant = {"status": "not_evaluated", "applicable": False, "source": "delivery_profile"}
@@ -278,13 +357,15 @@ def evaluate_host_facts(
     elif enforcement_errors:
         cause_id = "enforcement_unsupported"
     elif profile_errors:
-        cause_id = "profile_unsupported"
+        cause_id = "profile_state_mismatch" if "requested profile cannot downgrade candidate repository state" in profile_errors else "profile_unsupported"
     elif path_errors:
         cause_id = "invalid_change_set"
+    elif candidate_profile_errors:
+        cause_id = "candidate_profile_unreadable"
     elif validation_command_errors:
         cause_id = "validation_command_missing"
     else:
-        light_invariant, cause_id = _light_invariant(profile, profile_source, candidate_path)
+        light_invariant, cause_id = _light_invariant(candidate_profile, profile, profile_source, candidate_path)
 
     primary = _cause(cause_id)
     return {
@@ -307,6 +388,8 @@ def evaluate_host_facts(
             "changed_paths": paths,
             "profile_errors": profile_errors,
             "change_set_errors": path_errors,
+            "candidate_profile": candidate_profile_evidence,
+            "candidate_profile_errors": candidate_profile_errors,
         },
         "native_validation": {
             "command": validation_command,

--- a/skills/shared/scripts/delivery_gate.py
+++ b/skills/shared/scripts/delivery_gate.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from failure_envelope import envelope, primary_cause
+from light_profile import plan_payload as evaluate_light_profile
 
 
 SCHEMA = "loom-delivery-gate/v1"
@@ -66,6 +67,33 @@ CAUSES = {
         "owner": "repository",
         "retryable": True,
         "remediation_command": "fix the reported native validation failure, then rerun loom-delivery-gate",
+    },
+    "light_profile_forbidden_carrier": {
+        "failure_domain": "governance_metadata",
+        "code": "forbidden_carrier",
+        "locator": "candidate_tree:forbidden_carrier",
+        "summary": "The candidate tree contains carriers forbidden by the declared light profile.",
+        "owner": "repository",
+        "retryable": False,
+        "remediation_command": "remove forbidden light-profile carriers from the candidate tree",
+    },
+    "light_profile_state_unreadable": {
+        "failure_domain": "governance_metadata",
+        "code": "unreadable",
+        "locator": "candidate_tree:installed_state",
+        "summary": "The candidate tree does not expose readable light-profile installed state.",
+        "owner": "repository",
+        "retryable": False,
+        "remediation_command": "restore valid metadata-only light-profile installed state",
+    },
+    "light_profile_tree_unreadable": {
+        "failure_domain": "toolchain",
+        "code": "unreadable",
+        "locator": "candidate_tree:unreadable",
+        "summary": "The declared light-profile candidate tree could not be evaluated.",
+        "owner": "github",
+        "retryable": True,
+        "remediation_command": "rerun loom-delivery-gate after the candidate checkout is readable",
     },
     "enforcement_unsupported": {
         "failure_domain": "governance_metadata",
@@ -194,7 +222,34 @@ def _result(enforcement: str, cause_id: str) -> str:
     return "passed" if enforcement == "enforce" and cause_id == "passed" else "blocked"
 
 
-def evaluate_host_facts(host_facts: object, enforcement: object = "advisory") -> dict[str, Any]:
+def _light_invariant(profile: str, profile_source: str, candidate_path: Path | None) -> tuple[dict[str, Any], str]:
+    if profile != "light" or profile_source != "host_facts":
+        return {"status": "not_evaluated", "applicable": False, "source": "delivery_profile"}, "passed"
+    if candidate_path is None:
+        return {"status": "blocked", "applicable": True, "source": "candidate_tree", "violations": []}, "light_profile_tree_unreadable"
+    try:
+        evaluated = evaluate_light_profile(candidate_path)
+    except (OSError, ValueError):
+        return {"status": "blocked", "applicable": True, "source": "candidate_tree", "violations": []}, "light_profile_tree_unreadable"
+    cause_id = evaluated.get("primary_cause", {}).get("id")
+    if evaluated.get("result") == "pass":
+        return {"status": "passed", "applicable": bool(evaluated.get("applicable")), "source": "candidate_tree", "violations": []}, "passed"
+    if cause_id not in {"light_profile_forbidden_carrier", "light_profile_state_unreadable", "light_profile_tree_unreadable"}:
+        cause_id = "light_profile_tree_unreadable"
+    violations = evaluated.get("violations")
+    return {
+        "status": "blocked",
+        "applicable": True,
+        "source": "candidate_tree",
+        "violations": violations if isinstance(violations, list) else [],
+    }, cause_id
+
+
+def evaluate_host_facts(
+    host_facts: object,
+    enforcement: object = "advisory",
+    candidate_path: Path | None = None,
+) -> dict[str, Any]:
     """Evaluate host facts before the selected native validation runs."""
 
     host_errors: list[str] = []
@@ -217,6 +272,7 @@ def evaluate_host_facts(host_facts: object, enforcement: object = "advisory") ->
     profile, profile_source = _profile(facts, paths)
     validation_command, validation_command_errors = _validation_command(facts)
     enforcement_mode, enforcement_errors = _enforcement(enforcement)
+    light_invariant = {"status": "not_evaluated", "applicable": False, "source": "delivery_profile"}
     if host_errors:
         cause_id = "host_facts_unreadable"
     elif enforcement_errors:
@@ -228,7 +284,7 @@ def evaluate_host_facts(host_facts: object, enforcement: object = "advisory") ->
     elif validation_command_errors:
         cause_id = "validation_command_missing"
     else:
-        cause_id = "passed"
+        light_invariant, cause_id = _light_invariant(profile, profile_source, candidate_path)
 
     primary = _cause(cause_id)
     return {
@@ -258,14 +314,20 @@ def evaluate_host_facts(host_facts: object, enforcement: object = "advisory") ->
             "status": "pending",
             "security_boundary": "untrusted_execution_read_token_only",
         },
+        "light_invariant": light_invariant,
         "enforcement_errors": enforcement_errors,
     }
 
 
-def finalize_delivery_gate(host_facts: object, validation_result: object, enforcement: object = "advisory") -> dict[str, Any]:
+def finalize_delivery_gate(
+    host_facts: object,
+    validation_result: object,
+    enforcement: object = "advisory",
+    candidate_path: Path | None = None,
+) -> dict[str, Any]:
     """Apply the fixed delivery-cause priority after native validation."""
 
-    payload = evaluate_host_facts(host_facts, enforcement)
+    payload = evaluate_host_facts(host_facts, enforcement, candidate_path)
     result = validation_result if isinstance(validation_result, dict) else {}
     status = result.get("status")
     payload["native_validation"]["status"] = status if isinstance(status, str) else "command_missing"
@@ -491,14 +553,15 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--host-facts-file", type=Path, required=True)
     parser.add_argument("--validation-result-file", type=Path)
+    parser.add_argument("--candidate-path", type=Path)
     parser.add_argument("--enforcement", default="advisory")
     parser.add_argument("--output", type=Path)
     args = parser.parse_args()
     host_facts = _read_host_facts(args.host_facts_file)
     payload = (
-        finalize_delivery_gate(host_facts, _read_host_facts(args.validation_result_file), args.enforcement)
+        finalize_delivery_gate(host_facts, _read_host_facts(args.validation_result_file), args.enforcement, args.candidate_path)
         if args.validation_result_file
-        else evaluate_host_facts(host_facts, args.enforcement)
+        else evaluate_host_facts(host_facts, args.enforcement, args.candidate_path)
     )
     encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
     if args.output:

--- a/skills/shared/scripts/delivery_gate.py
+++ b/skills/shared/scripts/delivery_gate.py
@@ -245,7 +245,7 @@ def _candidate_profile(candidate_path: Path | None, paths: list[str]) -> tuple[s
         if companion is None or companion.get("schema_version") != "loom-repo-interface/v2":
             profile.update({"status": "unreadable", "authority": companion_locator})
             return None, profile, ["repo companion profile authority is unreadable"]
-        adoption_mode = "attach-only" if isinstance(companion.get("host_truth_locators"), list) and companion["host_truth_locators"] else "execution-control"
+        adoption_mode = "execution-control"
         resolved = ADOPTION_PROFILES[adoption_mode]
         profile.update({"status": "valid", "profile": resolved, "adoption_mode": adoption_mode, "authority": companion_locator})
         return resolved, profile, []

--- a/src/skills/shared/scripts/delivery_gate.py
+++ b/src/skills/shared/scripts/delivery_gate.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from failure_envelope import envelope, primary_cause
-from light_profile import plan_payload as evaluate_light_profile
+from light_profile import LIGHT_PROFILES, STATE_FILENAMES, installed_state, plan_payload as evaluate_light_profile, read_json
 
 
 SCHEMA = "loom-delivery-gate/v1"
@@ -18,6 +18,13 @@ REQUIRED_CHECK_IDENTITY_SCHEMA = "loom-delivery-gate-required-check-identity/v3"
 REQUIRED_CHECK_IDENTITY_READINESS_SCHEMA = "loom-delivery-gate-required-check-readiness/v3"
 SUPPORTED_EVENTS = {"pull_request", "merge_group", "workflow_call"}
 PROFILES = {"light", "standard", "reinforced"}
+PROFILE_ORDER = {"light": 0, "standard": 1, "reinforced": 2}
+ADOPTION_PROFILES = {
+    "attach-only": "light",
+    "light-governance": "light",
+    "execution-control": "standard",
+    "strong-governance": "reinforced",
+}
 ENFORCEMENTS = {"advisory", "enforce"}
 LIGHT_PATH_PREFIXES = ("docs/",)
 LIGHT_PATHS = {"README.md", "README.zh-CN.md"}
@@ -40,6 +47,24 @@ CAUSES = {
         "owner": "repository",
         "retryable": False,
         "remediation_command": "set host_facts.profile to light, standard, or reinforced",
+    },
+    "candidate_profile_unreadable": {
+        "failure_domain": "governance_metadata",
+        "code": "unreadable",
+        "locator": "candidate_tree:repository_profile",
+        "summary": "The candidate repository profile metadata is unreadable or unsupported.",
+        "owner": "repository",
+        "retryable": False,
+        "remediation_command": "restore valid installed-state or companion repository profile metadata",
+    },
+    "profile_state_mismatch": {
+        "failure_domain": "governance_metadata",
+        "code": "mismatch",
+        "locator": "delivery_profile:candidate_state_mismatch",
+        "summary": "The requested delivery profile would downgrade the candidate repository profile.",
+        "owner": "repository",
+        "retryable": False,
+        "remediation_command": "remove the profile override or select a profile at least as strong as candidate state",
     },
     "invalid_change_set": {
         "failure_domain": "governance_metadata",
@@ -186,10 +211,53 @@ def _paths(value: object) -> tuple[list[str], list[str]]:
     return paths, list(dict.fromkeys(errors))
 
 
-def _profile(facts: dict[str, Any], paths: list[str]) -> tuple[str, str]:
+def _candidate_profile(candidate_path: Path | None, paths: list[str]) -> tuple[str | None, dict[str, Any], list[str]]:
+    profile = {"status": "not_declared", "profile": None, "adoption_mode": None, "authority": None}
+    if candidate_path is None:
+        return None, profile, []
+    if candidate_path.is_symlink() or not candidate_path.is_dir():
+        profile["status"] = "unreadable"
+        return None, profile, ["candidate tree is unavailable"]
+    existing_state = next((locator for locator in STATE_FILENAMES if (candidate_path / locator).exists() or (candidate_path / locator).is_symlink()), None)
+    if existing_state is not None:
+        locator, state, state_error = installed_state(candidate_path)
+        repo_payload = state.get("repo_payload") if isinstance(state, dict) else None
+        adoption_mode = repo_payload.get("adoption_mode") if isinstance(repo_payload, dict) else None
+        if state_error or adoption_mode not in ADOPTION_PROFILES:
+            profile.update({"status": "unreadable", "adoption_mode": adoption_mode, "authority": locator})
+            return None, profile, [state_error or "installed-state adoption_mode is unsupported"]
+        if adoption_mode in LIGHT_PROFILES and repo_payload.get("mode") != "metadata-only":
+            profile.update({"status": "unreadable", "adoption_mode": adoption_mode, "authority": locator})
+            return None, profile, [f"{adoption_mode} installed-state must use metadata-only repository payload"]
+        resolved = ADOPTION_PROFILES[adoption_mode]
+        profile.update({"status": "valid", "profile": resolved, "adoption_mode": adoption_mode, "authority": locator})
+        return resolved, profile, []
+    if any(path in STATE_FILENAMES for path in paths):
+        profile["status"] = "unreadable"
+        return None, profile, ["candidate change set removed installed-state profile authority"]
+    companion_locator = ".loom/companion/repo-interface.json"
+    companion_path = candidate_path / companion_locator
+    if companion_path.exists() or companion_path.is_symlink():
+        if companion_path.is_symlink() or not companion_path.is_file():
+            profile.update({"status": "unreadable", "authority": companion_locator})
+            return None, profile, ["repo companion profile authority must be a regular file"]
+        companion = read_json(companion_path)
+        if companion is None or companion.get("schema_version") != "loom-repo-interface/v2":
+            profile.update({"status": "unreadable", "authority": companion_locator})
+            return None, profile, ["repo companion profile authority is unreadable"]
+        adoption_mode = "attach-only" if isinstance(companion.get("host_truth_locators"), list) and companion["host_truth_locators"] else "execution-control"
+        resolved = ADOPTION_PROFILES[adoption_mode]
+        profile.update({"status": "valid", "profile": resolved, "adoption_mode": adoption_mode, "authority": companion_locator})
+        return resolved, profile, []
+    return None, profile, []
+
+
+def _profile(facts: dict[str, Any], paths: list[str], candidate_profile: str | None) -> tuple[str, str]:
     requested = facts.get("profile")
     if isinstance(requested, str) and requested in PROFILES:
         return requested, "host_facts"
+    if candidate_profile is not None:
+        return candidate_profile, "candidate_state"
     if paths and all(path in LIGHT_PATHS or path.startswith(LIGHT_PATH_PREFIXES) for path in paths):
         return "light", "changed_paths"
     return "standard", "default"
@@ -222,8 +290,13 @@ def _result(enforcement: str, cause_id: str) -> str:
     return "passed" if enforcement == "enforce" and cause_id == "passed" else "blocked"
 
 
-def _light_invariant(profile: str, profile_source: str, candidate_path: Path | None) -> tuple[dict[str, Any], str]:
-    if profile != "light" or profile_source != "host_facts":
+def _light_invariant(
+    candidate_profile: str | None,
+    profile: str,
+    profile_source: str,
+    candidate_path: Path | None,
+) -> tuple[dict[str, Any], str]:
+    if candidate_profile != "light" and not (candidate_profile is None and profile == "light" and profile_source == "host_facts"):
         return {"status": "not_evaluated", "applicable": False, "source": "delivery_profile"}, "passed"
     if candidate_path is None:
         return {"status": "blocked", "applicable": True, "source": "candidate_tree", "violations": []}, "light_profile_tree_unreadable"
@@ -232,6 +305,8 @@ def _light_invariant(profile: str, profile_source: str, candidate_path: Path | N
     except (OSError, ValueError):
         return {"status": "blocked", "applicable": True, "source": "candidate_tree", "violations": []}, "light_profile_tree_unreadable"
     cause_id = evaluated.get("primary_cause", {}).get("id")
+    if evaluated.get("result") == "pass" and evaluated.get("applicable") is False:
+        return {"status": "blocked", "applicable": False, "source": "candidate_tree", "violations": []}, "profile_state_mismatch"
     if evaluated.get("result") == "pass":
         return {"status": "passed", "applicable": bool(evaluated.get("applicable")), "source": "candidate_tree", "violations": []}, "passed"
     if cause_id not in {"light_profile_forbidden_carrier", "light_profile_state_unreadable", "light_profile_tree_unreadable"}:
@@ -268,8 +343,12 @@ def evaluate_host_facts(
         host_errors.append("repository.owner and repository.name are required")
         repository = {}
     paths, path_errors = _paths(facts.get("changed_paths"))
+    candidate_profile, candidate_profile_evidence, candidate_profile_errors = _candidate_profile(candidate_path, paths)
     profile_errors = ["profile must be light, standard, or reinforced when supplied"] if "profile" in facts and facts.get("profile") not in PROFILES else []
-    profile, profile_source = _profile(facts, paths)
+    requested_profile = facts.get("profile")
+    if isinstance(requested_profile, str) and requested_profile in PROFILES and candidate_profile in PROFILES and PROFILE_ORDER[requested_profile] < PROFILE_ORDER[candidate_profile]:
+        profile_errors.append("requested profile cannot downgrade candidate repository state")
+    profile, profile_source = _profile(facts, paths, candidate_profile)
     validation_command, validation_command_errors = _validation_command(facts)
     enforcement_mode, enforcement_errors = _enforcement(enforcement)
     light_invariant = {"status": "not_evaluated", "applicable": False, "source": "delivery_profile"}
@@ -278,13 +357,15 @@ def evaluate_host_facts(
     elif enforcement_errors:
         cause_id = "enforcement_unsupported"
     elif profile_errors:
-        cause_id = "profile_unsupported"
+        cause_id = "profile_state_mismatch" if "requested profile cannot downgrade candidate repository state" in profile_errors else "profile_unsupported"
     elif path_errors:
         cause_id = "invalid_change_set"
+    elif candidate_profile_errors:
+        cause_id = "candidate_profile_unreadable"
     elif validation_command_errors:
         cause_id = "validation_command_missing"
     else:
-        light_invariant, cause_id = _light_invariant(profile, profile_source, candidate_path)
+        light_invariant, cause_id = _light_invariant(candidate_profile, profile, profile_source, candidate_path)
 
     primary = _cause(cause_id)
     return {
@@ -307,6 +388,8 @@ def evaluate_host_facts(
             "changed_paths": paths,
             "profile_errors": profile_errors,
             "change_set_errors": path_errors,
+            "candidate_profile": candidate_profile_evidence,
+            "candidate_profile_errors": candidate_profile_errors,
         },
         "native_validation": {
             "command": validation_command,

--- a/src/skills/shared/scripts/delivery_gate.py
+++ b/src/skills/shared/scripts/delivery_gate.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from failure_envelope import envelope, primary_cause
+from light_profile import plan_payload as evaluate_light_profile
 
 
 SCHEMA = "loom-delivery-gate/v1"
@@ -66,6 +67,33 @@ CAUSES = {
         "owner": "repository",
         "retryable": True,
         "remediation_command": "fix the reported native validation failure, then rerun loom-delivery-gate",
+    },
+    "light_profile_forbidden_carrier": {
+        "failure_domain": "governance_metadata",
+        "code": "forbidden_carrier",
+        "locator": "candidate_tree:forbidden_carrier",
+        "summary": "The candidate tree contains carriers forbidden by the declared light profile.",
+        "owner": "repository",
+        "retryable": False,
+        "remediation_command": "remove forbidden light-profile carriers from the candidate tree",
+    },
+    "light_profile_state_unreadable": {
+        "failure_domain": "governance_metadata",
+        "code": "unreadable",
+        "locator": "candidate_tree:installed_state",
+        "summary": "The candidate tree does not expose readable light-profile installed state.",
+        "owner": "repository",
+        "retryable": False,
+        "remediation_command": "restore valid metadata-only light-profile installed state",
+    },
+    "light_profile_tree_unreadable": {
+        "failure_domain": "toolchain",
+        "code": "unreadable",
+        "locator": "candidate_tree:unreadable",
+        "summary": "The declared light-profile candidate tree could not be evaluated.",
+        "owner": "github",
+        "retryable": True,
+        "remediation_command": "rerun loom-delivery-gate after the candidate checkout is readable",
     },
     "enforcement_unsupported": {
         "failure_domain": "governance_metadata",
@@ -194,7 +222,34 @@ def _result(enforcement: str, cause_id: str) -> str:
     return "passed" if enforcement == "enforce" and cause_id == "passed" else "blocked"
 
 
-def evaluate_host_facts(host_facts: object, enforcement: object = "advisory") -> dict[str, Any]:
+def _light_invariant(profile: str, profile_source: str, candidate_path: Path | None) -> tuple[dict[str, Any], str]:
+    if profile != "light" or profile_source != "host_facts":
+        return {"status": "not_evaluated", "applicable": False, "source": "delivery_profile"}, "passed"
+    if candidate_path is None:
+        return {"status": "blocked", "applicable": True, "source": "candidate_tree", "violations": []}, "light_profile_tree_unreadable"
+    try:
+        evaluated = evaluate_light_profile(candidate_path)
+    except (OSError, ValueError):
+        return {"status": "blocked", "applicable": True, "source": "candidate_tree", "violations": []}, "light_profile_tree_unreadable"
+    cause_id = evaluated.get("primary_cause", {}).get("id")
+    if evaluated.get("result") == "pass":
+        return {"status": "passed", "applicable": bool(evaluated.get("applicable")), "source": "candidate_tree", "violations": []}, "passed"
+    if cause_id not in {"light_profile_forbidden_carrier", "light_profile_state_unreadable", "light_profile_tree_unreadable"}:
+        cause_id = "light_profile_tree_unreadable"
+    violations = evaluated.get("violations")
+    return {
+        "status": "blocked",
+        "applicable": True,
+        "source": "candidate_tree",
+        "violations": violations if isinstance(violations, list) else [],
+    }, cause_id
+
+
+def evaluate_host_facts(
+    host_facts: object,
+    enforcement: object = "advisory",
+    candidate_path: Path | None = None,
+) -> dict[str, Any]:
     """Evaluate host facts before the selected native validation runs."""
 
     host_errors: list[str] = []
@@ -217,6 +272,7 @@ def evaluate_host_facts(host_facts: object, enforcement: object = "advisory") ->
     profile, profile_source = _profile(facts, paths)
     validation_command, validation_command_errors = _validation_command(facts)
     enforcement_mode, enforcement_errors = _enforcement(enforcement)
+    light_invariant = {"status": "not_evaluated", "applicable": False, "source": "delivery_profile"}
     if host_errors:
         cause_id = "host_facts_unreadable"
     elif enforcement_errors:
@@ -228,7 +284,7 @@ def evaluate_host_facts(host_facts: object, enforcement: object = "advisory") ->
     elif validation_command_errors:
         cause_id = "validation_command_missing"
     else:
-        cause_id = "passed"
+        light_invariant, cause_id = _light_invariant(profile, profile_source, candidate_path)
 
     primary = _cause(cause_id)
     return {
@@ -258,14 +314,20 @@ def evaluate_host_facts(host_facts: object, enforcement: object = "advisory") ->
             "status": "pending",
             "security_boundary": "untrusted_execution_read_token_only",
         },
+        "light_invariant": light_invariant,
         "enforcement_errors": enforcement_errors,
     }
 
 
-def finalize_delivery_gate(host_facts: object, validation_result: object, enforcement: object = "advisory") -> dict[str, Any]:
+def finalize_delivery_gate(
+    host_facts: object,
+    validation_result: object,
+    enforcement: object = "advisory",
+    candidate_path: Path | None = None,
+) -> dict[str, Any]:
     """Apply the fixed delivery-cause priority after native validation."""
 
-    payload = evaluate_host_facts(host_facts, enforcement)
+    payload = evaluate_host_facts(host_facts, enforcement, candidate_path)
     result = validation_result if isinstance(validation_result, dict) else {}
     status = result.get("status")
     payload["native_validation"]["status"] = status if isinstance(status, str) else "command_missing"
@@ -491,14 +553,15 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--host-facts-file", type=Path, required=True)
     parser.add_argument("--validation-result-file", type=Path)
+    parser.add_argument("--candidate-path", type=Path)
     parser.add_argument("--enforcement", default="advisory")
     parser.add_argument("--output", type=Path)
     args = parser.parse_args()
     host_facts = _read_host_facts(args.host_facts_file)
     payload = (
-        finalize_delivery_gate(host_facts, _read_host_facts(args.validation_result_file), args.enforcement)
+        finalize_delivery_gate(host_facts, _read_host_facts(args.validation_result_file), args.enforcement, args.candidate_path)
         if args.validation_result_file
-        else evaluate_host_facts(host_facts, args.enforcement)
+        else evaluate_host_facts(host_facts, args.enforcement, args.candidate_path)
     )
     encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
     if args.output:

--- a/src/skills/shared/scripts/delivery_gate.py
+++ b/src/skills/shared/scripts/delivery_gate.py
@@ -245,7 +245,7 @@ def _candidate_profile(candidate_path: Path | None, paths: list[str]) -> tuple[s
         if companion is None or companion.get("schema_version") != "loom-repo-interface/v2":
             profile.update({"status": "unreadable", "authority": companion_locator})
             return None, profile, ["repo companion profile authority is unreadable"]
-        adoption_mode = "attach-only" if isinstance(companion.get("host_truth_locators"), list) and companion["host_truth_locators"] else "execution-control"
+        adoption_mode = "execution-control"
         resolved = ADOPTION_PROFILES[adoption_mode]
         profile.update({"status": "valid", "profile": resolved, "adoption_mode": adoption_mode, "authority": companion_locator})
         return resolved, profile, []

--- a/tools/check_delivery_gate.py
+++ b/tools/check_delivery_gate.py
@@ -138,24 +138,23 @@ def check_evaluator() -> None:
     assert_primary_cause(evaluator.finalize_delivery_gate(caller["host_facts"], {"status": "passed"}, "enforce"), "passed", "enforce", "passed")
 
 
-def materialize_light_candidate(root: Path, forbidden: bool) -> Path:
-    candidate = root / ("forbidden" if forbidden else "clean")
+def materialize_candidate(root: Path, adoption_mode: str | None, forbidden: bool) -> Path:
+    candidate = root / f"{adoption_mode or 'companion-standard'}-{'forbidden' if forbidden else 'clean'}"
     candidate.mkdir()
     subprocess.run(["git", "init"], cwd=candidate, check=True, capture_output=True)
     subprocess.run(["git", "config", "user.email", "loom@example.invalid"], cwd=candidate, check=True)
     subprocess.run(["git", "config", "user.name", "Loom Fixture"], cwd=candidate, check=True)
-    state = candidate / ".loom" / "installed-state.json"
+    if adoption_mode is None:
+        state = candidate / ".loom" / "companion" / "repo-interface.json"
+        payload = {"schema_version": "loom-repo-interface/v2"}
+    else:
+        state = candidate / ".loom" / "installed-state.json"
+        payload = {
+            "schema_version": "loom-installed-state/v2",
+            "repo_payload": {"mode": "metadata-only", "adoption_mode": adoption_mode},
+        }
     state.parent.mkdir(parents=True)
-    state.write_text(
-        json.dumps(
-            {
-                "schema_version": "loom-installed-state/v2",
-                "repo_payload": {"mode": "metadata-only", "adoption_mode": "light-governance"},
-            }
-        )
-        + "\n",
-        encoding="utf-8",
-    )
+    state.write_text(json.dumps(payload) + "\n", encoding="utf-8")
     if forbidden:
         carrier = candidate / ".loom" / "status" / "current.md"
         carrier.parent.mkdir(parents=True)
@@ -172,23 +171,43 @@ def check_light_profile_host_integration() -> None:
     assert_primary_cause(missing_candidate, "light_profile_tree_unreadable", "enforce", "blocked")
     with tempfile.TemporaryDirectory(prefix="loom-delivery-light-") as raw_tmp:
         root = Path(raw_tmp)
-        forbidden = materialize_light_candidate(root, True)
-        clean = materialize_light_candidate(root, False)
-        blocked = evaluator.finalize_delivery_gate(facts, {"status": "passed"}, "enforce", forbidden)
+        direct_facts = json.loads((FIXTURES / "direct-light.json").read_text(encoding="utf-8"))
+        if "profile" in direct_facts or direct_facts.get("event") != "pull_request":
+            raise AssertionError("direct-event fixture must not inject a caller profile")
+        forbidden = materialize_candidate(root, "light-governance", True)
+        clean = materialize_candidate(root, "light-governance", False)
+        blocked = evaluator.finalize_delivery_gate(direct_facts, {"status": "passed"}, "enforce", forbidden)
         assert_primary_cause(blocked, "light_profile_forbidden_carrier", "enforce", "blocked")
-        if blocked.get("light_invariant", {}).get("status") != "blocked":
-            raise AssertionError("explicit light delivery profile must consume the forbidden candidate tree")
-        passed = evaluator.finalize_delivery_gate(facts, {"status": "passed"}, "enforce", clean)
+        delivery = blocked.get("delivery", {})
+        if blocked.get("light_invariant", {}).get("status") != "blocked" or delivery.get("profile") != "light" or delivery.get("profile_source") != "candidate_state":
+            raise AssertionError("direct light event must derive profile authority and consume the candidate tree")
+        passed = evaluator.finalize_delivery_gate(direct_facts, {"status": "passed"}, "enforce", clean)
         assert_primary_cause(passed, "passed", "enforce", "passed")
         for profile in ("standard", "reinforced"):
-            bypassed = evaluator.finalize_delivery_gate({**facts, "profile": profile}, {"status": "passed"}, "enforce", forbidden)
-            assert_primary_cause(bypassed, "passed", "enforce", "passed")
-            if bypassed.get("light_invariant", {}).get("status") != "not_evaluated":
-                raise AssertionError(f"{profile} delivery profile must not consume the light invariant")
+            elevated = evaluator.finalize_delivery_gate({**direct_facts, "profile": profile}, {"status": "passed"}, "enforce", forbidden)
+            assert_primary_cause(elevated, "light_profile_forbidden_carrier", "enforce", "blocked")
+
+        mismatch_facts = json.loads((FIXTURES / "profile-mismatch.json").read_text(encoding="utf-8"))
+        for adoption_mode in ("execution-control", "strong-governance"):
+            candidate = materialize_candidate(root, adoption_mode, True)
+            mismatch = evaluator.finalize_delivery_gate(mismatch_facts, {"status": "passed"}, "enforce", candidate)
+            assert_primary_cause(mismatch, "profile_state_mismatch", "enforce", "blocked")
+
+        companion = materialize_candidate(root, None, True)
+        companion_result = evaluator.finalize_delivery_gate(direct_facts, {"status": "passed"}, "enforce", companion)
+        assert_primary_cause(companion_result, "passed", "enforce", "passed")
+        if companion_result.get("delivery", {}).get("candidate_profile", {}).get("authority") != ".loom/companion/repo-interface.json":
+            raise AssertionError("legacy execution-control candidate must authenticate its companion profile")
+
+        deleted_state = materialize_candidate(root, "attach-only", False)
+        (deleted_state / ".loom" / "installed-state.json").unlink()
+        deleted_facts = {**direct_facts, "changed_paths": [".loom/installed-state.json"]}
+        deleted = evaluator.finalize_delivery_gate(deleted_facts, {"status": "passed"}, "enforce", deleted_state)
+        assert_primary_cause(deleted, "candidate_profile_unreadable", "enforce", "blocked")
 
         host_facts = root / "host-facts.json"
         validation = root / "validation.json"
-        host_facts.write_text(json.dumps(facts) + "\n", encoding="utf-8")
+        host_facts.write_text(json.dumps(direct_facts) + "\n", encoding="utf-8")
         validation.write_text('{"status":"passed"}\n', encoding="utf-8")
         completed = subprocess.run(
             [

--- a/tools/check_delivery_gate.py
+++ b/tools/check_delivery_gate.py
@@ -138,16 +138,28 @@ def check_evaluator() -> None:
     assert_primary_cause(evaluator.finalize_delivery_gate(caller["host_facts"], {"status": "passed"}, "enforce"), "passed", "enforce", "passed")
 
 
-def materialize_candidate(root: Path, adoption_mode: str | None, forbidden: bool) -> Path:
-    candidate = root / f"{adoption_mode or 'companion-standard'}-{'forbidden' if forbidden else 'clean'}"
+def materialize_candidate(
+    root: Path,
+    adoption_mode: str | None,
+    forbidden: bool,
+    *,
+    companion: bool = False,
+    host_truth_locators: object = None,
+) -> Path:
+    authority = "companion" if companion else "installed-state"
+    candidate = root / f"{authority}-{adoption_mode or 'legacy'}-{'forbidden' if forbidden else 'clean'}"
     candidate.mkdir()
     subprocess.run(["git", "init"], cwd=candidate, check=True, capture_output=True)
     subprocess.run(["git", "config", "user.email", "loom@example.invalid"], cwd=candidate, check=True)
     subprocess.run(["git", "config", "user.name", "Loom Fixture"], cwd=candidate, check=True)
-    if adoption_mode is None:
+    if companion:
         state = candidate / ".loom" / "companion" / "repo-interface.json"
         payload = {"schema_version": "loom-repo-interface/v2"}
+        if host_truth_locators is not None:
+            payload["host_truth_locators"] = host_truth_locators
     else:
+        if adoption_mode is None:
+            raise AssertionError("installed-state fixture requires adoption_mode")
         state = candidate / ".loom" / "installed-state.json"
         payload = {
             "schema_version": "loom-installed-state/v2",
@@ -181,6 +193,8 @@ def check_light_profile_host_integration() -> None:
         delivery = blocked.get("delivery", {})
         if blocked.get("light_invariant", {}).get("status") != "blocked" or delivery.get("profile") != "light" or delivery.get("profile_source") != "candidate_state":
             raise AssertionError("direct light event must derive profile authority and consume the candidate tree")
+        if delivery.get("candidate_profile", {}).get("authority") != ".loom/installed-state.json":
+            raise AssertionError("light adoption must come from explicit installed-state authority")
         passed = evaluator.finalize_delivery_gate(direct_facts, {"status": "passed"}, "enforce", clean)
         assert_primary_cause(passed, "passed", "enforce", "passed")
         for profile in ("standard", "reinforced"):
@@ -193,11 +207,12 @@ def check_light_profile_host_integration() -> None:
             mismatch = evaluator.finalize_delivery_gate(mismatch_facts, {"status": "passed"}, "enforce", candidate)
             assert_primary_cause(mismatch, "profile_state_mismatch", "enforce", "blocked")
 
-        companion = materialize_candidate(root, None, True)
-        companion_result = evaluator.finalize_delivery_gate(direct_facts, {"status": "passed"}, "enforce", companion)
-        assert_primary_cause(companion_result, "passed", "enforce", "passed")
-        if companion_result.get("delivery", {}).get("candidate_profile", {}).get("authority") != ".loom/companion/repo-interface.json":
-            raise AssertionError("legacy execution-control candidate must authenticate its companion profile")
+        for fixture_id, host_truth in ((None, ["issue:1"]), ("execution-control", {"work_item": "github:issue"})):
+            execution_companion = materialize_candidate(root, fixture_id, True, companion=True, host_truth_locators=host_truth)
+            execution_result = evaluator.finalize_delivery_gate(direct_facts, {"status": "passed"}, "enforce", execution_companion)
+            assert_primary_cause(execution_result, "passed", "enforce", "passed")
+            if execution_result.get("light_invariant", {}).get("status") != "not_evaluated" or execution_result.get("delivery", {}).get("candidate_profile", {}).get("adoption_mode") != "execution-control":
+                raise AssertionError("execution-control host truth locators must not imply light adoption")
 
         deleted_state = materialize_candidate(root, "attach-only", False)
         (deleted_state / ".loom" / "installed-state.json").unlink()

--- a/tools/check_delivery_gate.py
+++ b/tools/check_delivery_gate.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -134,6 +136,80 @@ def check_evaluator() -> None:
     ):
         raise AssertionError("caller fixture must prove a pull_request caller selects pinned Loom and candidate paths")
     assert_primary_cause(evaluator.finalize_delivery_gate(caller["host_facts"], {"status": "passed"}, "enforce"), "passed", "enforce", "passed")
+
+
+def materialize_light_candidate(root: Path, forbidden: bool) -> Path:
+    candidate = root / ("forbidden" if forbidden else "clean")
+    candidate.mkdir()
+    subprocess.run(["git", "init"], cwd=candidate, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "loom@example.invalid"], cwd=candidate, check=True)
+    subprocess.run(["git", "config", "user.name", "Loom Fixture"], cwd=candidate, check=True)
+    state = candidate / ".loom" / "installed-state.json"
+    state.parent.mkdir(parents=True)
+    state.write_text(
+        json.dumps(
+            {
+                "schema_version": "loom-installed-state/v2",
+                "repo_payload": {"mode": "metadata-only", "adoption_mode": "light-governance"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    if forbidden:
+        carrier = candidate / ".loom" / "status" / "current.md"
+        carrier.parent.mkdir(parents=True)
+        carrier.write_text("forbidden\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=candidate, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "fixture"], cwd=candidate, check=True, capture_output=True)
+    return candidate
+
+
+def check_light_profile_host_integration() -> None:
+    evaluator = load_evaluator()
+    facts = {**json.loads((FIXTURES / "docs.json").read_text(encoding="utf-8")), "profile": "light"}
+    missing_candidate = evaluator.finalize_delivery_gate(facts, {"status": "passed"}, "enforce")
+    assert_primary_cause(missing_candidate, "light_profile_tree_unreadable", "enforce", "blocked")
+    with tempfile.TemporaryDirectory(prefix="loom-delivery-light-") as raw_tmp:
+        root = Path(raw_tmp)
+        forbidden = materialize_light_candidate(root, True)
+        clean = materialize_light_candidate(root, False)
+        blocked = evaluator.finalize_delivery_gate(facts, {"status": "passed"}, "enforce", forbidden)
+        assert_primary_cause(blocked, "light_profile_forbidden_carrier", "enforce", "blocked")
+        if blocked.get("light_invariant", {}).get("status") != "blocked":
+            raise AssertionError("explicit light delivery profile must consume the forbidden candidate tree")
+        passed = evaluator.finalize_delivery_gate(facts, {"status": "passed"}, "enforce", clean)
+        assert_primary_cause(passed, "passed", "enforce", "passed")
+        for profile in ("standard", "reinforced"):
+            bypassed = evaluator.finalize_delivery_gate({**facts, "profile": profile}, {"status": "passed"}, "enforce", forbidden)
+            assert_primary_cause(bypassed, "passed", "enforce", "passed")
+            if bypassed.get("light_invariant", {}).get("status") != "not_evaluated":
+                raise AssertionError(f"{profile} delivery profile must not consume the light invariant")
+
+        host_facts = root / "host-facts.json"
+        validation = root / "validation.json"
+        host_facts.write_text(json.dumps(facts) + "\n", encoding="utf-8")
+        validation.write_text('{"status":"passed"}\n', encoding="utf-8")
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(SOURCE),
+                "--host-facts-file",
+                str(host_facts),
+                "--validation-result-file",
+                str(validation),
+                "--candidate-path",
+                str(forbidden),
+                "--enforcement",
+                "enforce",
+            ],
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        payload = json.loads(completed.stdout)
+        if completed.returncode != 0 or payload.get("result") != "blocked" or payload.get("primary_cause", {}).get("id") != "light_profile_forbidden_carrier":
+            raise AssertionError(f"host-level light-profile negative integration drifted: {payload}")
 
 
 def check_generated_copies() -> None:
@@ -366,12 +442,13 @@ def check_workflow() -> None:
         "if: ${{ always() && inputs.loom_ref == '' }}",
         "LOOM_SOURCE_PATH: ${{ inputs.loom_ref != '' && 'loom' || '.' }}",
         "CANDIDATE_PATH: ${{ inputs.loom_ref != '' && 'candidate' || '.' }}",
-        "DELIVERY_GATE_ENFORCEMENT: ${{ inputs.loom_ref != '' && inputs.enforcement || 'advisory' }}",
+        "DELIVERY_GATE_ENFORCEMENT: ${{ inputs.loom_ref != '' && inputs.enforcement || 'enforce' }}",
         "LOOM_SOURCE_PATH",
         "CANDIDATE_PATH",
         "$LOOM_SOURCE_PATH/src/skills/shared/scripts/delivery_gate.py",
         "bash -o pipefail -c \"$VALIDATION_COMMAND\"",
         "--validation-result-file",
+        "--candidate-path \"$CANDIDATE_PATH\"",
         "--enforcement \"$DELIVERY_GATE_ENFORCEMENT\"",
         "LOOM_DELIVERY_GATE_CHANGED_PATHS_FILE",
         "LOOM_DELIVERY_GATE_HOST_FACTS_FILE",
@@ -427,6 +504,7 @@ def check_workflow() -> None:
 
 def main() -> int:
     check_evaluator()
+    check_light_profile_host_integration()
     check_generated_copies()
     check_required_check_identity()
     check_identity_reader_boundary()

--- a/tools/fixtures/delivery-gate/direct-light.json
+++ b/tools/fixtures/delivery-gate/direct-light.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "loom-delivery-gate-host-facts/v1",
+  "event": "pull_request",
+  "repository": {
+    "owner": "Example",
+    "name": "LightRepo"
+  },
+  "changed_paths": [
+    ".loom/status/current.md"
+  ]
+}

--- a/tools/fixtures/delivery-gate/profile-mismatch.json
+++ b/tools/fixtures/delivery-gate/profile-mismatch.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "loom-delivery-gate-host-facts/v1",
+  "event": "workflow_call",
+  "repository": {
+    "owner": "Example",
+    "name": "GovernedRepo"
+  },
+  "profile": "light",
+  "changed_paths": [
+    "src/runtime.py"
+  ]
+}


### PR DESCRIPTION
## 摘要

- 将 direct PR 与 merge-group 的 loom-delivery-gate 从 advisory 改为 enforce。
- 显式 light profile 时读取 candidate tree，并对 forbidden carrier、installed-state 和 tree readback fail closed。
- 保持 standard/reinforced 与 changed-path 自动轻量验证不误触发 light invariant。

## 验证

- make delivery-gate-check
- make light-profile-check
- python3 tools/py_compile_clean.py src/skills/shared/scripts/delivery_gate.py tools/check_delivery_gate.py
- python3 tools/skills_surface.py check
- git diff --check

## 风险与边界

- direct PR gate 现在真实 enforce；candidate checkout 或 installed-state 不可读会阻断。
- 不恢复 current/progress/review/shadow carrier。
- 不包含 WebEnvoy rollout。

## Related Work

- Work Item: work_item:2039
- Closes #2039