### PR TITLE
fix(governance): 收敛轻治理验收与 limited gate

### DIFF
--- a/docs/adoption/ci-required-checks-bootstrap.md
+++ b/docs/adoption/ci-required-checks-bootstrap.md
@@ -126,12 +126,13 @@ branch rules 与 Actions workflow id/path/state。后者由 GitHub 按目标 bra
 
 - `required_workflow`：当前只能收集诊断，固定为 `limited`；仅有 workflow path、
   repository/ref/ruleset id 与 workflow id/path/state 仍不能证明当前 run、目标分支和
-  ruleset enforcement 的完整绑定，#2063 完成专用 host adapter 前不得返回 `strong`；
+  ruleset enforcement 的完整绑定，因此当前返回 blocked 且不得宣称 `strong`；
 - `distinct_app_check`：required check 绑定到不同于 GitHub Actions（app id
   `15368`）的专用 GitHub App，才是 `strong`；
 - `pull_request_target_same_app`：base-owned coordinator 的 identity assurance 为
-  `limited`；identity reader 以 `host_enforcement_unavailable` 表示“未达到 strong”，
-  不等于 delivery check 可以忽略 native failure。
+  `limited`；当 branch protection 恰好一次绑定预期 context 与 GitHub Actions app id
+  时，identity reader 返回 `ready`、`passed_limited`。这只证明 required set 已准确
+  配置，不表示 context 不可被同 App 冒充，也不允许 delivery check 忽略 native failure。
 
 当前 Loom repo rulesets 为空，org rulesets API 返回“Upgrade to GitHub Team”，且
 repo-level REST rules surface 不提供 required-workflow rule。因此 v0.30 明确采用

--- a/plugins/loom/.codex-plugin/plugin.json
+++ b/plugins/loom/.codex-plugin/plugin.json
@@ -23,7 +23,7 @@
     "source_git_sha": "e44db754f6b6d6bf03579bca40086c8e61dae79f",
     "source_git_sha_status": "release_commit",
     "plugin_payload_version": "0.29.1",
