### PR TITLE
fix(closure): 消费最新交付检查结果

### DIFF
--- a/.github/workflows/loom-fr-phase-close-guard.yml
+++ b/.github/workflows/loom-fr-phase-close-guard.yml
@@ -60,8 +60,8 @@ jobs:
                                   pageInfo { hasNextPage }
                                   nodes {
                                     __typename
-                                    ... on CheckRun { name status conclusion }
-                                    ... on StatusContext { context state }
+                                    ... on CheckRun { name status conclusion startedAt completedAt }
+                                    ... on StatusContext { context state createdAt }
                                   }
                                 }
                               }
@@ -113,6 +113,9 @@ jobs:
                           status: context.status,
                           conclusion: context.conclusion,
                           state: context.state,
+                          started_at: context.startedAt,
+                          completed_at: context.completedAt,
+                          created_at: context.createdAt,
                         })) || [],
                       },
                       commit_sha: commit?.oid,

--- a/plugins/loom/.codex-plugin/plugin.json
+++ b/plugins/loom/.codex-plugin/plugin.json
@@ -23,7 +23,7 @@
     "source_git_sha": "e44db754f6b6d6bf03579bca40086c8e61dae79f",
     "source_git_sha_status": "release_commit",
     "plugin_payload_version": "0.29.1",
