### PR TITLE
fix(closure): 输出宿主证明诊断

### DIFF
--- a/plugins/loom/.codex-plugin/plugin.json
+++ b/plugins/loom/.codex-plugin/plugin.json
@@ -23,7 +23,7 @@
     "source_git_sha": "e44db754f6b6d6bf03579bca40086c8e61dae79f",
     "source_git_sha_status": "release_commit",
     "plugin_payload_version": "0.29.1",
-    "plugin_payload_hash": "7435043f0974077603de8a2dcb6de2463c42a9221d2aef169490b310949de7e3",
+    "plugin_payload_hash": "50d375025ae43b9dca83c401dc989cf6a015c5ddfb5ee818680b1a808cb7b918",
     "repository_payload": false
   },
   "keywords": [

--- a/src/skills/shared/scripts/github_closure_guard.py
+++ b/src/skills/shared/scripts/github_closure_guard.py
@@ -234,37 +234,45 @@ def _green_merged_pr(issue: dict[str, Any], default_branch: str) -> bool:
     return False
 
 
-def _valid_host_action_attestation(issue: dict[str, Any], repository: str) -> bool:
+def _host_action_attestation_errors(issue: dict[str, Any], repository: str) -> list[str]:
     comments = issue.get("comments")
     if issue.get("comments_complete") is not True or not isinstance(comments, list):
-        return False
+        return ["comments_unreadable"]
     matches: list[tuple[dict[str, Any], dict[str, Any]]] = []
     for comment in comments:
         if not isinstance(comment, dict) or not isinstance(comment.get("body"), str):
-            return False
+            return ["comment_identity_unreadable"]
         for match in HOST_ACTION_ARTIFACT_RE.finditer(comment["body"]):
             try:
                 payload = json.loads(match.group(1))
             except json.JSONDecodeError:
-                return False
+                return ["marker_json_invalid"]
             if isinstance(payload, dict):
                 matches.append((comment, payload))
     if len(matches) != 1:
-        return False
+        return [f"marker_count:{len(matches)}"]
     comment, payload = matches[0]
     user = comment.get("user") if isinstance(comment.get("user"), dict) else {}
     observed_at = _parse_time(payload.get("observed_at"))
-    return (
-        set(payload) == {"schema_version", "action_locator", "observed_at", "verdict"}
-        and payload.get("schema_version") == "loom-host-action-attestation/v1"
-        and isinstance(payload.get("action_locator"), str)
-        and payload["action_locator"].casefold().startswith(f"github://{repository}/host-action/".casefold())
-        and observed_at is not None
-        and _text(payload.get("verdict")) == "passed"
-        and _text(comment.get("author_association")) in TRUSTED_AUTHOR_ASSOCIATIONS
-        and isinstance(user.get("login"), str)
-        and bool(user.get("login"))
-    )
+    errors: list[str] = []
+    if set(payload) != {"schema_version", "action_locator", "observed_at", "verdict"} or payload.get("schema_version") != "loom-host-action-attestation/v1":
+        errors.append("schema_invalid")
+    action_locator = payload.get("action_locator")
+    if not isinstance(action_locator, str) or not action_locator.casefold().startswith(f"github://{repository}/host-action/".casefold()):
+        errors.append("action_locator_invalid")
+    if observed_at is None:
+        errors.append("observed_at_invalid")
+    if _text(payload.get("verdict")) != "passed":
+        errors.append("verdict_not_passed")
+    if _text(comment.get("author_association")) not in TRUSTED_AUTHOR_ASSOCIATIONS:
+        errors.append("author_association_untrusted")
+    if not isinstance(user.get("login"), str) or not user.get("login"):
+        errors.append("author_login_unreadable")
+    return errors
+
+
+def _valid_host_action_attestation(issue: dict[str, Any], repository: str) -> bool:
+    return not _host_action_attestation_errors(issue, repository)
 
 
 def _validate_completed(
@@ -300,7 +308,11 @@ def _validate_completed(
     if kind == "work_item":
         if _green_merged_pr(issue, default_branch):
             return
-        if HOST_ONLY_DELIVERY_LABEL in _labels(issue) and _valid_host_action_attestation(issue, repository):
+        if HOST_ONLY_DELIVERY_LABEL in _labels(issue):
+            attestation_errors = _host_action_attestation_errors(issue, repository)
+            if not attestation_errors:
+                return
+            reasons.append(_reason("missing_delivery_attestation", locator, "host-only-delivery attestation is invalid: " + ", ".join(attestation_errors)))
             return
         reasons.append(_reason("missing_delivery_attestation", locator, "Work Item needs merged delivery checks, or an authenticated host-action attestation when explicitly labeled host-only-delivery"))
         return


### PR DESCRIPTION
## Summary

- Problem: host-only attestation 在 Actions token 下失败时只返回 generic missing delivery，无法区分 marker、schema、locator、time、association 或 login。
- Scope: 保持现有 verdict 与 fail-closed 行为，仅输出安全的分类诊断，不回显评论正文或身份数据。

## Validation

- [x] `PYTHONDONTWRITEBYTECODE=1 make fr-phase-close-guard-check authority-contract-check py-compile`
- [x] `PYTHONDONTWRITEBYTECODE=1 python3 tools/check_npm_package.py`
- [x] `git diff --check`

## Related Work

- Work Item: MC-and-his-Agents/Loom/work_item/2054
- Issue: #2054

<!-- loom:repo-pr-metadata
{
  "schema_version":"loom-repo-pr-metadata/v1",
  "metadata_contract_id":"loom-governance-intensity",
  "surface":"merge_ready",
  "fields":{"work_item_locator":"MC-and-his-Agents/Loom/work_item/2054","governance_intensity":"standard","governance_mode":"host-enforced","governance_assurance":"limited","advisory_risk_label":null,"host_enforcement_required":true,"change_class":"implementation","suite_path":"minimal","suite_not_applicable":null,"review_requirement":"host_readback_only","fact_chain_required":false,"pr_gate_required":true,"release_judgment":"no_release","closeout_required":true,"upgrade_triggers":[],"anchor_issue":null,"covered_issues":null,"excluded_scope":null},
  "source":{"rendered_hash":"fix:host-attestation-diagnostics"},
  "parser_version":"loom-pr-metadata-parser/v2"
}
-->