### PR TITLE
fix(closure): 移除不可读的保护规则依赖

### DIFF
--- a/.github/workflows/loom-fr-phase-close-guard.yml
+++ b/.github/workflows/loom-fr-phase-close-guard.yml
@@ -139,7 +139,6 @@ jobs:
               repository: `${owner}/${repo}`,
               event_closed_at: context.payload.issue?.closed_at || null,
               default_branch: null,
-              review_policy: { read_complete: false, required_approving_review_count: null },
               host_readable: true,
               issues: [],
             };
@@ -159,19 +158,6 @@ jobs:
                 queue.push(...fetched.issue.children);
               }
               snapshot.issues = [...byNumber.values()];
-              const protection = await github.rest.repos.getBranchProtection({
-                owner,
-                repo,
-                branch: snapshot.default_branch,
-              });
-              const requiredApprovals = protection.data?.required_pull_request_reviews?.required_approving_review_count;
-              if (!Number.isInteger(requiredApprovals) || requiredApprovals < 0) {
-                throw new Error("GitHub required review policy read is incomplete");
-              }
-              snapshot.review_policy = {
-                read_complete: true,
-                required_approving_review_count: requiredApprovals,
-              };
             } catch (error) {
               snapshot.host_readable = false;
               core.warning(`closure guard host read failed: ${error.message}`);

--- a/plugins/loom/.codex-plugin/plugin.json
+++ b/plugins/loom/.codex-plugin/plugin.json
@@ -23,7 +23,7 @@
     "source_git_sha": "e44db754f6b6d6bf03579bca40086c8e61dae79f",
     "source_git_sha_status": "release_commit",
     "plugin_payload_version": "0.29.1",
-    "plugin_payload_hash": "fecb4c59e983fe9e794ccde416edcb0e77fddd48df9f491dcd8294e853fbe6dd",
+    "plugin_payload_hash": "e4ece63f065e1a97e92da8a158678289b49a0446247622e07ac05ef957c5bda2",
     "repository_payload": false
   },
   "keywords": [

--- a/src/skills/shared/scripts/github_closure_guard.py
+++ b/src/skills/shared/scripts/github_closure_guard.py
@@ -313,7 +313,7 @@ def _valid_single_maintainer_attestation(pr: dict[str, Any]) -> bool:
     )
 
 
-def _reviewed_green_merged_pr(issue: dict[str, Any], default_branch: str, review_policy: dict[str, Any]) -> bool:
+def _reviewed_green_merged_pr(issue: dict[str, Any], default_branch: str) -> bool:
     prs = issue.get("merged_prs")
     if not isinstance(prs, list):
         return False
