### PR TITLE
fix(ci): 为 checker 迁移补隔离 Git 快照

### DIFF
--- a/tools/run_trusted_candidate_validation.py
+++ b/tools/run_trusted_candidate_validation.py
@@ -248,6 +248,36 @@ def trusted_overlay(
     return contract_transition
 
 
+def initialize_contract_transition_git_snapshot(transition_root: Path, environment: dict[str, str]) -> None:
+    git_commands = (
+        ("git", "init", "-b", "main"),
+        ("git", "add", "--all"),
+        (
+            "git",
+            "-c",
+            "user.name=Loom Contract Transition",
+            "-c",
+            "user.email=loom-transition@invalid.local",
+            "-c",
+            "commit.gpgSign=false",
+            "commit",
+            "-m",
+            "contract transition snapshot",
+        ),
+    )
+    for command in git_commands:
+        completed = subprocess.run(
+            command,
+            cwd=transition_root,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if completed.returncode != 0:
+            raise ValueError(f"could not initialize isolated contract transition Git snapshot: {command[1]}")
+
+
 def run_contract_transition_check(
     candidate_root: Path,
     temporary_root: Path,
@@ -265,9 +295,12 @@ def run_contract_transition_check(
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source, destination)
     isolated_home.mkdir()
-    environment = dict(safe_environment)
+    environment = {key: value for key, value in safe_environment.items() if not key.startswith("GIT_")}
     environment.update(
         {
+            "GIT_CONFIG_GLOBAL": str(isolated_home / ".gitconfig"),
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_TERMINAL_PROMPT": "0",
             "HOME": str(isolated_home),
             "LOOM_CONTRACT_TRANSITION": "1",
             "PYTHONPATH": os.pathsep.join(
@@ -278,6 +311,7 @@ def run_contract_transition_check(
             ),
         }
     )
+    initialize_contract_transition_git_snapshot(transition_root, environment)
     checker = str(transition_root / CONTRACT_TRANSITION_CHECKER)
     targeted = subprocess.run(
         [sys.executable, checker, "--surface", CONTRACT_TRANSITION_SURFACE],


### PR DESCRIPTION
## Summary

- Problem: #2107 的 candidate 24/25 surfaces 通过，但 aggregate 在隔离 transition root 读取 `git rev-parse HEAD` 时失败；runner 没有复制真实 `.git`，也没有提供本地 fixture repository。
- Scope: 在 tracked-regular-files-only transition root 内初始化无 remote 的本地 Git snapshot；继续隔离 HOME/config/token，不修改 checker、runtime、required checks 或 branch protection。

## Validation

- [x] Verified locally
- [x] Verified by automation
- [ ] Not applicable

Validation details:
- `make py-compile`：61 files passed。
- `python3 tools/check_delivery_gate.py`：passed。
- `git diff --check`：passed。
- isolated snapshot fixture：本地 commit/HEAD 可读、仅 tracked file、remote 为空。
- security review：0 blocker / 0 major；不复制 candidate `.git`/hooks/config，不读取真实 Git config/credential，不扩大 exact-SHA/checker-only trust boundary。
- 原失败 run：#2107 `29240310026`，24/25 surfaces passed，aggregate only failure 为 missing `.git`。

## Risks And Follow-ups

- Risks: `assurance=limited`；base runner 仍依赖 branch protection 与语义 review。candidate aggregate 可修改自己的临时 `.git`，但环境无 token/remote且整个 root 随 job 删除。
- Follow-ups: 合并/main readback 后 rebase #2107 并等待同一 trusted candidate aggregate；不直接 rerun 旧 head。

## Related Work

- Work Item: MC-and-his-Agents/Loom/work_item/2103
- Issue: #2103
- Related PR: #2107

## PR Metadata Machine Carrier

<!-- loom:repo-pr-metadata
{
  "schema_version": "loom-repo-pr-metadata/v1",
  "metadata_contract_id": "loom-governance-intensity",
  "surface": "merge_ready",
  "fields": {
    "work_item_locator": "MC-and-his-Agents/Loom/work_item/2103",
    "governance_intensity": "standard",
    "change_class": "contract",
    "suite_path": "minimal",
    "suite_not_applicable": null,
    "review_requirement": "host_readback_only",
    "fact_chain_required": false,
    "pr_gate_required": true,
    "release_judgment": "no_release",
    "closeout_required": true,
    "upgrade_triggers": ["validation_harness_transition"]
  },
  "source": {"rendered_hash": "renderer:loom-pr-metadata-render/v2"},
  "parser_version": "loom-pr-metadata-parser/v2"
}
-->
