### PR TITLE
fix(closure): 冻结合并时检查证据

### DIFF
--- a/.github/workflows/loom-fr-phase-close-guard.yml
+++ b/.github/workflows/loom-fr-phase-close-guard.yml
@@ -49,7 +49,7 @@ jobs:
                     closedByPullRequestsReferences(first:100) {
                       pageInfo { hasNextPage }
                       nodes {
-                        number merged baseRefName headRefOid mergeCommit { oid } reviewDecision
+                        number merged mergedAt baseRefName headRefOid mergeCommit { oid } reviewDecision
                         commits(last:1) {
                           nodes {
                             commit {
@@ -100,6 +100,7 @@ jobs:
                     return {
                       number: entry.number,
                       merged: entry.merged,
+                      merged_at: entry.mergedAt,
                       base_ref: entry.baseRefName,
                       head_sha: entry.headRefOid,
                       merge_commit: entry.mergeCommit?.oid,

--- a/plugins/loom/.codex-plugin/plugin.json
+++ b/plugins/loom/.codex-plugin/plugin.json
@@ -23,7 +23,7 @@
     "source_git_sha": "e44db754f6b6d6bf03579bca40086c8e61dae79f",
     "source_git_sha_status": "release_commit",
     "plugin_payload_version": "0.29.1",
-    "plugin_payload_hash": "27f8ad0d6bc89e75368539e087d7f96ad13b8802f713feef06c1b454bb35eb08",
+    "plugin_payload_hash": "fecb4c59e983fe9e794ccde416edcb0e77fddd48df9f491dcd8294e853fbe6dd",
     "repository_payload": false
   },
   "keywords": [

--- a/src/skills/shared/scripts/github_closure_guard.py
+++ b/src/skills/shared/scripts/github_closure_guard.py
@@ -106,7 +106,8 @@ def _deferred_ready(issue: dict[str, Any]) -> list[dict[str, str]]:
 
 def _successful_check_rollup(pr: dict[str, Any]) -> bool:
     rollup = pr.get("check_rollup")
-    if not isinstance(rollup, dict) or rollup.get("contexts_complete") is not True:
+    merged_at = _parse_time(pr.get("merged_at"))
+    if not isinstance(rollup, dict) or rollup.get("contexts_complete") is not True or merged_at is None:
         return False
     contexts = rollup.get("contexts")
     if not isinstance(contexts, list):
@@ -124,6 +125,8 @@ def _successful_check_rollup(pr: dict[str, Any]) -> bool:
             or _parse_time(context.get("created_at"))
             or datetime.min.replace(tzinfo=timezone.utc)
         )
+        if timestamp > merged_at:
+            continue
         current = latest.get(name)
         if current is None or (timestamp, index) > (current[0], current[1]):
             latest[name] = (timestamp, index, context)

--- a/tools/check_fr_phase_close_guard.py
+++ b/tools/check_fr_phase_close_guard.py
@@ -92,6 +92,7 @@ def main() -> int:
     pr = {
         "number": 31,
         "merged": True,
+        "merged_at": "2026-07-11T00:02:30Z",
         "base_ref": "main",
         "head_sha": "a" * 40,
         "merge_commit": "b" * 40,
@@ -134,10 +135,11 @@ def main() -> int:
     retried_checks = issue(3, "work_item", merged_prs=[{**pr, "check_rollup": {"state": "FAILURE", "contexts_complete": True, "contexts": [
         {"type": "CheckRun", "name": "loom-pr-merge-gate", "status": "COMPLETED", "conclusion": "FAILURE", "completed_at": "2026-07-11T00:00:00Z"},
         {"type": "CheckRun", "name": "loom-pr-merge-gate", "status": "COMPLETED", "conclusion": "SUCCESS", "completed_at": "2026-07-11T00:02:00Z"},
+        {"type": "CheckRun", "name": "loom-pr-merge-gate", "status": "COMPLETED", "conclusion": "FAILURE", "completed_at": "2026-07-11T00:03:00Z"},
         {"type": "CheckRun", "name": "optional-demo", "status": "COMPLETED", "conclusion": "FAILURE", "completed_at": "2026-07-11T00:03:00Z"},
     ]}}])
     if module.evaluate_closure(snapshot(1, [phase, fr, retried_checks]), host_resolved=True).get("verdict") != "allow_completed_close":
-        raise AssertionError("latest successful delivery check attempt must supersede stale failures and unrelated optional checks")
+        raise AssertionError("latest pre-merge successful delivery attempt must supersede stale failures, post-merge checks, and unrelated optional checks")
     skipped_optional = issue(3, "work_item", merged_prs=[{**pr, "check_rollup": {"state": "SUCCESS", "contexts_complete": True, "contexts": [*pr["check_rollup"]["contexts"], {"type": "CheckRun", "status": "COMPLETED", "conclusion": "SKIPPED"}]}}])
     if module.evaluate_closure(snapshot(1, [phase, fr, skipped_optional]), host_resolved=True).get("verdict") != "allow_completed_close":
         raise AssertionError("a successful aggregate rollup must allow intentionally skipped optional checks")


### PR DESCRIPTION
## Summary

- Problem: post-merge PR body edits会触发新的失败 gate，不能覆盖实际 merge-time 成功证据。
- Scope: closure snapshot读取 mergedAt，只选择合并前完成的每个 delivery context 最新 attempt；post-merge checks 不参与完成判定。

## Validation

- [x] Verified locally
- [x] Verified by automation

- closure guard、workflow contract、npm payload、diff checks 通过。

## Related Work

- Work Item: MC-and-his-Agents/Loom/work_item/2054
- Issue: #2054

<!-- loom:repo-pr-metadata
{
  "schema_version":"loom-repo-pr-metadata/v1",
  "metadata_contract_id":"loom-governance-intensity",
  "surface":"merge_ready",
  "fields":{"work_item_locator":"MC-and-his-Agents/Loom/work_item/2054","governance_intensity":"standard","governance_mode":"host-enforced","governance_assurance":"limited","advisory_risk_label":null,"host_enforcement_required":true,"change_class":"workflow","suite_path":"minimal","suite_not_applicable":null,"review_requirement":"host_readback_only","fact_chain_required":false,"pr_gate_required":true,"release_judgment":"no_release","closeout_required":true,"upgrade_triggers":["protected_closure_checker_bootstrap"],"anchor_issue":null,"covered_issues":null,"excluded_scope":null},
  "source":{"rendered_hash":"fix:closure-merge-time-checks"},
  "parser_version":"loom-pr-metadata-parser/v2"
}
-->
