### PR TITLE
fix(ci): 建立一次性可信 checker 迁移

### DIFF
--- a/tools/run_trusted_candidate_validation.py
+++ b/tools/run_trusted_candidate_validation.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib.util
 import json
 import os
@@ -34,6 +35,11 @@ PROTECTED_HARNESS_FILES = (
     "test/npm-package-smoke.test.mjs",
     *tuple(f"tools/{name}" for name in TRUSTED_TOOL_FILES),
 )
+CONTRACT_TRANSITION_CHECKER = "tools/check_cli_contract.py"
+CONTRACT_TRANSITION_SURFACE = "legacy-command-eol"
+CONTRACT_TRANSITION_REQUIRED_TARGET = "cli-contract-check"
+CONTRACT_TRANSITION_TRUSTED_SHA256 = "9570ae1384a389725cd140b954ccac79e29cbbc03e31851bf02e90154d5628b5"
+CONTRACT_TRANSITION_CANDIDATE_SHA256 = "d02e1176ef644f41d04aab0bfc8b02dd3579c99814ff3b7e87bbc55b044c42d9"
 
 
 def ensure_contained_path(root: Path, destination: Path) -> None:
@@ -100,6 +106,65 @@ def protected_harness_drift(trusted_root: Path, candidate_root: Path) -> list[st
     )
 
 
