### PR TITLE
fix(acceptance): 允许阶段验收输入

### DIFF
--- a/.github/workflows/loom-product-acceptance.yml
+++ b/.github/workflows/loom-product-acceptance.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       story_issue:
-        description: 'FR issue number receiving this Stage A verdict.'
+        description: 'FR or Phase issue number receiving this Stage A verdict.'
         required: true
         type: choice
         options:
@@ -16,6 +16,7 @@ on:
           - '1984'
           - '1985'
           - '1986'
+          - '2037'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Problem: product acceptance producer 只允许 #1979–#1986，无法为最终 Phase #2037 产生独立、可认证的 verdict。
- Scope: 复用同一 workflow/evidence schema，将 #2037 加入显式 choice；不新增 adapter、registry 或 release。

## Validation

- [x] `PYTHONDONTWRITEBYTECODE=1 python3 tools/check_product_acceptance_adapter.py`
- [x] `PYTHONDONTWRITEBYTECODE=1 make py-compile`
- [x] `git diff --check`

## Related Work

- Work Item: MC-and-his-Agents/Loom/work_item/2054
- Issue: #2054

<!-- loom:repo-pr-metadata
{
  "schema_version":"loom-repo-pr-metadata/v1",
  "metadata_contract_id":"loom-governance-intensity",
  "surface":"merge_ready",
  "fields":{"work_item_locator":"MC-and-his-Agents/Loom/work_item/2054","governance_intensity":"standard","governance_mode":"host-enforced","governance_assurance":"limited","advisory_risk_label":null,"host_enforcement_required":true,"change_class":"workflow","suite_path":"minimal","suite_not_applicable":null,"review_requirement":"host_readback_only","fact_chain_required":false,"pr_gate_required":true,"release_judgment":"no_release","closeout_required":true,"upgrade_triggers":[],"anchor_issue":null,"covered_issues":null,"excluded_scope":null},
  "source":{"rendered_hash":"fix:phase-acceptance-input"},
  "parser_version":"loom-pr-metadata-parser/v2"
}
-->