@@ -323,8 +323,7 @@ def _reviewed_green_merged_pr(issue: dict[str, Any], default_branch: str, review
         pr_number, head_sha, merge_commit, commit_sha = pr.get("number"), pr.get("head_sha"), pr.get("merge_commit"), pr.get("commit_sha")
         if not isinstance(pr_number, int) or not all(isinstance(value, str) and value for value in (head_sha, merge_commit, commit_sha)) or commit_sha != head_sha:
             continue
-        required_approvals = review_policy.get("required_approving_review_count")
-        review_ready = required_approvals == 0 or _text(pr.get("review_decision")) == "approved"
+        review_ready = _text(pr.get("review_decision")) == "approved"
         if SINGLE_MAINTAINER_LABEL in _labels(issue):
             review_ready = _valid_single_maintainer_attestation(pr)
         if review_ready and _successful_check_rollup(pr):
@@ -336,7 +335,6 @@ def _validate_completed(
     issue: dict[str, Any],
     issues: dict[int, dict[str, Any]],
     default_branch: str,
-    review_policy: dict[str, Any],
     reasons: list[dict[str, str]],
     visiting: set[int],
 ) -> None:
@@ -363,7 +361,7 @@ def _validate_completed(
             reasons.append(_reason("open_native_blocker", locator, "completed closure cannot retain an open or unreadable native blocker"))
     kind = _type(issue)
     if kind == "work_item":
-        if not _reviewed_green_merged_pr(issue, default_branch, review_policy):
+        if not _reviewed_green_merged_pr(issue, default_branch):
             reasons.append(_reason("missing_reviewed_merged_pr_or_green_check", locator, "Work Item needs a default-branch merged PR satisfying the host review policy and successful host check rollup"))
         return
     expected = EXPECTED_CHILD_TYPE.get(kind)
@@ -380,7 +378,7 @@ def _validate_completed(
         if _type(child) != expected:
             reasons.append(_reason("invalid_native_child_type", f"issue:{child_number}", f"{kind} requires native {expected} children"))
             continue
-        _validate_completed(child, issues, default_branch, review_policy, reasons, next_visiting)
+        _validate_completed(child, issues, default_branch, reasons, next_visiting)
 
 
 def evaluate_closure(snapshot: object, *, host_resolved: bool = False) -> dict[str, Any]:
@@ -390,7 +388,6 @@ def evaluate_closure(snapshot: object, *, host_resolved: bool = False) -> dict[s
     subject = snapshot.get("subject")
     issue_rows = snapshot.get("issues")
     default_branch = snapshot.get("default_branch")
-    review_policy = snapshot.get("review_policy")
     issues = {
         row.get("number"): row
         for row in issue_rows
@@ -423,20 +420,12 @@ def evaluate_closure(snapshot: object, *, host_resolved: bool = False) -> dict[s
         return _payload(subject, "allow_non_completion_close", "Explicit non-completion closure is not counted as completed.", [], completed=False)
     if labels.intersection(NON_COMPLETION_LABELS):
         return _payload(subject, "reopen_required", "Non-completion labels must use not planned semantics.", [_reason("non_completion_requires_not_planned", f"issue:{subject}", "non-completion labels cannot use completed semantics")], completed=False)
-    if (
-        not isinstance(review_policy, dict)
-        or review_policy.get("read_complete") is not True
-        or not isinstance(review_policy.get("required_approving_review_count"), int)
-        or isinstance(review_policy.get("required_approving_review_count"), bool)
-        or review_policy["required_approving_review_count"] < 0
-    ):
-        return _payload(subject, "reopen_required", "GitHub review policy is unreadable.", [_reason("host_unreadable", f"issue:{subject}", "required approving review policy read is missing")], completed=False)
     reasons: list[dict[str, str]] = []
     _trusted_product_acceptance(snapshot, subject, labels, reasons, host_resolved=host_resolved)
-    _validate_completed(subject_issue, issues, default_branch, review_policy, reasons, set())
+    _validate_completed(subject_issue, issues, default_branch, reasons, set())
     if reasons:
         return _payload(subject, "reopen_required", "Completed FR/Phase closure is missing required host facts.", reasons, completed=False)
-    return _payload(subject, "allow_completed_close", "Trusted product acceptance, native children, dependencies, review policy, and check evidence permit completed closure.", [], completed=True)
+    return _payload(subject, "allow_completed_close", "Trusted product acceptance, native children, dependencies, review evidence, and check evidence permit completed closure.", [], completed=True)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tools/check_fr_phase_close_guard.py
+++ b/tools/check_fr_phase_close_guard.py
@@ -63,7 +63,6 @@ def snapshot(subject: int, issues: list[dict[str, object]], *, product_acceptanc
         "subject": subject,
         "repository": "o/r",
         "default_branch": "main",
-        "review_policy": {"read_complete": True, "required_approving_review_count": 1},
         "issues": issues,
         "product_acceptance": acceptance(subject) if product_acceptance is None else product_acceptance,
     }
@@ -118,14 +117,6 @@ def main() -> int:
     unapproved = issue(3, "work_item", merged_prs=[{**pr, "review_decision": "CHANGES_REQUESTED"}])
     if module.evaluate_closure({"subject": 1, "default_branch": "main", "issues": [phase, fr, unapproved]}).get("verdict") != "reopen_required":
         raise AssertionError("a merged PR without approval must reopen")
-    zero_approval_policy = snapshot(1, [phase, fr, issue(3, "work_item", merged_prs=[{**pr, "review_decision": None}])])
-    zero_approval_policy["review_policy"] = {"read_complete": True, "required_approving_review_count": 0}
-    if module.evaluate_closure(zero_approval_policy, host_resolved=True).get("verdict") != "allow_completed_close":
-        raise AssertionError("a merged green PR must satisfy a host policy requiring zero approvals")
-    unreadable_review_policy = snapshot(1, [phase, fr, work_item])
-    unreadable_review_policy["review_policy"] = {"read_complete": False}
-    if module.evaluate_closure(unreadable_review_policy, host_resolved=True).get("verdict") != "reopen_required":
-        raise AssertionError("unreadable host review policy must fail closed")
     pending_checks = issue(3, "work_item", merged_prs=[{**pr, "check_rollup": {"state": "PENDING", "contexts_complete": True, "contexts": pr["check_rollup"]["contexts"]}}])
     if module.evaluate_closure({"subject": 1, "default_branch": "main", "issues": [phase, fr, pending_checks]}).get("verdict") != "reopen_required":
         raise AssertionError("a merged PR without a successful check rollup must reopen")

--- a/tools/check_fr_phase_close_guard_workflow.py
+++ b/tools/check_fr_phase_close_guard_workflow.py
@@ -66,6 +66,8 @@ def main() -> int:
         "head.sha",
         "const evaluate",
         "validateCompleted",
+        "getBranchProtection",
+        "required_approving_review_count",
     )
     missing = [needle for needle in required if needle not in text]
     present = [needle for needle in forbidden if needle in text]
@@ -79,6 +81,7 @@ def main() -> int:
         "loom:product-acceptance-artifact",
         "loom:host-attestation-artifact",
         "failure_envelope",
+        'review_ready = _text(pr.get("review_decision")) == "approved"',
     )
     evaluator_missing = [needle for needle in evaluator_required if needle not in evaluator]
     if missing or present or evaluator_missing:


### PR DESCRIPTION
## Summary

- Root cause: `issues.closed` 的仓库 `GITHUB_TOKEN` 无权读取 branch-protection 管理面，导致完整 GitHub tree 被误标为 `host_unreadable` 并反复 reopen。
- Scope: 移除该不可消费的管理面读取；普通 WI 仍要求 GitHub `APPROVED`，显式单维护者 WI 仍只接受经过 host readback、绑定 PR head 的 attestation。
- Impact: closure guard 不需要 App、secret 或管理员 token，也不会把零审批策略自动视为 review 完成。

## Validation

- [x] `make fr-phase-close-guard-check authority-contract-check host-attestation-check product-acceptance-adapter-check py-compile`
- [x] `git diff --check`

## Related Work

- Work Item: MC-and-his-Agents/Loom/work_item/2054
- Issue: #2054

<!-- loom:repo-pr-metadata
{
  "schema_version":"loom-repo-pr-metadata/v1",
  "metadata_contract_id":"loom-governance-intensity",
  "surface":"merge_ready",
  "fields":{"work_item_locator":"MC-and-his-Agents/Loom/work_item/2054","governance_intensity":"standard","governance_mode":"host-enforced","governance_assurance":"limited","advisory_risk_label":null,"host_enforcement_required":true,"change_class":"workflow","suite_path":"minimal","suite_not_applicable":null,"review_requirement":"host_readback_only","fact_chain_required":false,"pr_gate_required":true,"release_judgment":"no_release","closeout_required":true,"upgrade_triggers":["closure_host_permission_blocker"],"anchor_issue":null,"covered_issues":null,"excluded_scope":null},
  "source":{"rendered_hash":"fix:closure-host-permissions"},
  "parser_version":"loom-pr-metadata-parser/v2"
}
-->