-    "plugin_payload_hash": "4e07aa6cac0200226f544e35d22fe9075006466d0e4043b7dc0aa32d202e1dec",
+    "plugin_payload_hash": "27f8ad0d6bc89e75368539e087d7f96ad13b8802f713feef06c1b454bb35eb08",
     "repository_payload": false
   },
   "keywords": [

--- a/src/skills/shared/scripts/github_closure_guard.py
+++ b/src/skills/shared/scripts/github_closure_guard.py
@@ -29,10 +29,21 @@ SINGLE_MAINTAINER_LABEL = "review_policy_single_maintainer"
 PRODUCT_ARTIFACT_RE = re.compile(r"<!--\s*loom:product-acceptance-artifact\s+id:(\d+)\s*-->", re.IGNORECASE)
 ATTESTATION_ARTIFACT_RE = re.compile(r"<!--\s*loom:host-attestation-artifact\s+pr:(\d+)\s+head:([0-9a-f]{40})\s+id:(\d+)\s*-->", re.IGNORECASE)
 SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+DELIVERY_CHECK_CONTEXTS = frozenset({"py-compile", "loom-delivery-gate", "loom-pr-merge-gate"})
 
 
 def _text(value: object) -> str:
     return str(value or "").strip().casefold().replace("-", "_").replace(" ", "_")
+
+
+def _parse_time(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.astimezone(timezone.utc) if parsed.tzinfo else None
 
 
 def _labels(issue: dict[str, Any]) -> set[str]:
@@ -95,10 +106,40 @@ def _deferred_ready(issue: dict[str, Any]) -> list[dict[str, str]]:
 
 def _successful_check_rollup(pr: dict[str, Any]) -> bool:
     rollup = pr.get("check_rollup")
-    if not isinstance(rollup, dict) or _text(rollup.get("state")) != "success" or rollup.get("contexts_complete") is not True:
+    if not isinstance(rollup, dict) or rollup.get("contexts_complete") is not True:
         return False
     contexts = rollup.get("contexts")
-    return isinstance(contexts, list) and bool(contexts)
+    if not isinstance(contexts, list):
+        return False
+    latest: dict[str, tuple[datetime, int, dict[str, Any]]] = {}
+    for index, context in enumerate(contexts):
+        if not isinstance(context, dict):
+            return False
+        name = str(context.get("name") or "").strip()
+        if name not in DELIVERY_CHECK_CONTEXTS:
+            continue
+        timestamp = (
+            _parse_time(context.get("completed_at"))
+            or _parse_time(context.get("started_at"))
+            or _parse_time(context.get("created_at"))
+            or datetime.min.replace(tzinfo=timezone.utc)
+        )
+        current = latest.get(name)
+        if current is None or (timestamp, index) > (current[0], current[1]):
+            latest[name] = (timestamp, index, context)
+    if not latest:
+        return False
+    for _timestamp, _index, context in latest.values():
+        kind = _text(context.get("type"))
+        if kind == "checkrun":
+            if _text(context.get("status")) != "completed" or _text(context.get("conclusion")) not in {"success", "neutral", "skipped"}:
+                return False
+        elif kind == "statuscontext":
+            if _text(context.get("state")) != "success":
+                return False
+        else:
+            return False
+    return True
 
 
 def _comment_marker(bodies: object, pattern: re.Pattern[str], *, pr_number: int | None = None) -> tuple[int | None, list[str]]:

--- a/tools/check_fr_phase_close_guard.py
+++ b/tools/check_fr_phase_close_guard.py
@@ -97,7 +97,7 @@ def main() -> int:
         "merge_commit": "b" * 40,
         "commit_sha": "a" * 40,
         "review_decision": "APPROVED",
-        "check_rollup": {"state": "SUCCESS", "contexts_complete": True, "contexts": [{"type": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"}]},
+        "check_rollup": {"state": "SUCCESS", "contexts_complete": True, "contexts": [{"type": "CheckRun", "name": "py-compile", "status": "COMPLETED", "conclusion": "SUCCESS", "completed_at": "2026-07-11T00:01:00Z"}]},
     }
     work_item = issue(3, "work_item", merged_prs=[pr])
     fr = issue(2, "fr", children=[3])
@@ -128,9 +128,16 @@ def main() -> int:
     pending_checks = issue(3, "work_item", merged_prs=[{**pr, "check_rollup": {"state": "PENDING", "contexts_complete": True, "contexts": pr["check_rollup"]["contexts"]}}])
     if module.evaluate_closure({"subject": 1, "default_branch": "main", "issues": [phase, fr, pending_checks]}).get("verdict") != "reopen_required":
         raise AssertionError("a merged PR without a successful check rollup must reopen")
-    failed_checks = issue(3, "work_item", merged_prs=[{**pr, "check_rollup": {"state": "FAILURE", "contexts_complete": True, "contexts": pr["check_rollup"]["contexts"]}}])
-    if module.evaluate_closure({"subject": 1, "default_branch": "main", "issues": [phase, fr, failed_checks]}).get("verdict") != "reopen_required":
+    failed_checks = issue(3, "work_item", merged_prs=[{**pr, "check_rollup": {"state": "FAILURE", "contexts_complete": True, "contexts": [{**pr["check_rollup"]["contexts"][0], "conclusion": "FAILURE"}]}}])
+    if module.evaluate_closure(snapshot(1, [phase, fr, failed_checks]), host_resolved=True).get("verdict") != "reopen_required":
         raise AssertionError("a merged PR with a failed check rollup must reopen")
+    retried_checks = issue(3, "work_item", merged_prs=[{**pr, "check_rollup": {"state": "FAILURE", "contexts_complete": True, "contexts": [
+        {"type": "CheckRun", "name": "loom-pr-merge-gate", "status": "COMPLETED", "conclusion": "FAILURE", "completed_at": "2026-07-11T00:00:00Z"},
+        {"type": "CheckRun", "name": "loom-pr-merge-gate", "status": "COMPLETED", "conclusion": "SUCCESS", "completed_at": "2026-07-11T00:02:00Z"},
+        {"type": "CheckRun", "name": "optional-demo", "status": "COMPLETED", "conclusion": "FAILURE", "completed_at": "2026-07-11T00:03:00Z"},
+    ]}}])
+    if module.evaluate_closure(snapshot(1, [phase, fr, retried_checks]), host_resolved=True).get("verdict") != "allow_completed_close":
+        raise AssertionError("latest successful delivery check attempt must supersede stale failures and unrelated optional checks")
     skipped_optional = issue(3, "work_item", merged_prs=[{**pr, "check_rollup": {"state": "SUCCESS", "contexts_complete": True, "contexts": [*pr["check_rollup"]["contexts"], {"type": "CheckRun", "status": "COMPLETED", "conclusion": "SKIPPED"}]}}])
     if module.evaluate_closure(snapshot(1, [phase, fr, skipped_optional]), host_resolved=True).get("verdict") != "allow_completed_close":
         raise AssertionError("a successful aggregate rollup must allow intentionally skipped optional checks")


### PR DESCRIPTION
## Summary

- Problem: GitHub statusCheckRollup 会保留同一 context 的历史失败与后续成功，并因无关 optional checks 返回全局 FAILURE；closure guard 因而误拒绝已经成功重跑并合并的 WI PR。
- Scope: 只消费 py-compile 与新旧 Loom delivery/merge gate，按宿主完成时间选择每个 context 的最新 attempt；忽略无关 optional checks；最新 delivery check 失败仍 fail closed。

## Validation

- [x] Verified locally
- [x] Verified by automation

- `python3 tools/check_fr_phase_close_guard.py`
- `python3 tools/check_fr_phase_close_guard_workflow.py`
- `python3 tools/check_npm_package.py`
- `git diff --check`

## Risks And Follow-ups

- Risks: 不把旧 checks 恢复为 required；旧 `loom-pr-merge-gate` 仅作为历史 delivery evidence 兼容读取。
- Follow-ups: 合并后再次关闭 #1979 并消费 guard readback。

## Related Work

- Work Item: MC-and-his-Agents/Loom/work_item/2054
- Issue: #2054

<!-- loom:repo-pr-metadata
{
  "schema_version": "loom-repo-pr-metadata/v1",
  "metadata_contract_id": "loom-governance-intensity",
  "surface": "merge_ready",
  "fields": {
    "work_item_locator": "MC-and-his-Agents/Loom/work_item/2054",
    "governance_intensity": "standard",
    "governance_mode": "host-enforced",
    "governance_assurance": "limited",
    "advisory_risk_label": null,
    "host_enforcement_required": true,
    "change_class": "workflow",
    "suite_path": "minimal",
    "suite_not_applicable": null,
    "review_requirement": "host_readback_only",
    "fact_chain_required": false,
    "pr_gate_required": true,
    "release_judgment": "no_release",
    "closeout_required": true,
    "upgrade_triggers": ["protected_closure_checker_bootstrap"],
    "anchor_issue": null,
    "covered_issues": null,
    "excluded_scope": null
  },
  "source": {"rendered_hash": "fix:closure-latest-delivery-check"},
  "parser_version": "loom-pr-metadata-parser/v2"
}
-->
