### PR TITLE
fix(closure): 保留失败事项定位

### DIFF
--- a/.github/workflows/loom-fr-phase-close-guard.yml
+++ b/.github/workflows/loom-fr-phase-close-guard.yml
@@ -236,7 +236,7 @@ jobs:
               return;
             }
             const details = Array.isArray(verdict.reasons)
-              ? verdict.reasons.map((entry) => `- \`${entry.code}\`: ${entry.message}`).join("\n")
+              ? verdict.reasons.map((entry) => `- \`${entry.code}\` at \`${entry.locator || "issue:unknown"}\`: ${entry.message}`).join("\n")
               : "- \`host_unreadable\`: the closure evaluator returned no structured reasons";
             const body = `${remediationMarker}\n\nLoom 已重新打开该 FR/Phase：它不能以 completed 关闭。\n\n${details}\n\n处理后再次关闭；不要通过补 current、carrier、shadow 或手写 head 字段绕过。`;
             const markerComments = comments.filter((comment) => String(comment.body || "").includes(remediationMarker));


### PR DESCRIPTION
## Summary

- Root cause: close guard 的结构化 reason 已包含 locator，但 remediation comment 丢弃了它，多个子 WI 时无法知道哪个事项失败。
- Scope: remediation 每条原因同时输出 error code 与 `issue:<n>` locator；不改变 evaluator、关闭公式或安全边界。

## Validation

- [x] `PYTHONDONTWRITEBYTECODE=1 make fr-phase-close-guard-check py-compile`
- [x] `git diff --check`

## Related Work

- Work Item: MC-and-his-Agents/Loom/work_item/2054
- Issue: #2054

<!-- loom:repo-pr-metadata
{
  "schema_version":"loom-repo-pr-metadata/v1",
  "metadata_contract_id":"loom-governance-intensity",
  "surface":"merge_ready",
  "fields":{"work_item_locator":"MC-and-his-Agents/Loom/work_item/2054","governance_intensity":"standard","governance_mode":"host-enforced","governance_assurance":"limited","advisory_risk_label":null,"host_enforcement_required":true,"change_class":"workflow","suite_path":"minimal","suite_not_applicable":null,"review_requirement":"host_readback_only","fact_chain_required":false,"pr_gate_required":true,"release_judgment":"no_release","closeout_required":true,"upgrade_triggers":[],"anchor_issue":null,"covered_issues":null,"excluded_scope":null},
  "source":{"rendered_hash":"fix:closure-reason-locator"},
  "parser_version":"loom-pr-metadata-parser/v2"
}
-->