+def tracked_tree_snapshot(root: Path, *, excluded: set[str]) -> tuple[tuple[str, str, object], ...]:
+    indexed = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-s", "-z"],
+        check=False,
+        capture_output=True,
+    )
+    if indexed.returncode != 0:
+        raise ValueError(f"could not read tracked tree: {root}")
+    snapshot: list[tuple[str, str, object]] = []
+    for entry in indexed.stdout.split(b"\0"):
+        if not entry:
+            continue
+        metadata, raw_path = entry.split(b"\t", 1)
+        mode = os.fsdecode(metadata.split(b" ", 1)[0])
+        relative = os.fsdecode(raw_path)
+        if relative in excluded:
+            continue
+        snapshot.append((relative, mode, path_snapshot(root / relative)))
+    return tuple(snapshot)
+
+
+def file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def contract_transition_allowed(
+    trusted_root: Path,
+    candidate_root: Path,
+    drift: list[str],
+    targets: list[str],
+    runner_root: Path,
+) -> bool:
+    if (
+        runner_root != trusted_root
+        or drift != [CONTRACT_TRANSITION_CHECKER]
+        or CONTRACT_TRANSITION_REQUIRED_TARGET not in targets
+    ):
+        return False
+    trusted_checker = trusted_root / CONTRACT_TRANSITION_CHECKER
+    checker = candidate_root / CONTRACT_TRANSITION_CHECKER
+    if (
+        not trusted_checker.is_file()
+        or trusted_checker.is_symlink()
+        or not checker.is_file()
+        or checker.is_symlink()
+        or file_sha256(trusted_checker) != CONTRACT_TRANSITION_TRUSTED_SHA256
+        or file_sha256(checker) != CONTRACT_TRANSITION_CANDIDATE_SHA256
+    ):
+        return False
+    excluded = {CONTRACT_TRANSITION_CHECKER}
+    if tracked_tree_snapshot(trusted_root, excluded=excluded) != tracked_tree_snapshot(candidate_root, excluded=excluded):
+        return False
+    try:
+        compile(checker.read_text(encoding="utf-8"), str(checker), "exec")
+    except (OSError, SyntaxError, UnicodeError):
+        return False
+    return True
+
+
 def candidate_symlinks(candidate_root: Path, policy: str) -> list[Path]:
     symlinks: set[Path] = set()
     indexed = subprocess.run(
@@ -145,12 +210,26 @@ def candidate_symlinks(candidate_root: Path, policy: str) -> list[Path]:
     return sorted(unsafe)
 
 
-def trusted_overlay(trusted_root: Path, candidate_root: Path, output_root: Path, symlink_policy: str) -> None:
+def trusted_overlay(
+    trusted_root: Path,
+    candidate_root: Path,
+    output_root: Path,
+    symlink_policy: str,
+    targets: list[str],
+    runner_root: Path,
+) -> bool:
     unsafe = candidate_symlinks(candidate_root, symlink_policy)
     if unsafe:
         raise ValueError("candidate tree contains symlinks: " + ", ".join(str(path) for path in unsafe))
     drift = protected_harness_drift(trusted_root, candidate_root)
-    if drift:
+    contract_transition = bool(drift) and contract_transition_allowed(
+        trusted_root,
+        candidate_root,
+        drift,
+        targets,
+        runner_root,
+    )
+    if drift and not contract_transition:
         raise ValueError("protected validation harness drift requires a base-trusted bootstrap: " + ", ".join(drift))
     shutil.copytree(candidate_root, output_root, symlinks=symlink_policy != "reject")
     replace_path(trusted_root / "Makefile", output_root / "Makefile", output_root)
@@ -166,6 +245,55 @@ def trusted_overlay(trusted_root: Path, candidate_root: Path, output_root: Path,
     package_test = trusted_root / "test" / "npm-package-smoke.test.mjs"
     if package_test.is_file():
         replace_path(package_test, output_root / "test" / package_test.name, output_root)
+    return contract_transition
+
+
+def run_contract_transition_check(
+    candidate_root: Path,
+    temporary_root: Path,
+    safe_environment: dict[str, str],
+) -> int:
+    transition_root = temporary_root / "contract-transition"
+    isolated_home = temporary_root / "contract-transition-home"
+    transition_root.mkdir()
+    for relative, _mode, snapshot in tracked_tree_snapshot(candidate_root, excluded=set()):
+        if not isinstance(snapshot, tuple) or not snapshot or snapshot[0] != "file":
+            raise ValueError(f"contract transition requires regular tracked files: {relative}")
+        source = candidate_root / relative
+        destination = transition_root / relative
+        ensure_contained_path(transition_root, destination)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+    isolated_home.mkdir()
+    environment = dict(safe_environment)
+    environment.update(
+        {
+            "HOME": str(isolated_home),
+            "LOOM_CONTRACT_TRANSITION": "1",
+            "PYTHONPATH": os.pathsep.join(
+                (
+                    str(transition_root / "src" / "skills" / "shared" / "scripts"),
+                    str(transition_root / "tools"),
+                )
+            ),
+        }
+    )
+    checker = str(transition_root / CONTRACT_TRANSITION_CHECKER)
+    targeted = subprocess.run(
+        [sys.executable, checker, "--surface", CONTRACT_TRANSITION_SURFACE],
+        cwd=transition_root,
+        env=environment,
+        check=False,
+    )
+    if targeted.returncode != 0:
+        return targeted.returncode
+    aggregate = subprocess.run(
+        [sys.executable, checker],
+        cwd=transition_root,
+        env=environment,
+        check=False,
+    )
+    return aggregate.returncode
 
 
 def main() -> int:
@@ -203,7 +331,14 @@ def main() -> int:
     with tempfile.TemporaryDirectory(prefix="loom-candidate-validation-") as temporary:
         validation_root = Path(temporary) / "candidate"
         try:
-            trusted_overlay(trusted_root, candidate_root, validation_root, args.symlink_policy)
+            contract_transition = trusted_overlay(
+                trusted_root,
+                candidate_root,
+                validation_root,
+                args.symlink_policy,
+                targets,
+                runner_root,
+            )
             safe_environment = {
                 key: value
                 for key, value in os.environ.items()
@@ -227,6 +362,12 @@ def main() -> int:
                 env=safe_environment,
                 check=False,
             )
+            if completed.returncode == 0 and contract_transition:
+                return run_contract_transition_check(
+                    candidate_root,
+                    Path(temporary),
+                    safe_environment,
+                )
         except ValueError as error:
             print(str(error), file=sys.stderr)
             return 2


### PR DESCRIPTION
## Summary

- Problem: base-owned aggregate 会保护 `tools/check_cli_contract.py`，但 #2103 必须先把 checker 从“隐藏命令仍存在”迁移到双状态 EOL 合同；直接改 checker 会被旧 gate 自锁。
- Scope: #2103 checkpoint 1/3，仅增加一次性、精确 SHA 绑定的 checker-only contract transition；不修改 checker、runtime、required checks 或 branch protection。

## Validation

- [x] Verified locally
- [x] Verified by automation
- [ ] Not applicable

Validation details:
- `make py-compile`：61 files passed。
- `python3 tools/check_delivery_gate.py`：passed。
- `git diff --check`：passed。
- exact transition admission：仅 `tools/check_cli_contract.py` drift、必须包含 `cli-contract-check` target、direct Loom validation、其余 tracked tree 字节一致时通过；缺 target 或 candidate-owned runner 时拒绝。
- trusted checker SHA256：`9570ae1384a389725cd140b954ccac79e29cbbc03e31851bf02e90154d5628b5`。
- candidate checker SHA256：`d02e1176ef644f41d04aab0bfc8b02dd3579c99814ff3b7e87bbc55b044c42d9`；candidate 25/25 surfaces、aggregate 700.22s、total 909.41s。
- current-head security review：0 blocker/major/minor。

## Risks And Follow-ups

- Risks: `assurance=limited`。当前 PR 仍依赖 base branch protection 与语义 review，不宣称独立、不可伪造的 strong trust root。候选 checker 会在隔离 HOME/PYTHONPATH、无 token/secret、tracked-regular-files-only 的环境执行，但仍属于精确 SHA 约束下的候选代码执行。
- Follow-ups: 合并并完成 main readback 后，checkpoint 2 仅提交精确 SHA 的 dual-state checker；随后 checkpoint 3 才删除96个 decoder、旧 schema/envelope 与 hot-path consumers。前三个 checkpoint 不关闭 #2103。

## Related Work

- Work Item: MC-and-his-Agents/Loom/work_item/2103
- Issue: #2103
- Spec / plan: GitHub Work Item body 与 #2103 checkpoint comment；不创建 repo-local spec/plan carrier。

## PR Metadata Machine Carrier

<!-- loom:repo-pr-metadata
{
  "schema_version": "loom-repo-pr-metadata/v1",
  "metadata_contract_id": "loom-governance-intensity",
  "surface": "merge_ready",
  "fields": {
    "work_item_locator": "MC-and-his-Agents/Loom/work_item/2103",
    "governance_intensity": "standard",
    "change_class": "contract",
    "suite_path": "minimal",
    "suite_not_applicable": null,
    "review_requirement": "host_readback_only",
    "fact_chain_required": false,
    "pr_gate_required": true,
    "release_judgment": "no_release",
    "closeout_required": true,
    "upgrade_triggers": ["validation_harness_transition"]
  },
  "source": {"rendered_hash": "renderer:loom-pr-metadata-render/v2"},
  "parser_version": "loom-pr-metadata-parser/v2"
}
-->
