### PR TITLE
fix(ci): 完整绑定隔离验证导入根

### DIFF
--- a/tools/check_delivery_gate.py
+++ b/tools/check_delivery_gate.py
@@ -1024,13 +1024,23 @@ def check_trusted_candidate_harness() -> None:
         env_probe = (
             "import build_distribution\n"
             "import os\n"
+            "import subprocess\n"
+            "import sys\n"
+            "from pathlib import Path\n"
             "assert build_distribution.VALUE == 'candidate-support'\n"
             "for prefix in ('ACTIONS_', 'GITHUB_', 'RUNNER_'):\n"
             "    assert not any(key.startswith(prefix) for key in os.environ), prefix\n"
+            "subprocess.run([sys.executable, str(Path(__file__).parents[1] / 'src/skills/shared/scripts/probe.py')], check=True)\n"
         )
         for tree in (env_trusted, env_candidate):
             (tree / "tools" / "build_distribution.py").write_text(
                 "VALUE = 'candidate-support'\n",
+                encoding="utf-8",
+            )
+            shared = tree / "src" / "skills" / "shared" / "scripts"
+            (shared / "support_module.py").write_text("VALUE = 'shared-support'\n", encoding="utf-8")
+            (shared / "probe.py").write_text(
+                "import support_module\nassert support_module.VALUE == 'shared-support'\n",
                 encoding="utf-8",
             )
             (tree / "tools" / "check_probe.py").write_text(env_probe, encoding="utf-8")

--- a/tools/run_trusted_candidate_validation.py
+++ b/tools/run_trusted_candidate_validation.py
@@ -213,7 +213,12 @@ def main() -> int:
                 {
                     "LOOM_CANDIDATE_VALIDATION": "1",
                     "PYTHONSAFEPATH": "1",
-                    "PYTHONPATH": str(validation_root / "tools"),
+                    "PYTHONPATH": os.pathsep.join(
+                        (
+                            str(validation_root / "src" / "skills" / "shared" / "scripts"),
+                            str(validation_root / "tools"),
+                        )
+                    ),
                 }
             )
             completed = subprocess.run(


### PR DESCRIPTION
## Summary

- Problem: isolated validation with `PYTHONSAFEPATH=1` must expose both trusted import roots; `tools/` alone fixes checker imports but direct shared-script fixtures still lose sibling modules.
- Scope: bind an ordered, isolated-only `PYTHONPATH` to `src/skills/shared/scripts` then `tools`, and regress both import classes while retaining credential stripping.

## Validation

- [x] Verified locally
- [x] Verified by automation

- `python3 tools/check_delivery_gate.py`
- isolated `check_cli_contract.py --surface aggregate`: passed in 588.42s
- `git diff --check`

## Risks And Follow-ups

- Risks: protected runner/check change intentionally requires the final base-trusted bootstrap exception.
- Follow-ups: #2081 must pass the normal required gate after rebasing; no further exception is allowed for its implementation diff.

## Related Work

- Work Item: MC-and-his-Agents/Loom/work_item/2054
- Issue: #2054

<!-- loom:repo-pr-metadata
{
  "schema_version": "loom-repo-pr-metadata/v1",
  "metadata_contract_id": "loom-governance-intensity",
  "surface": "merge_ready",
  "fields": {
    "work_item_locator": "MC-and-his-Agents/Loom/work_item/2054",
    "governance_intensity": "standard",
    "governance_mode": "host-enforced",
    "governance_assurance": "limited",
    "advisory_risk_label": null,
    "host_enforcement_required": true,
    "change_class": "workflow",
    "suite_path": "minimal",
    "suite_not_applicable": null,
    "review_requirement": "host_readback_only",
    "fact_chain_required": false,
    "pr_gate_required": true,
    "release_judgment": "no_release",
    "closeout_required": true,
    "upgrade_triggers": ["protected_validation_import_root_bootstrap"],
    "anchor_issue": null,
    "covered_issues": null,
    "excluded_scope": null
  },
  "source": {"rendered_hash": "bootstrap:2054-isolated-import-roots"},
  "parser_version": "loom-pr-metadata-parser/v2"
}
-->