-    "plugin_payload_hash": "0a19ef63ff3735510531458642f421a4cd44bf0e40d3c0a0de602005d24a2bac",
+    "plugin_payload_hash": "1960dd317d620e2af56cc4706afe2e26ced622b37c4201da5d22b0a51907aa7c",
     "repository_payload": false
   },
   "keywords": [

--- a/src/skills/shared/scripts/delivery_control.py
+++ b/src/skills/shared/scripts/delivery_control.py
@@ -8824,6 +8824,7 @@ def governance_capability_profile_payload(
         host_enforcement.get("branch_protection_readable") is True
         or host_enforcement.get("ruleset_readable") is True
     )
+    host_trust_verdict = host_enforcement.get("trust_verdict")
 
     if mode == "host-enforced":
         if not host_required:
@@ -8834,13 +8835,13 @@ def governance_capability_profile_payload(
             "schema_version": GOVERNANCE_CAPABILITY_PROFILE_SCHEMA,
             "mode": "host-enforced",
             "result": "pass" if not missing_inputs else "block",
-            "assurance": "strong",
+            "assurance": "strong" if host_trust_verdict == "strong" else "limited",
             "risk_label": None,
             "host_enforcement_status": "host_enforced" if not missing_inputs else "unverified",
             "explicit_opt_in": False,
             "change_class": normalized_change_class or None,
             "summary": (
-                "host-enforced governance is proven by host required checks."
+                "host-enforced governance is proven by host required checks; identity assurance remains limited unless trusted host readback proves a distinct identity."
                 if not missing_inputs
                 else "host-enforced governance cannot be proven from host readback."
             ),

--- a/src/skills/shared/scripts/execution_flow.py
+++ b/src/skills/shared/scripts/execution_flow.py
@@ -125,6 +125,7 @@ from governance_surface import (
 from execution_attempts import (
     persist_execution_attempt,
 )
+from loom_init import host_derived_manifest
 
 FLOW_ENTRYPOINT = Path(__file__).with_name("loom_flow.py")
 
@@ -2501,7 +2502,7 @@ def render_governance_intensity_metadata_body(
         "work_item_locator": work_item_locator,
         "governance_intensity": governance_intensity,
         "governance_mode": "host-enforced",
-        "governance_assurance": "strong",
+        "governance_assurance": "limited",
         "advisory_risk_label": None,
         "host_enforcement_required": True,
         "change_class": change_class,
@@ -3200,6 +3201,80 @@ def maturity_upgrade_path(governance_surface: dict[str, Any], target_root: Path)
 
 def lifecycle_intent_for_operation(operation: str) -> str | None:
     return {"build": "build", "pre-review": "pr", "closeout": "closeout"}.get(operation)
+
+
+def host_derived_flow_payload(
+    *,
+    target_root: Path,
+    args: argparse.Namespace,
+    manifest: dict[str, object],
+    runtime_state: dict[str, Any],
+    lifecycle_admission: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Route light-profile flows without reading committed execution state."""
+
+    admission = lifecycle_admission
+    if admission is None:
+        intent = "ship" if args.operation == "merge-ready" else "build"
+        admission = lifecycle_admission_payload(
+            target_root=target_root,
+            owner=args.owner,
+            repo_name=args.repo_name,
+            issue_number=args.issue,
+            fr_number=args.fr,
+            pr_number=args.pr,
+            branch_name=args.branch,
+            intent=intent,
+        )
+    admission_passed = admission.get("result") == "pass"
+    missing_inputs = list(admission.get("missing_inputs", [])) if not admission_passed else []
+    if not admission_passed and not missing_inputs:
+        missing_inputs.append(str(admission.get("summary") or admission.get("admission_state") or "host lifecycle admission blocked"))
+    fallback_to: str | None = admission.get("primary_remediation") if missing_inputs else None
+    result = "pass" if admission_passed else "block"
+    if args.operation in {"review", "spec-review"}:
+        result = "block"
+        missing_inputs.append("current GitHub host attestation artifact")
+        fallback_to = "loom attestation readback --repo <owner/repo> --pr <n> --work-item <n> --artifact-input <file> --json"
+    elif args.operation == "merge-ready" and result == "pass":
+        result = "block"
+        missing_inputs.append("current-head PR gate and merge check host readback")
+        fallback_to = "loom pr gate <pr> --json && loom merge check <pr> --json"
+
+    return {
+        "command": "flow",
+        "operation": args.operation,
+        "result": result,
+        "summary": (
+            "light-profile flow consumed GitHub lifecycle admission and current worktree facts without repository execution carriers."
+            if result == "pass"
+            else "light-profile flow stopped at a missing host fact without falling back to repository execution carriers."
+        ),
+        "profile": manifest.get("profile"),
+        "missing_inputs": list(dict.fromkeys(missing_inputs)),
+        "fallback_to": fallback_to,
+        "runtime_state": runtime_state,
+        "lifecycle_admission": admission,
+        "worktree": {
+            "repository_locator": ".",
+            "branch": git_branch(target_root),
+            "head_sha": git_head_sha(target_root),
+            "workspace_entry": ".",
+            "source": "git_worktree_readback",
+        },
+        "steps": [
+            {"name": "runtime-state", "result": runtime_state["result"]},
+            {"name": "host-lifecycle-admission", "result": admission.get("result")},
+            {"name": "git-worktree-readback", "result": "pass"},
+        ],
+        "carrier_mutations": False,
+        "repo_execution_carriers_consumed": False,
+        "committed_current_consumed": False,
+        "committed_status_consumed": False,
+        "committed_progress_consumed": False,
+        "committed_review_consumed": False,
+        "committed_shadow_consumed": False,
+    }
 
 def runtime_parity_check(
     name: str,
@@ -4369,6 +4444,32 @@ def handle_flow(args: argparse.Namespace) -> int:
 
     if args.operation == "story":
         return emit(story_flow_payload(target_root=target_root, runtime_state=runtime_state, steps=steps))
+
+    derived_manifest, manifest_errors = host_derived_manifest(target_root)
+    if manifest_errors:
+        return emit(
+            {
+                "command": "flow",
+                "operation": args.operation,
+                "result": "block",
+                "summary": "light-profile manifest is invalid; legacy carriers are not a fallback.",
+                "missing_inputs": manifest_errors,
+                "fallback_to": "adoption",
+                "runtime_state": runtime_state,
+                "carrier_mutations": False,
+                "repo_execution_carriers_consumed": False,
+            }
+        )
+    if derived_manifest is not None:
+        return emit(
+            host_derived_flow_payload(
+                target_root=target_root,
+                args=args,
+                manifest=derived_manifest,
+                runtime_state=runtime_state,
+                lifecycle_admission=lifecycle_admission,
+            )
+        )
 
     context, errors = load_context_with_retained_idle_fallback(target_root, args.output, args.item)
     if errors:

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -145,9 +145,10 @@ def source_snapshot_ignore(root: Path):
 
 SOURCE_PROFILE_MARKERS = (
     "src/skills/shared/scripts/loom_check.py",
+    "src/skills/registry.json",
     "tools/loom_check.py",
-    "skills/registry.json",
-    "packages/loom-installer",
+    "tools/loom.py",
+    "package.json",
     "examples/new-project",
 )
 

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+from pathlib import Path
 from typing import Any
 
 try:
@@ -552,6 +553,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Init-result path relative to the target root",
     )
     review.add_argument("--review-file", help="Optional review artifact path relative to the target root")
+    review.add_argument("--owner", help="GitHub owner for light-profile host attestation")
+    review.add_argument("--repo", dest="repo_name", help="GitHub repository for light-profile host attestation")
+    review.add_argument("--issue", type=int, help="GitHub Work Item issue for light-profile host attestation")
+    review.add_argument("--pr", type=int, help="GitHub PR for light-profile host attestation")
+    review.add_argument("--host-artifact-input", type=Path, help="JSON containing only the GitHub Actions artifact_id")
+    review.add_argument("--review-policy", choices=("approved", "single_maintainer"), default="approved")
     review.add_argument("--decision", choices=tuple(sorted(REVIEW_DECISIONS)))
     review.add_argument("--kind", choices=tuple(sorted(REVIEW_KINDS)))
     review.add_argument("--summary", help="Stable review conclusion summary")

--- a/src/skills/shared/scripts/loom_init.py
+++ b/src/skills/shared/scripts/loom_init.py
@@ -3290,6 +3290,27 @@ def validate_host_derived_manifest(target_root: Path, payload: object) -> list[s
     return errors
 
 
+def host_derived_manifest(target_root: Path) -> tuple[dict[str, object] | None, list[str]]:
+    """Read the light-profile manifest without falling back to execution carriers."""
+
+    path = target_root / ".loom/bootstrap/manifest.json"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None, []
+    except OSError as exc:
+        return None, [f"bootstrap manifest is unreadable: {exc}"]
+    except json.JSONDecodeError as exc:
+        return None, [f"bootstrap manifest is invalid JSON: {exc.msg}"]
+    if not isinstance(payload, dict):
+        return None, ["bootstrap manifest must be a JSON object"]
+    if payload.get("schema_version") == "loom-bootstrap-manifest/v1":
+        return None, []
+    if payload.get("schema_version") != "loom-bootstrap-manifest/v2":
+        return None, ["bootstrap manifest schema is unsupported"]
+    return payload, validate_host_derived_manifest(target_root, payload)
+
+
 def scaffold_target(
     target_root: Path,
     result: dict[str, object],

--- a/src/skills/shared/scripts/loom_status.py
+++ b/src/skills/shared/scripts/loom_status.py
@@ -45,7 +45,7 @@ from loom_flow import (
     validate_goal_execution_contract,
 )
 from flow_runtime import git_branch, git_head_sha
-from loom_init import validate_host_derived_manifest
+from loom_init import host_derived_manifest
 from authority_contract import parse_typed_locator
 from delivery_control import (
     pr_body_field_value,
@@ -54,25 +54,6 @@ from delivery_control import (
 )
 
 IDLE_ITEM_ID = "no_active_item"
-
-
-def host_derived_manifest(target_root: Path) -> tuple[dict[str, object] | None, list[str]]:
-    path = target_root / ".loom/bootstrap/manifest.json"
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except FileNotFoundError:
-        return None, []
-    except OSError as exc:
-        return None, [f"bootstrap manifest is unreadable: {exc}"]
-    except json.JSONDecodeError as exc:
-        return None, [f"bootstrap manifest is invalid JSON: {exc.msg}"]
-    if not isinstance(payload, dict):
-        return None, ["bootstrap manifest must be a JSON object"]
-    if payload.get("schema_version") == "loom-bootstrap-manifest/v1":
-        return None, []
-    if payload.get("schema_version") != "loom-bootstrap-manifest/v2":
-        return None, ["bootstrap manifest schema is unsupported"]
-    return payload, validate_host_derived_manifest(target_root, payload)
 
 
 def host_derived_status_payload(

--- a/src/skills/shared/scripts/review_flow.py
+++ b/src/skills/shared/scripts/review_flow.py
@@ -71,6 +71,9 @@ from runtime_paths import (
     global_runtime_locator_for_path,
     shared_asset,
 )
+from loom_init import host_derived_manifest
+from host_attestation import _artifact_id as host_attestation_artifact_id
+from host_attestation import readback as host_attestation_readback
 
 FLOW_ENTRYPOINT = Path(__file__).with_name("loom_flow.py")
 
@@ -4071,6 +4074,71 @@ def pre_review_readiness_cost_guard_payload(
 
 def handle_review(args: argparse.Namespace) -> int:
     target_root = resolve_target_arg(args.target)
+    derived_manifest, manifest_errors = host_derived_manifest(target_root)
+    if manifest_errors:
+        return emit(
+            {
+                "command": "review",
+                "operation": args.operation,
+                "result": "block",
+                "summary": "light-profile manifest is invalid; repository review carriers are not a fallback.",
+                "missing_inputs": manifest_errors,
+                "fallback_to": "adoption",
+                "carrier_mutations": False,
+                "repo_execution_carriers_consumed": False,
+            }
+        )
+    if derived_manifest is not None:
+        detected_owner, detected_repo = detect_github_repo(target_root)
+        requested_owner = getattr(args, "owner", None)
+        requested_repo = getattr(args, "repo_name", None)
+        owner, repo_name = detected_owner, detected_repo
+        missing = []
+        if not detected_owner or not detected_repo:
+            missing.append("target origin GitHub owner/repo")
+        elif (requested_owner and requested_owner != detected_owner) or (requested_repo and requested_repo != detected_repo):
+            missing.append("explicit GitHub owner/repo must match the target origin")
+        if not isinstance(getattr(args, "issue", None), int):
+            missing.append("--issue Work Item number")
+        if not isinstance(getattr(args, "pr", None), int):
+            missing.append("--pr number")
+        if getattr(args, "host_artifact_input", None) is None:
+            missing.append("--host-artifact-input locator")
+        artifact_id = None
+        if not missing:
+            try:
+                artifact_id = host_attestation_artifact_id(args.host_artifact_input)
+            except ValueError as exc:
+                missing.append(str(exc))
+        if not missing:
+            assert owner and repo_name and isinstance(args.issue, int) and isinstance(args.pr, int) and isinstance(artifact_id, int)
+            result = host_attestation_readback(
+                target_root,
+                owner,
+                repo_name,
+                args.pr,
+                args.issue,
+                artifact_id,
+                review_policy=getattr(args, "review_policy", "approved"),
+            )
+            result["command"] = "review"
+            result["operation"] = args.operation
+            result["profile"] = derived_manifest.get("profile")
+            result["repo_execution_carriers_consumed"] = False
+            return emit(result)
+        return emit(
+            {
+                "command": "review",
+                "operation": args.operation,
+                "result": "block",
+                "summary": "light-profile review requires GitHub host attestation; repository review carriers are disabled.",
+                "profile": derived_manifest.get("profile"),
+                "missing_inputs": missing,
+                "fallback_to": "loom review read --target <repo> --issue <work-item> --pr <n> --host-artifact-input <file> --json",
+                "carrier_mutations": False,
+                "repo_execution_carriers_consumed": False,
+            }
+        )
     context, errors = load_context_with_retained_idle_fallback(target_root, args.output, args.item)
     if errors:
         return emit(

--- a/test/derived_state_bootstrap_test.py
+++ b/test/derived_state_bootstrap_test.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
+import importlib.util
+import io
 import json
 import subprocess
 import sys
@@ -17,6 +20,18 @@ sys.path.insert(0, str(RUNTIME))
 
 import loom_init
 import loom_status
+import execution_flow
+import review_flow
+
+
+def load_global_cli():
+    sys.path.insert(0, str(ROOT / "tools"))
+    spec = importlib.util.spec_from_file_location("loom_global_cli_derived_state", ROOT / "tools/loom.py")
+    if spec is None or spec.loader is None:
+        raise AssertionError("global CLI is not importable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def string_values(value: object) -> list[str]:
@@ -28,6 +43,159 @@ def string_values(value: object) -> list[str]:
 
 
 class DerivedStateBootstrapTest(unittest.TestCase):
+    def test_light_review_and_closeout_consume_host_attestation(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            companion = root / ".loom/companion"
+            companion.mkdir(parents=True)
+            (companion / "repo-interface.json").write_text("{}\n", encoding="utf-8")
+            bootstrap = root / ".loom/bootstrap"
+            bootstrap.mkdir(parents=True)
+            (bootstrap / "manifest.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": "loom-bootstrap-manifest/v2",
+                        "profile": "light-governance",
+                        "repository_locator": ".",
+                        "companion_locator": ".loom/companion/repo-interface.json",
+                        "capabilities": [],
+                        "artifact_locators": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            artifact = root / "artifact.json"
+            artifact.write_text('{"artifact_id":7}\n', encoding="utf-8")
+            host_pass = {
+                "result": "pass",
+                "summary": "host attestation passed",
+                "missing_inputs": [],
+                "attestation": {"carrier_mutations": False},
+            }
+
+            original_detect = review_flow.detect_github_repo
+            original_review = review_flow.host_attestation_readback
+            try:
+                review_flow.detect_github_repo = lambda _root: ("owner", "repo")
+                review_flow.host_attestation_readback = lambda *_args, **_kwargs: dict(host_pass)
+                output = io.StringIO()
+                with contextlib.redirect_stdout(output):
+                    code = review_flow.handle_review(
+                        argparse.Namespace(
+                            target=str(root),
+                            operation="read",
+                            output=".loom/bootstrap/init-result.json",
+                            item=None,
+                            owner=None,
+                            repo_name=None,
+                            issue=42,
+                            pr=7,
+                            host_artifact_input=artifact,
+                            review_policy="single_maintainer",
+                        )
+                    )
+                review = json.loads(output.getvalue())
+                self.assertEqual(code, 0)
+                self.assertEqual(review["result"], "pass")
+                self.assertFalse(review["repo_execution_carriers_consumed"])
+
+                review_flow.host_attestation_readback = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                    AssertionError("cross-repository review must block before host readback")
+                )
+                output = io.StringIO()
+                with contextlib.redirect_stdout(output):
+                    code = review_flow.handle_review(
+                        argparse.Namespace(
+                            target=str(root), operation="read", output=".loom/bootstrap/init-result.json",
+                            item=None, owner="other", repo_name="repo", issue=42, pr=7,
+                            host_artifact_input=artifact, review_policy="single_maintainer",
+                        )
+                    )
+                mismatch = json.loads(output.getvalue())
+                self.assertNotEqual(code, 0)
+                self.assertEqual(mismatch["result"], "block")
+                self.assertIn("must match the target origin", " ".join(mismatch["missing_inputs"]))
+            finally:
+                review_flow.detect_github_repo = original_detect
+                review_flow.host_attestation_readback = original_review
+
+            cli = load_global_cli()
+            original_closeout = cli.ship_host_attestation
+            original_infer = cli.infer_github_repo
+            try:
+                cli.infer_github_repo = lambda _target: "owner/repo"
+                cli.ship_host_attestation = lambda *_args, **_kwargs: dict(host_pass)
+                output = io.StringIO()
+                with contextlib.redirect_stdout(output):
+                    code = cli.handle_scenario(
+                        "closeout",
+                        [
+                            "--target", str(root),
+                            "--owner", "owner",
+                            "--repo", "repo",
+                            "--issue", "42",
+                            "--pr", "7",
+                            "--attestation-artifact-input", str(artifact),
+                            "--json",
+                        ],
+                    )
+                closeout = json.loads(output.getvalue())
+                self.assertEqual(code, 0)
+                self.assertEqual(closeout["result"], "pass")
+                self.assertFalse(closeout["repo_execution_carriers_consumed"])
+
+                mismatch = original_closeout(
+                    argparse.Namespace(
+                        owner="other", repo_name="repo", issue=42, pr=7,
+                        pr_role=None, implementation_pr=None, release_pr=None,
+                        carrier_sync_pr=None, final_closeout_pr=None,
+                        attestation_artifact_input=artifact, review_policy="single_maintainer",
+                    ),
+                    root,
+                    closeout=True,
+                )
+                self.assertEqual(mismatch["result"], "block")
+                self.assertIn("must match the target origin", " ".join(mismatch["missing_inputs"]))
+            finally:
+                cli.ship_host_attestation = original_closeout
+                cli.infer_github_repo = original_infer
+
+    def test_light_flow_never_reads_stale_execution_carriers(self) -> None:
+        args = argparse.Namespace(
+            operation="resume",
+            owner="MC-and-his-Agents",
+            repo_name="Loom",
+            issue=2054,
+            fr=None,
+            pr=None,
+            branch="work/2054-v030-acceptance-release",
+        )
+        payload = execution_flow.host_derived_flow_payload(
+            target_root=ROOT,
+            args=args,
+            manifest={"profile": "light-governance"},
+            runtime_state={"result": "pass"},
+            lifecycle_admission={"result": "pass", "missing_inputs": [], "carrier_mutations": False},
+        )
+
+        self.assertEqual(payload["result"], "pass", payload)
+        self.assertFalse(payload["repo_execution_carriers_consumed"])
+        self.assertFalse(payload["committed_current_consumed"])
+        self.assertFalse(payload["committed_progress_consumed"])
+        self.assertFalse(payload["committed_review_consumed"])
+        self.assertFalse(payload["committed_shadow_consumed"])
+        self.assertNotIn("fact-chain", json.dumps(payload))
+
+        blocked = execution_flow.host_derived_flow_payload(
+            target_root=ROOT,
+            args=args,
+            manifest={"profile": "light-governance"},
+            runtime_state={"result": "pass"},
+            lifecycle_admission={"result": "block", "admission_state": "needs_breakdown"},
+        )
+        self.assertEqual(blocked["result"], "block", blocked)
+        self.assertIn("needs_breakdown", blocked["missing_inputs"])
+
     def test_unrequested_full_bootstrap_uses_host_derived_light_profile(self) -> None:
         self.assertEqual(
             loom_init.scaffold_profile_key("full-bootstrap", {}),

--- a/test/governance_merge_profile_test.py
+++ b/test/governance_merge_profile_test.py
@@ -46,6 +46,34 @@ class GovernanceMergeProfileTest(unittest.TestCase):
         self.assertEqual(payload["result"], "block")
         self.assertIn("loom-pr-merge-gate", payload["missing_inputs"][0])
 
+    def test_host_enforced_defaults_to_limited_without_distinct_identity_readback(self) -> None:
+        limited = loom_flow.governance_capability_profile_payload(
+            mode="host-enforced",
+            host_enforcement={
+                "required": True,
+                "branch_protection_readable": True,
+                "ruleset_readable": True,
+            },
+            allow_advisory=False,
+            allow_high_risk_advisory=False,
+            change_class=None,
+        )
+        strong = loom_flow.governance_capability_profile_payload(
+            mode="host-enforced",
+            host_enforcement={
+                "required": True,
+                "branch_protection_readable": True,
+                "trust_verdict": "strong",
+            },
+            allow_advisory=False,
+            allow_high_risk_advisory=False,
+            change_class=None,
+        )
+
+        self.assertEqual(limited["result"], "pass")
+        self.assertEqual(limited["assurance"], "limited")
+        self.assertEqual(strong["assurance"], "strong")
+
     def test_advisory_requires_explicit_opt_in_and_remains_low_assurance(self) -> None:
         blocked = loom_flow.governance_capability_profile_payload(
             mode="advisory/local-enforced",
@@ -127,7 +155,7 @@ class GovernanceMergeProfileTest(unittest.TestCase):
         self.assertEqual(missing, [])
         fields = envelope["fields"]
         self.assertEqual(fields["governance_mode"], "host-enforced")
-        self.assertEqual(fields["governance_assurance"], "strong")
+        self.assertEqual(fields["governance_assurance"], "limited")
         self.assertTrue(fields["host_enforcement_required"])
         self.assertIn("governance_mode", body)
 
@@ -147,6 +175,21 @@ class GovernanceMergeProfileTest(unittest.TestCase):
         self.assertEqual(policy["governance_mode"], "advisory/local-enforced")
         self.assertEqual(policy["advisory_risk_label"], "low_assurance")
         self.assertFalse(policy["host_enforced"])
+
+    def test_closeout_policy_does_not_trust_authored_strong_assurance(self) -> None:
+        policy = loom_cli.ship_closeout_policy(
+            {
+                "governance_intensity": "standard",
+                "governance_mode": "host-enforced",
+                "governance_assurance": "strong",
+                "change_class": "metadata_schema",
+                "release_judgment": "no_release",
+                "upgrade_triggers": [],
+            }
+        )
+
+        self.assertEqual(policy["governance_assurance"], "limited")
+        self.assertTrue(policy["host_enforced"])
 
 
 if __name__ == "__main__":

--- a/tools/host_default_lifecycle_contract.py
+++ b/tools/host_default_lifecycle_contract.py
@@ -136,6 +136,7 @@ def check_executable_host_default_paths() -> None:
         "ship_changed_paths_payload": loom.ship_changed_paths_payload,
         "ship_validation_profile_payload": loom.ship_validation_profile_payload,
         "host_attestation_readback": loom.host_attestation_readback,
+        "infer_github_repo": loom.infer_github_repo,
     }
     emitted: dict[str, object] = {}
     flow_calls: list[list[str]] = []
@@ -181,6 +182,7 @@ def check_executable_host_default_paths() -> None:
     loom.ship_changed_paths_payload = lambda *_args, **_kwargs: {"result": "pass", "paths": ["README.md"], "errors": []}
     loom.ship_validation_profile_payload = lambda *_args, **_kwargs: {"result": "pass", "selected_profile": "light"}
     loom.host_attestation_readback = fake_attestation
+    loom.infer_github_repo = lambda _target: "o/r"
     try:
         with tempfile.TemporaryDirectory() as directory:
             artifact = Path(directory) / "artifact.json"

--- a/tools/loom.py
+++ b/tools/loom.py
@@ -77,6 +77,7 @@ from host_attestation import _artifact_id as host_attestation_artifact_id
 from host_attestation import main as host_attestation_main
 from host_attestation import readback as host_attestation_readback
 from product_acceptance import main as product_acceptance_main
+from loom_init import host_derived_manifest
 
 LOOM_BOOTSTRAP_START = "<!-- LOOM_BOOTSTRAP_START -->"
 LOOM_BOOTSTRAP_END = "<!-- LOOM_BOOTSTRAP_END -->"
@@ -768,8 +769,8 @@ PUBLIC_COMMAND_PROTOCOL_TYPES = {
 HELP_TASK_ROUTES: list[dict[str, Any]] = [
     {
         "task": "resume",
-        "summary": "Take over the current Work Item from repository facts.",
-        "first_command": "loom route --target <repo> --item <WI> --json",
+        "summary": "Take over the current Work Item from GitHub and worktree facts.",
+        "first_command": "loom status --target <repo> --issue <work-item> --json",
         "next_step": "Continue with build, review, merge-ready, or closeout based on the derived route.",
     },
     {
@@ -7057,7 +7058,7 @@ def ship_closeout_policy(fields: dict[str, Any], *, intensity_override: str | No
     change_class = fields.get("change_class")
     release_judgment = fields.get("release_judgment")
     governance_mode = fields.get("governance_mode") or "host-enforced"
-    governance_assurance = fields.get("governance_assurance") or ("low" if governance_mode == "advisory/local-enforced" else "strong")
+    governance_assurance = "low" if governance_mode == "advisory/local-enforced" else "limited"
     advisory_risk_label = fields.get("advisory_risk_label") if governance_mode == "advisory/local-enforced" else None
     triggers = [str(value) for value in fields.get("upgrade_triggers", []) if str(value)]
     lowered = " ".join([str(change_class or ""), *triggers]).lower()
@@ -8835,11 +8836,15 @@ def handle_ship_status(argv: list[str], *, mode: str) -> int:
 
 
 def ship_host_attestation(args: argparse.Namespace, target: Path, *, closeout: bool) -> dict[str, Any]:
-    repo_slug = f"{args.owner}/{args.repo_name}" if args.owner and args.repo_name else infer_github_repo(target)
+    detected_repo = infer_github_repo(target)
+    requested_repo = f"{args.owner}/{args.repo_name}" if args.owner and args.repo_name else None
+    repo_slug = detected_repo
     pr_number = closeout_current_pr_input(args) or getattr(args, "pr", None)
     missing: list[str] = []
-    if not isinstance(repo_slug, str) or repo_slug.count("/") != 1:
+    if not isinstance(detected_repo, str) or detected_repo.count("/") != 1:
         missing.append("target origin GitHub owner/repo")
+    elif requested_repo is not None and requested_repo != detected_repo:
+        missing.append("explicit GitHub owner/repo must match the target origin")
     if args.issue is None:
         missing.append("--issue Work Item number")
     if not isinstance(pr_number, int):
@@ -12609,6 +12614,8 @@ def handle_scenario(command: str, argv: list[str]) -> int:
     parser.add_argument("--status-checks-file")
     parser.add_argument("--branch-protection-file")
     parser.add_argument("--ruleset-file")
+    parser.add_argument("--attestation-artifact-input", type=Path)
+    parser.add_argument("--review-policy", choices=("approved", "single_maintainer"), default="approved")
     parser.add_argument("--skip-gate", action="store_true")
     parser.add_argument("--project-drift-mode", choices=("advisory", "blocking"), default="advisory")
     parser.add_argument("--json", action="store_true")
@@ -12617,6 +12624,25 @@ def handle_scenario(command: str, argv: list[str]) -> int:
     target = resolve_target(args.target)
     if not target.exists():
         return emit(block_target(command, target, "target path does not exist"))
+    derived_manifest, manifest_errors = host_derived_manifest(target)
+    if manifest_errors:
+        return emit(
+            agent_safe_payload(
+                output(
+                    command,
+                    "block",
+                    schema_version=SCENARIO_SCHEMA,
+                    summary="Light-profile manifest is invalid; legacy execution carriers are not a fallback.",
+                    target=str(target),
+                    missing_inputs=manifest_errors,
+                    fallback_to="loom adopt verify --target <repo> --json",
+                    carrier_mutations=False,
+                    repo_execution_carriers_consumed=False,
+                ),
+                target_root=target,
+                full_output=args.full_output,
+            )
+        )
 
     flow_operations = {
         "story": "story",
@@ -12705,6 +12731,18 @@ def handle_scenario(command: str, argv: list[str]) -> int:
         )
 
     if command == "closeout":
+        if derived_manifest is not None:
+            attestation = ship_host_attestation(args, target, closeout=True)
+            attestation["command"] = "closeout"
+            attestation["profile"] = derived_manifest.get("profile")
+            attestation["repo_execution_carriers_consumed"] = False
+            return emit(
+                agent_safe_payload(
+                    attestation,
+                    target_root=target,
+                    full_output=args.full_output,
+                )
+            )
         flow_args = ["closeout", "check", "--target", str(target)]
         for flag, value in (
             ("--item", args.item),


### PR DESCRIPTION
## Summary

- Problem: v0.30 的 light profile 仍会从部分公开入口回退到 committed execution carriers，same-App required gate 也被错误地当成不可用，而产品验收缺少可由 GitHub host readback 认证的 producer。
- Scope: 让 light/attach-only 默认入口只消费 GitHub、worktree 与 host attestation；将精确 same-App required binding 定义为 `ready + limited`；增加仅从 default branch 运行的 Stage A acceptance workflow 和可信 artifact adapter。

## Validation

- [x] Verified locally
- [x] Verified by automation

Validation details:

- `PYTHONDONTWRITEBYTECODE=1 make check`
- 12/12 derived-state bootstrap tests
- light profile、delivery gate、product acceptance、workflow、host-default lifecycle、CLI 与 npm/package contracts 全部通过
- `git diff --check`

## Risks And Follow-ups

- Risks: same-App check identity 仍只有 limited assurance；本 PR 明确不宣称 strong 或不可伪造。
- Follow-ups: 合并后由 #2054 Stage A 从 main 为 #1979–#1986 生成并认证 product acceptance artifacts；稳定发布在 FR 收口后单独进行。

## Related Work

- Work Item: MC-and-his-Agents/Loom/work_item/2054
- Issue: #2054
- Spec / plan: Milestone #29 与 #2054 Stage A

不会关闭 #2054；该事项需保持开放直到 v0.30.0 发布与 host readback 完成。

<!-- loom:repo-pr-metadata
{
  "schema_version": "loom-repo-pr-metadata/v1",
  "metadata_contract_id": "loom-governance-intensity",
  "surface": "merge_ready",
  "fields": {
    "work_item_locator": "MC-and-his-Agents/Loom/work_item/2054",
    "governance_intensity": "standard",
    "governance_mode": "host-enforced",
    "governance_assurance": "limited",
    "advisory_risk_label": null,
    "host_enforcement_required": true,
    "change_class": "mixed",
    "suite_path": "minimal",
    "suite_not_applicable": null,
    "review_requirement": "host_readback_only",
    "fact_chain_required": false,
    "pr_gate_required": true,
    "release_judgment": "no_release",
    "closeout_required": true,
    "upgrade_triggers": [],
    "anchor_issue": null,
    "covered_issues": null,
    "excluded_scope": null
  },
  "source": {
    "rendered_hash": "renderer:loom-pr-metadata-render/v2"
  },
  "parser_version": "loom-pr-metadata-parser/v2"
}
-->
