### PR TITLE
fix(closure): 支持阶段问题树收口

### DIFF
--- a/plugins/loom/.codex-plugin/plugin.json
+++ b/plugins/loom/.codex-plugin/plugin.json
@@ -20,10 +20,10 @@
     "payload_root": "skills",
     "source_package": "@mc-and-his-agents/loom",
     "source_package_version": "0.30.0",
-    "source_git_sha": "unreleased",
-    "source_git_sha_status": "pending_release_commit",
+    "source_git_sha": "9dddc72eab902add17ce8c1f41e4d607ce2a75ea",
+    "source_git_sha_status": "release_commit",
     "plugin_payload_version": "0.30.0",
-    "plugin_payload_hash": "b9afebc04a39700521224343ffb8891ffbb898dd2f741f5ff3d4bdc672fc421e",
+    "plugin_payload_hash": "a66d0900f97bfb540a676e05fe863c994c3437d968f732b6713d41302be078d1",
     "repository_payload": false
   },
   "keywords": [

--- a/src/skills/shared/scripts/github_closure_guard.py
+++ b/src/skills/shared/scripts/github_closure_guard.py
@@ -20,9 +20,10 @@ from product_acceptance import resolve_acceptance
 
 SCHEMA = "loom-fr-phase-close-guard/v1"
 NON_COMPLETION_LABELS = {"duplicate", "invalid", "cancelled", "canceled", "superseded"}
-TYPE_LABELS = {"fr": "fr", "phase": "phase", "work-item": "work_item"}
+TYPE_LABELS = {"fr": "fr", "phase": "phase", "product-problem": "product_problem", "work-item": "work_item"}
 DEFERRED_LABEL = "deferred"
-EXPECTED_CHILD_TYPE = {"phase": "fr", "fr": "work_item"}
+EXPECTED_CHILD_TYPE = {"product_problem": "fr", "fr": "work_item"}
+PHASE_CHILD_TYPES = {"product_problem", "fr", "work_item"}
 WAIVER_POLICY_LABEL = "product_acceptance_waiver_allowed"
 PRODUCT_ARTIFACT_RE = re.compile(r"<!--\s*loom:product-acceptance-artifact\s+id:(\d+)\s*-->", re.IGNORECASE)
 HOST_ACTION_ARTIFACT_RE = re.compile(r"<!--\s*loom:host-action-attestation\s+(\{.*?\})\s*-->", re.IGNORECASE | re.DOTALL)
@@ -52,7 +53,7 @@ def _labels(issue: dict[str, Any]) -> set[str]:
 
 def _type(issue: dict[str, Any]) -> str:
     declared = _text(issue.get("type"))
-    if declared in {"fr", "phase", "work_item"}:
+    if declared in {"fr", "phase", "product_problem", "work_item"}:
         return declared
     inferred = {TYPE_LABELS[label.replace("_", "-")] for label in _labels(issue) if label.replace("_", "-") in TYPE_LABELS}
     return inferred.pop() if len(inferred) == 1 else "unknown"
@@ -325,19 +326,22 @@ def _validate_completed(
             return
         reasons.append(_reason("missing_delivery_attestation", locator, "Work Item needs merged delivery checks, or an authenticated host-action attestation when explicitly labeled host-only-delivery"))
         return
-    expected = EXPECTED_CHILD_TYPE.get(kind)
     children = issue.get("children")
-    if expected is None or not isinstance(children, list) or not children:
-        reasons.append(_reason("missing_native_child", locator, "completed FR/Phase requires its native child tree"))
+    if not isinstance(children, list) or not children:
+        reasons.append(_reason("missing_native_child", locator, "completed Phase, Product Problem, or FR requires its native child tree"))
         return
+    expected = EXPECTED_CHILD_TYPE.get(kind)
+    allowed_types = PHASE_CHILD_TYPES if kind == "phase" else {expected} if expected else set()
     next_visiting = {*visiting, number}
     for child_number in children:
         child = issues.get(child_number) if isinstance(child_number, int) else None
         if not isinstance(child, dict):
             reasons.append(_reason("host_unreadable", locator, "a native child cannot be read from GitHub"))
             continue
-        if _type(child) != expected:
-            reasons.append(_reason("invalid_native_child_type", f"issue:{child_number}", f"{kind} requires native {expected} children"))
+        child_type = _type(child)
+        if child_type not in allowed_types:
+            expected_label = ", ".join(sorted(allowed_types)) or "no child"
+            reasons.append(_reason("invalid_native_child_type", f"issue:{child_number}", f"{kind} requires native children of type: {expected_label}"))
             continue
         _validate_completed(child, issues, repository, actor, default_branch, reasons, next_visiting)
 

--- a/tools/check_fr_phase_close_guard.py
+++ b/tools/check_fr_phase_close_guard.py
@@ -88,6 +88,12 @@ def main() -> int:
     valid = module.evaluate_closure(snapshot(1, [phase, fr, work_item]), host_resolved=True)
     if valid.get("verdict") != "allow_completed_close" or valid.get("completed") is not True:
         raise AssertionError(f"complete native tree should close: {valid}")
+    problem = issue(7, "product_problem", labels=["product-problem"], children=[2])
+    release_work_item = issue(8, "work_item", merged_prs=[pr])
+    phase_with_problem = issue(1, "phase", children=[7, 8])
+    nested = module.evaluate_closure(snapshot(1, [phase_with_problem, problem, fr, work_item, release_work_item]), host_resolved=True)
+    if nested.get("verdict") != "allow_completed_close":
+        raise AssertionError(f"Phase must accept a Product Problem subtree and a phase-scoped release WI: {nested}")
     host_marker = '<!-- loom:host-action-attestation {"schema_version":"loom-host-action-attestation/v1","action_locator":"github://o/r/host-action/branch-protection/main","observed_at":"2026-07-11T00:02:00Z","verdict":"passed"} -->'
     host_comment = {"body": host_marker, "created_at": "2026-07-11T00:02:00Z", "author_association": "NONE", "user": {"id": 1, "login": "maintainer"}}
     host_only = issue(3, "work_item", labels=["host-only-delivery"], comments=[host_comment])

--- a/tools/check_fr_phase_close_guard_workflow.py
+++ b/tools/check_fr_phase_close_guard_workflow.py
@@ -84,6 +84,8 @@ def main() -> int:
         "host_only_delivery",
         "failure_envelope",
         "missing_delivery_attestation",
+        "product_problem",
+        "PHASE_CHILD_TYPES",
     )
     evaluator_missing = [needle for needle in evaluator_required if needle not in evaluator]
     if missing or present or evaluator_missing:


### PR DESCRIPTION
## Summary

- Root cause: shipped closure guard 只接受 `Phase → FR → WI`，但 GitHub 真相的合理层级是 `Phase → Product Problem → FR → WI`，且 Phase 可直接拥有 release/observability WI。
- Scope: 增加 `product-problem` 原生类型；Product Problem 必须拥有 FR，Phase 可组合 Product Problem、直接 FR 和 phase-scoped WI；所有节点继续递归验证 completed、dependencies 与 delivery evidence。
- Release judgment: v0.30.0 已发布，本修正只解决 milestone host closeout，不重发 tag/npm；plugin metadata 绑定已发布 commit `9dddc72e…`。

## Validation

- [x] `PYTHONDONTWRITEBYTECODE=1 make fr-phase-close-guard-check authority-contract-check product-acceptance-adapter-check py-compile`
- [x] `python3 tools/version_surface_check.py`
- [x] `python3 tools/check_release_surface.py`
- [x] `python3 tools/check_npm_package.py --surface aggregate`
- [x] `git diff --check`

## Related Work

- Work Item: MC-and-his-Agents/Loom/work_item/2054
- Issue: #2054

<!-- loom:repo-pr-metadata
{
  "schema_version":"loom-repo-pr-metadata/v1",
  "metadata_contract_id":"loom-governance-intensity",
  "surface":"merge_ready",
  "fields":{"work_item_locator":"MC-and-his-Agents/Loom/work_item/2054","governance_intensity":"standard","governance_mode":"host-enforced","governance_assurance":"limited","advisory_risk_label":null,"host_enforcement_required":true,"change_class":"workflow","suite_path":"minimal","suite_not_applicable":null,"review_requirement":"host_readback_only","fact_chain_required":false,"pr_gate_required":true,"release_judgment":"no_release","closeout_required":true,"upgrade_triggers":["phase_product_problem_tree"],"anchor_issue":null,"covered_issues":null,"excluded_scope":null},
  "source":{"rendered_hash":"fix:phase-product-problem-tree"},
  "parser_version":"loom-pr-metadata-parser/v2"
}
-->