### PR TITLE
fix(ci): 补全隔离验证模块路径

### DIFF
--- a/tools/check_delivery_gate.py
+++ b/tools/check_delivery_gate.py
@@ -1022,11 +1022,17 @@ def check_trusted_candidate_harness() -> None:
         shutil.copytree(trusted, env_trusted)
         shutil.copytree(trusted, env_candidate)
         env_probe = (
+            "import build_distribution\n"
             "import os\n"
+            "assert build_distribution.VALUE == 'candidate-support'\n"
             "for prefix in ('ACTIONS_', 'GITHUB_', 'RUNNER_'):\n"
             "    assert not any(key.startswith(prefix) for key in os.environ), prefix\n"
         )
         for tree in (env_trusted, env_candidate):
+            (tree / "tools" / "build_distribution.py").write_text(
+                "VALUE = 'candidate-support'\n",
+                encoding="utf-8",
+            )
             (tree / "tools" / "check_probe.py").write_text(env_probe, encoding="utf-8")
         safe_env = os.environ.copy()
         safe_env.update({"ACTIONS_RUNTIME_TOKEN": "secret", "GITHUB_TOKEN": "secret", "RUNNER_TRACKING_ID": "secret"})

--- a/tools/run_trusted_candidate_validation.py
+++ b/tools/run_trusted_candidate_validation.py
@@ -209,7 +209,13 @@ def main() -> int:
                 for key, value in os.environ.items()
                 if key in {"HOME", "LANG", "LC_ALL", "PATH", "SHELL", "SYSTEMROOT", "TEMP", "TMP", "TMPDIR"}
             }
-            safe_environment.update({"LOOM_CANDIDATE_VALIDATION": "1", "PYTHONSAFEPATH": "1"})
+            safe_environment.update(
+                {
+                    "LOOM_CANDIDATE_VALIDATION": "1",
+                    "PYTHONSAFEPATH": "1",
+                    "PYTHONPATH": str(validation_root / "tools"),
+                }
+            )
             completed = subprocess.run(
                 ["make", "-f", str(validation_root / "Makefile"), "--", *targets],
                 cwd=validation_root,


### PR DESCRIPTION
## Summary

- Problem: isolated candidate validation enables `PYTHONSAFEPATH=1` but does not expose its own `tools/` support modules, so trusted checks such as `check_cli_contract.py` cannot import `build_distribution.py`.
- Scope: bind `PYTHONPATH` only to the freshly copied isolated validation root and add a regression proving sibling support imports work while Actions/GitHub/runner credentials remain stripped.

## Validation

- [x] Verified locally
- [x] Verified by automation

- `python3 tools/check_delivery_gate.py`
- `python3 tools/check_npm_package.py`
- `git diff --check`

## Risks And Follow-ups

- Risks: this changes the protected runner itself, so the current gate must reject it as bootstrap drift.
- Follow-ups: after this one-time base merge, #2081 must pass normal enforced candidate validation without exceptions.

## Related Work

- Work Item: MC-and-his-Agents/Loom/work_item/2054
- Issue: #2054
- Spec / plan: Milestone #29 / #2054 Stage A

<!-- loom:repo-pr-metadata
{
  "schema_version": "loom-repo-pr-metadata/v1",
  "metadata_contract_id": "loom-governance-intensity",
  "surface": "merge_ready",
  "fields": {
    "work_item_locator": "MC-and-his-Agents/Loom/work_item/2054",
    "governance_intensity": "standard",
    "governance_mode": "host-enforced",
    "governance_assurance": "limited",
    "advisory_risk_label": null,
    "host_enforcement_required": true,
    "change_class": "workflow",
    "suite_path": "minimal",
    "suite_not_applicable": null,
    "review_requirement": "host_readback_only",
    "fact_chain_required": false,
    "pr_gate_required": true,
    "release_judgment": "no_release",
    "closeout_required": true,
    "upgrade_triggers": ["protected_validation_runner_bootstrap"],
    "anchor_issue": null,
    "covered_issues": null,
    "excluded_scope": null
  },
  "source": {"rendered_hash": "bootstrap:2054-isolated-runner"},
  "parser_version": "loom-pr-metadata-parser/v2"
}
-->
